### PR TITLE
NV6106 and NV6117: minor fixes on the k3s's asset information.

### DIFF
--- a/share/osutil/user_linux.go
+++ b/share/osutil/user_linux.go
@@ -94,7 +94,7 @@ func GetAllUsers(pid int, users map[int]string) (int, int, error) {
 
 	dat, err := global.SYS.ReadContainerFile("/etc/passwd", pid, 0, 0)
 	if err != nil {
-		log.WithFields(log.Fields{"err": err, "pid": pid}).Debug("Get /etc/passwd fail")
+		// log.WithFields(log.Fields{"err": err, "pid": pid}).Debug("Get /etc/passwd fail")
 		return 0, uidStart, err
 	}
 	uidMap, err := getUserNsUid(pid)

--- a/share/system/sysinfo/util.go
+++ b/share/system/sysinfo/util.go
@@ -8,8 +8,20 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 )
+
+func joinLink(root, link, dir string) string {
+	var path string
+	if filepath.IsAbs(link) {
+		 path = filepath.Join(root, link)
+	} else {
+	   path = filepath.Join(dir, link)
+	   path = filepath.Join(root, path)
+	}
+	return path
+ }
 
 // Read one-liner text files, strip newline.
 func slurpFile(path string) string {
@@ -29,8 +41,11 @@ func spewFile(path string, data string, perm os.FileMode) {
 }
 
 func openFile(path string) (*os.File, error) {
-	path = fmt.Sprintf("%s%s", rootPathPrefix, path)
-	return os.Open(path)
+	rpath := filepath.Join(rootPathPrefix, path)
+	if link, err := os.Readlink(rpath); err == nil {
+		rpath = joinLink(rootPathPrefix, link, filepath.Dir(path))
+	}
+	return os.Open(rpath)
 }
 
 func statFile(path string) (os.FileInfo, error) {


### PR DESCRIPTION
Missing some asset's information on k3s clusters.

(1) containerd: retriving container's privileged status via cri interface.

(2) os name: resolved symbolic link issue.

(3) removing messages from enforcer's logs:  "Get /etc/passwd fail".