### PR TITLE
NV6134 patch: unable to detect exit status of parent pod on oc 4.9

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -479,7 +479,7 @@ func main() {
 	agentTimerWheel.Start()
 
 	// Read existing containers again, cluster start can take a while.
-	existing := global.RT.ListContainerIDs()
+	existing, _ := global.RT.ListContainerIDs()
 
 	if existing.Cardinality() > containerTaskChanSizeMin {
 		ContainerTaskChan = make(chan *ContainerTask, existing.Cardinality())

--- a/agent/probe/process_test.go
+++ b/agent/probe/process_test.go
@@ -34,7 +34,7 @@ func (d *dummyRTDriver) GetContainer(id string) (*container.ContainerMetaExtra, 
 func (d *dummyRTDriver) ListContainers(runningOnly bool) ([]*container.ContainerMeta, error) {
 	return nil, nil
 }
-func (d *dummyRTDriver) ListContainerIDs() utils.Set { return nil }
+func (d *dummyRTDriver) ListContainerIDs() (utils.Set, utils.Set) { return nil, nil }
 func (d *dummyRTDriver) GetImageHistory(name string) ([]*container.ImageHistory, error) {
 	return nil, nil
 }

--- a/share/container/containerd.go
+++ b/share/container/containerd.go
@@ -372,19 +372,19 @@ func (d *containerdDriver) GetImageFile(id string) (io.ReadCloser, error) {
 	return nil, ErrMethodNotSupported
 }
 
-func (d *containerdDriver) ListContainerIDs() utils.Set {
+func (d *containerdDriver) ListContainerIDs() (utils.Set, utils.Set) {
 	ids := utils.NewSet()
 
 	containers, err := d.client.Containers(context.Background())
 	if err != nil {
 		log.WithFields(log.Fields{"error": err.Error()}).Error("Failed to list containers")
-		return ids
+		return ids, nil
 	}
 
 	for _, c := range containers {
 		ids.Add(c.ID())
 	}
-	return ids
+	return ids, nil
 }
 
 func (d *containerdDriver) GetNetworkEndpoint(netName, container, epName string) (*NetworkEndpoint, error) {

--- a/share/container/docker.go
+++ b/share/container/docker.go
@@ -103,19 +103,19 @@ func (d *dockerDriver) GetDevice(id string) (*share.CLUSDevice, *ContainerMetaEx
 	return getDevice(id, d, d.sys)
 }
 
-func (d *dockerDriver) ListContainerIDs() utils.Set {
+func (d *dockerDriver) ListContainerIDs() (utils.Set, utils.Set) {
 	set := utils.NewSet()
 
 	containers, err := d.client.ListContainers(true, false, "")
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Error in listing containers")
-		return set
+		return set, nil
 	}
 
 	for _, c := range containers {
 		set.Add(c.Id)
 	}
-	return set
+	return set, nil
 }
 
 func (d *dockerDriver) ListContainers(runningOnly bool) ([]*ContainerMeta, error) {

--- a/share/container/types.go
+++ b/share/container/types.go
@@ -25,7 +25,7 @@ type Runtime interface {
 	GetDevice(id string) (*share.CLUSDevice, *ContainerMetaExtra, error)
 	GetContainer(id string) (*ContainerMetaExtra, error)
 	ListContainers(runningOnly bool) ([]*ContainerMeta, error)
-	ListContainerIDs() utils.Set
+	ListContainerIDs() (utils.Set, utils.Set)
 	GetImageHistory(name string) ([]*ImageHistory, error)
 	GetImage(name string) (*ImageMeta, error)
 	GetImageFile(id string) (io.ReadCloser, error)


### PR DESCRIPTION
For runtime-engine CRIO only: create 3 states (running, stop, deleted) of conatiners/pods while polling their status.