### PR TITLE
ZeroDrift: include sandbox process tree protection.

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1519,7 +1519,7 @@ func taskInterceptContainer(id string, info *container.ContainerMetaExtra) {
 
 	// entry to apply group policies
 	workloadJoinGroup(c)
-	prober.BuildProcessFamilyGroups(c.id, c.pid)
+	prober.BuildProcessFamilyGroups(c.id, c.pid, parent == nil)
 	prober.HandleAnchorModeChange(true, c.id, c.upperDir, c.pid)
 
 	if parent == nil {

--- a/agent/group_profile.go
+++ b/agent/group_profile.go
@@ -1078,7 +1078,7 @@ func updateContainerFamilyTrees(name string) {
 		c, ok := gInfo.activeContainers[cid]
 		gInfoRUnlock()
 		if ok {
-			prober.BuildProcessFamilyGroups(c.id, c.pid)
+			prober.BuildProcessFamilyGroups(c.id, c.pid, false)
 		}
 	}
 }


### PR DESCRIPTION
Some reused sandbox will not create a new "pause" prcesses (observed at CRIO). 