### PR TITLE
NV6145, NV6249 and NV6038: pathWalker updates.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -275,6 +275,7 @@ func main() {
 	skip_nvProtect := flag.Bool("s", false, "Skip NV Protect")
 	show_monitor_trace := flag.Bool("m", false, "Show process/file monitor traces")
 	disable_kv_congest_ctl := flag.Bool("no_kvc", false, "disable kv congestion control")
+	disable_scan_secrets := flag.Bool("no_scrt", false, "disable secret scans")
 	flag.Parse()
 
 	if *debug {
@@ -286,6 +287,12 @@ func main() {
 	if *disable_kv_congest_ctl {
 		log.Info("KV congestion control is disabled")
 		agentEnv.kvCongestCtrl = false
+	}
+
+	agentEnv.scanSecrets = true
+	if *disable_scan_secrets {
+		log.Info("Scanning secrets on containers is disabled")
+		agentEnv.scanSecrets = false
 	}
 
 	if *join != "" {
@@ -321,7 +328,7 @@ func main() {
 		os.Exit(-2)
 	}
 
-	walkerTask = workerlet.NewWalkerTask(false, global.SYS)
+	walkerTask = workerlet.NewWalkerTask(*show_monitor_trace, global.SYS)
 
 	log.WithFields(log.Fields{"endpoint": *rtSock, "runtime": global.RT.String()}).Info("Container socket connected")
 	if platform == share.PlatformKubernetes {

--- a/agent/bench.go
+++ b/agent/bench.go
@@ -286,8 +286,10 @@ func (b *Bench) BenchLoop() {
 					// skip kubernetes pod
 					if Host.Platform != share.PlatformKubernetes || c.parentNS != "" {
 						wls = append(wls, createWorkload(c.info))
-						group := makeLearnedGroupName(utils.NormalizeForURL(c.service))
-						b.taskScanner.addScanTask(c.pid, name, id, group)
+						if agentEnv.scanSecrets {
+							group := makeLearnedGroupName(utils.NormalizeForURL(c.service))
+							b.taskScanner.addScanTask(c.pid, name, id, group)
+						}
 					}
 				}
 			}
@@ -1364,7 +1366,7 @@ func (b *Bench) runFindSecrets(rootPid int, name, id, group string) {
 		TimeoutSec: 3 * 60,
 	}
 
-	permBytes, secretBytes, err := walkerTask.Run(req)
+	permBytes, secretBytes, err := walkerTask.RunWithTimeout(req, id, time.Duration(req.TimeoutSec)*time.Second)
 	if err != nil {
 		log.WithFields(log.Fields{"pid": rootPid, "id": id, "error": err}).Error()
 	} else {

--- a/agent/grpc.go
+++ b/agent/grpc.go
@@ -99,7 +99,7 @@ func (ss *ScanService) ScanGetFiles(ctx context.Context, req *share.ScanRunningR
 		ObjType: req.Type,
 	}
 
-	bytesValue, _, err := walkerTask.Run(taskReq)
+	bytesValue, _, err := walkerTask.Run(taskReq, req.ID)
 	if err == nil {
 		if err = json.Unmarshal(bytesValue, &data); err != nil {
 			log.WithFields(log.Fields{"id": req.ID, "error": err}).Error()

--- a/agent/probe/faccess_linux.go
+++ b/agent/probe/faccess_linux.go
@@ -108,7 +108,7 @@ func appendDirPath(dirs []string, path string) []string {
 }
 
 /////
-func (fa *FileAccessCtrl) enumExecutables(rootpid int) (map[string]int, []string) {
+func (fa *FileAccessCtrl) enumExecutables(rootpid int, id string) (map[string]int, []string) {
 	var dirs []string
 	execs := make(map[string]int)
 
@@ -130,7 +130,7 @@ func (fa *FileAccessCtrl) enumExecutables(rootpid int) (map[string]int, []string
 		Timeout: time.Duration(4 * time.Second),
 	}
 
-	bytesValue, _, err := fa.prober.walkerTask.Run(req)
+	bytesValue, _, err := fa.prober.walkerTask.RunWithTimeout(req, id, req.Timeout)
 	if err == nil {
 		err = json.Unmarshal(bytesValue, &res)
 	}
@@ -409,7 +409,7 @@ func (fa *FileAccessCtrl) AddContainerControlByPolicyOrder(id, setting string, r
 		return false
 	}
 
-	execs, dirs := fa.enumExecutables(rootpid)
+	execs, dirs := fa.enumExecutables(rootpid, id)
 
 	fa.lockMux()
 	defer fa.unlockMux()

--- a/agent/types.go
+++ b/agent/types.go
@@ -18,6 +18,7 @@ type AgentEnvInfo struct {
 	cgroupMemory         string
 	cgroupCPUAcct        string
 	kvCongestCtrl        bool
+	scanSecrets          bool
 }
 
 const (

--- a/agent/workerlet/pathWalker/pathWalker.go
+++ b/agent/workerlet/pathWalker/pathWalker.go
@@ -68,6 +68,7 @@ func main() {
 	walkType := flag.String("t", "", "walk type: path, pkg, or scrt (Required)")
 	uuid := flag.String("u", "uuid", "result uuid name")
 	debugTrace := flag.Bool("d", false, "enable debug trace")
+	cid := flag.String("cid", "", "container identifier")
 	flag.Usage = usage
 	flag.Parse()
 
@@ -81,7 +82,7 @@ func main() {
 	// create a working path from the input file
 	workPath := filepath.Join(workerlet.WalkerBasePath, *uuid)
 	os.MkdirAll(workPath, os.ModePerm)
-	log.WithFields(log.Fields{"workPath": workPath}).Debug()
+	log.WithFields(log.Fields{"workPath": workPath, "cid": *cid}).Debug()
 
 	pass := false
 	if sys.IsRunningInContainer() {
@@ -234,7 +235,7 @@ func (tm *taskMain) WalkPathTask(req workerlet.WalkPathRequest) {
 				},
 			}
 			res.Dirs = append(res.Dirs, ddata)
-			log.WithFields(log.Fields{"dir": ddata.Dir}).Debug()
+			// log.WithFields(log.Fields{"dir": ddata.Dir}).Debug()
 		} else {
 			bExec := false
 			if info.Mode().IsRegular() {
@@ -256,7 +257,7 @@ func (tm *taskMain) WalkPathTask(req workerlet.WalkPathRequest) {
 			if req.ExecOnly {
 				if fdata.IsExec {
 					res.Files = append(res.Files, fdata)
-					log.WithFields(log.Fields{"file": fdata.File}).Debug()
+					//log.WithFields(log.Fields{"file": fdata.File}).Debug()
 				}
 			} else {
 				if info.Mode().IsRegular() {
@@ -264,7 +265,7 @@ func (tm *taskMain) WalkPathTask(req workerlet.WalkPathRequest) {
 					fdata.Hash = utils.FileHashCrc32(path, info.Size())
 				}
 				res.Files = append(res.Files, fdata)
-				log.WithFields(log.Fields{"file": fdata.File}).Debug()
+				// log.WithFields(log.Fields{"file": fdata.File}).Debug()
 			}
 		}
 		return nil

--- a/monitor/monitor.c
+++ b/monitor/monitor.c
@@ -40,6 +40,7 @@
 #define ENV_SKIP_NV_PROTECT    "ENFORCER_SKIP_NV_PROTECT"
 #define ENV_SHOW_MONITOR_TRACE "ENF_MONITOR_TRACE"
 #define ENV_NO_KV_CONGEST_CTL  "ENF_NO_KV_CONGESTCTL"
+#define ENV_NO_SCAN_SECRETS    "ENF_NO_SECRET_SCANS"
 #define ENV_PWD_VALID_UNIT     "PWD_VALID_UNIT"
 
 #define ENV_SCANNER_DOCKER_URL  "SCANNER_DOCKER_URL"
@@ -416,6 +417,9 @@ static pid_t fork_exec(int i)
         }
         if (getenv(ENV_NO_KV_CONGEST_CTL)) {
             args[a ++] = "-no_kvc";
+        }
+        if (getenv(ENV_NO_SCAN_SECRETS)) {
+            args[a ++] = "-no_scrt";
         }
         args[a] = NULL;
         break;


### PR DESCRIPTION
(1) To prevent pathWalkers from running into an indefinite state. 

(2) For debugging purpose, the enforcer will pass the container identifier to the pathWalker, too.