### PR TITLE
NV6099: agent crashes at workerlet.(*Tasker).Run()

### DIFF
--- a/agent/group_profile.go
+++ b/agent/group_profile.go
@@ -409,7 +409,7 @@ func fileMemberChanges(members utils.Set) {
 		c, ok := gInfo.activeContainers[id]
 		gInfoRUnlock()
 		if ok {
-			go applyFileGroupProfile(c)
+			applyFileGroupProfile(c)
 		} else {
 			log.WithFields(log.Fields{"id": id}).Debug("GRP: left")
 		}


### PR DESCRIPTION
Reduce the launch speed of the file monitors. It will help a temporary relief of the "create_thread()" presssures from the walkerlets.
 