### PR TITLE
NV6088: memory reading is zero in rke2+containerd+cgroup v2

### DIFF
--- a/share/system/cgroup_linux.go
+++ b/share/system/cgroup_linux.go
@@ -289,7 +289,8 @@ func getCgroupPathReaderV2(file io.ReadSeeker) string {
 		tokens := strings.Split(scanner.Text(), ":")
 		if len(tokens) > 2 {
 			// log.WithFields(log.Fields{"cpath": tokens[2]}).Debug()
-			if strings.HasPrefix(tokens[2], "/kubepods.slice/") {
+			// example: "0::/kubepods/besteffort/podad1189b4-15b6-4ee5-b509-084defdd5c70/f459165f653a853823b2807f22e5b21c4214ff1d89e71790ca28da9b38695ea1"
+			if strings.HasPrefix(tokens[2], "/kubepods") {
 				return filepath.Join("/sys/fs/cgroup", tokens[2])
 			}
 		}

--- a/share/system/system_linux.go
+++ b/share/system/system_linux.go
@@ -101,12 +101,11 @@ func NewSystemTools() *SystemTools {
 		log.Info("cgroup v2")
 		s.cgroupVersion = cgroup_v2
 		// update cgroup v2 path
-		path, _ := getCgroupPath_cgroup_v2(0)
-		if _, err := os.Stat(filepath.Join(path, "memory.current")); err != nil {
-			entries, _ := ioutil.ReadDir("/sys/fs/cgroup")
-			log.WithFields(log.Fields{"err": err, "entries": entries}).Error("Failed to find cgroup path")
+		if path, err := getCgroupPath_cgroup_v2(0); err == nil {
+			s.cgroupMemoryDir = path
+		} else {
+			s.cgroupMemoryDir = "/sys/fs/cgroup"  // last resort
 		}
-		s.cgroupMemoryDir = path
 	} else {
 		log.Info("cgroup v1")
 		s.cgroupVersion = cgroup_v1


### PR DESCRIPTION
cgroup v2 only: 

The "memory.current" is not always readable from its default cgroup path for a root-privileged pod.   