### PR TITLE
NVSHAS-5942/5943, set internal xff default value on enforcer to disabled 

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -113,7 +113,8 @@ type localSystemInfo struct {
 
 var defaultPolicyMode string = share.PolicyModeLearn
 var defaultTapProxymesh bool = true
-var defaultXffEnabled bool = true
+//to avoid false positive implicit violation on dp during upgrade, set XFF default to disabled
+var defaultXffEnabled bool = false
 var specialSubnets map[string]share.CLUSSpecSubnet = make(map[string]share.CLUSSpecSubnet)
 var rtStorageDriver string
 

--- a/controller/cluster.go
+++ b/controller/cluster.go
@@ -154,6 +154,8 @@ func leadChangeHandler(newLead, oldLead string) {
 			//old still use 16bit loose factor for mask while new use 8bit loose
 			//factor, here we push internal subnet to enforcer after lead change
 			cache.PutInternalIPNetToCluseterUpgrade()
+			//make sure xff_enabled=true is updated in enforcer
+			kv.EnforceXffEnabledSetting()
 		}
 	}
 }

--- a/controller/kv/create.go
+++ b/controller/kv/create.go
@@ -782,6 +782,14 @@ func createDefaultXffSetting() {
 	}
 }
 
+func EnforceXffEnabledSetting() {
+	acc := access.NewReaderAccessControl()
+	cfg, rev := clusHelper.GetSystemConfigRev(acc)
+	if cfg.XffEnabled {
+		clusHelper.PutSystemConfigRev(cfg, rev)
+	}
+}
+
 func createDefaultVulnerabilityProfile() {
 	key := share.CLUSVulnerabilityProfileKey(share.DefaultVulnerabilityProfileName)
 	profile := &share.CLUSVulnerabilityProfile{

--- a/dp/ctrl.c
+++ b/dp/ctrl.c
@@ -2211,7 +2211,8 @@ static int dp_ctrl_bld_dlp_update_ep(json_t *msg)
     return ret;
 }
 
-uint8_t g_xff_enabled = 1;
+//to avoid false positive implicit violation, set g_xff_enabled default to 0
+uint8_t g_xff_enabled = 0;
 
 static int dp_ctrl_sys_conf(json_t *msg)
 {


### PR DESCRIPTION
to avoid implicit violation related to xff policy matching during upgrade, this is without changing XFF default as enabled.