### PR TITLE
Use 'basic'/'zero-drift' as supported profile mode values. Obsolete v…

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -246,6 +246,8 @@ func main() {
 	admctrlPort := flag.Uint("admctrl_port", 20443, "Admission Webhook server port")
 	crdvalidatectrlPort := flag.Uint("crdvalidatectrl_port", 30443, "general crd Webhook server port")
 	pwdValidUnit := flag.Uint("pwd_valid_unit", 1440, "")
+	rancherEP := flag.String("rancher_ep", "", "Rancher endpoint URL")
+	rancherSSO := flag.Bool("rancher_sso", false, "Rancher SSO integration")
 	flag.Parse()
 
 	if *debug {
@@ -288,7 +290,10 @@ func main() {
 	log.WithFields(log.Fields{"endpoint": *rtSock, "runtime": global.RT.String()}).Info("Container socket connected")
 	if platform == share.PlatformKubernetes {
 		k8sVer, ocVer := global.ORCH.GetVersion()
-		log.WithFields(log.Fields{"k8s": k8sVer, "oc": ocVer}).Info()
+		//if flavor == "" && resource.IsRancherFlavor() {
+		//	flavor = share.FlavorRancher
+		//}
+		log.WithFields(log.Fields{"k8s": k8sVer, "oc": ocVer, "flavor": flavor}).Info()
 	}
 
 	if _, err = global.ORCH.GetOEMVersion(); err != nil {
@@ -522,9 +527,12 @@ func main() {
 	orchObjChan := make(chan *resource.Event, 32)
 	orchScanChan := make(chan *resource.Event, 16)
 
+	log.WithFields(log.Fields{"rancherEP": *rancherEP, "rancherSSO": *rancherSSO}).Debug()
 	// Initialize cache
 	// - Start policy learning thread and build learnedPolicyRuleWrapper from KV
 	cctx := cache.Context{
+		//RancherEP:                *rancherEP,
+		//RancherSSO:               *rancherSSO,
 		LocalDev:                 dev,
 		EvQueue:                  evqueue,
 		AuditQueue:               auditQueue,

--- a/controller/kv/upgrade.go
+++ b/controller/kv/upgrade.go
@@ -57,6 +57,15 @@ func upgradeSystemConfig(cfg *share.CLUSSystemConfig) (bool, bool) {
 	if cfg.NewServiceProfileBaseline == "" {
 		cfg.NewServiceProfileBaseline = common.DefaultSystemConfig.NewServiceProfileBaseline
 		upd = true
+	} else {
+		blValue := strings.ToLower(cfg.NewServiceProfileBaseline)
+		if blValue == share.ProfileDefault || blValue == share.ProfileShield {
+			blValue = share.ProfileZeroDrift
+		}
+		if blValue != cfg.NewServiceProfileBaseline {
+			cfg.NewServiceProfileBaseline = blValue
+			upd = true
+		}
 	}
 	if cfg.ClusterName == "" {
 		cfg.ClusterName = common.DefaultSystemConfig.ClusterName
@@ -260,9 +269,24 @@ func upgradeProcessProfile(cfg *share.CLUSProcessProfile) (bool, bool) {
 		upd = true
 	}
 
-	if utils.DoesGroupHavePolicyMode(cfg.Group) && cfg.Baseline == "" {
-		cfg.Baseline = share.ProfileBasic
-		upd = true
+	if utils.DoesGroupHavePolicyMode(cfg.Group) {
+		if cfg.Baseline == "" {
+			if utils.IsGroupNodes(cfg.Group) {
+				cfg.Baseline = share.ProfileBasic
+			} else {
+				cfg.Baseline = share.ProfileZeroDrift
+			}
+			upd = true
+		} else {
+			blValue := strings.ToLower(cfg.Baseline)
+			if blValue == share.ProfileDefault || blValue == share.ProfileShield {
+				blValue = share.ProfileZeroDrift
+			}
+			if blValue != cfg.Baseline {
+				cfg.Baseline = blValue
+				upd = true
+			}
+		}
 	}
 
 	for i, _ := range cfg.Process {
@@ -1448,8 +1472,8 @@ func upgradeWebhookConfig() {
 
 func upgradeCrdSecurityRule(cfg *share.CLUSCrdSecurityRule) (bool, bool) {
 	var upd bool
-	if cfg.ProcessProfile.Baseline != share.ProfileCrdBasic && cfg.ProcessProfile.Baseline != share.ProfileCrdZeroDrift {
-		cfg.ProcessProfile.Baseline = share.ProfileCrdBasic
+	if cfg.ProcessProfile.Baseline != share.ProfileBasic && cfg.ProcessProfile.Baseline != share.ProfileZeroDrift {
+		cfg.ProcessProfile.Baseline = share.ProfileZeroDrift
 		upd = true
 	}
 	return upd, upd

--- a/controller/rest/configmap.go
+++ b/controller/rest/configmap.go
@@ -283,9 +283,12 @@ func handlesystemcfg(yaml_data []byte, load bool, skip *bool, context *configMap
 	}
 
 	if rc.NewServiceProfileBaseline != nil {
-		switch *rc.NewServiceProfileBaseline {
-		case share.ProfileBasic, share.ProfileZeroDrift:
-			cconf.NewServiceProfileBaseline = *rc.NewServiceProfileBaseline
+		blValue := strings.ToLower(*rc.NewServiceProfileBaseline)
+		switch blValue {
+		case share.ProfileBasic:
+			cconf.NewServiceProfileBaseline = share.ProfileBasic
+		case share.ProfileDefault, share.ProfileShield, share.ProfileZeroDrift:
+			cconf.NewServiceProfileBaseline = share.ProfileZeroDrift
 		default:
 			e := "Invalid new service profile baseline"
 			log.WithFields(log.Fields{"new_service_profile_baseline": *rc.NewServiceProfileBaseline}).Error(e)

--- a/controller/rest/process.go
+++ b/controller/rest/process.go
@@ -294,16 +294,19 @@ func handlerProcessProfileConfig(w http.ResponseWriter, r *http.Request, ps http
 			return
 		}
 
-		if utils.IsGroupNodes(group) && *conf.Baseline != share.ProfileBasic {
+		blValue := strings.ToLower(*conf.Baseline)
+		if utils.IsGroupNodes(group) && blValue != share.ProfileBasic {
 			// nodes is not change-able, always "share.ProfileBasic"
 			log.WithFields(log.Fields{"group": group, "baseline": *conf.Baseline}).Error("Invalid profile baseline")
 			restRespError(w, http.StatusBadRequest, api.RESTErrInvalidRequest)
 			return
 		}
 
-		switch *conf.Baseline {
-		case share.ProfileBasic, share.ProfileZeroDrift:
-			profile.Baseline = *conf.Baseline
+		switch blValue {
+		case share.ProfileBasic:
+			profile.Baseline = share.ProfileBasic
+		case share.ProfileDefault, share.ProfileShield, share.ProfileZeroDrift:
+			profile.Baseline = share.ProfileZeroDrift
 		default:
 			log.WithFields(log.Fields{"group": group, "baseline": *conf.Baseline}).Error("Invalid profile baseline")
 			restRespError(w, http.StatusBadRequest, api.RESTErrInvalidRequest)

--- a/controller/rest/system.go
+++ b/controller/rest/system.go
@@ -910,9 +910,12 @@ func handlerSystemConfig(w http.ResponseWriter, r *http.Request, ps httprouter.P
 			}
 			// New baseline profile setting
 			if rc.NewServiceProfileBaseline != nil {
-				switch *rc.NewServiceProfileBaseline {
-				case share.ProfileBasic, share.ProfileZeroDrift:
-					cconf.NewServiceProfileBaseline = *rc.NewServiceProfileBaseline
+				blValue := strings.ToLower(*rc.NewServiceProfileBaseline)
+				switch blValue {
+				case share.ProfileBasic:
+					cconf.NewServiceProfileBaseline = share.ProfileBasic
+				case share.ProfileDefault, share.ProfileShield, share.ProfileZeroDrift:
+					cconf.NewServiceProfileBaseline = share.ProfileZeroDrift
 				default:
 					e := "Invalid new service profile baseline"
 					log.WithFields(log.Fields{"new_service_profile_baseline": *rc.NewServiceProfileBaseline}).Error(e)
@@ -1808,7 +1811,7 @@ func _importHandler(w http.ResponseWriter, r *http.Request, tid, importType, tem
 					Server:   login.server,
 				}
 				domainRoles := access.DomainRole{access.AccessDomainGlobal: api.UserRoleImportStatus}
-				_, tempToken, _ = jwtGenerateToken(user, domainRoles, login.remote, _interactiveSessionID, "")
+				_, tempToken, _ = jwtGenerateToken(user, domainRoles, login.remote, login.mainSessionID, "")
 			}
 
 			importTask.TotalLines = lines

--- a/share/types.go
+++ b/share/types.go
@@ -38,11 +38,10 @@ const (
 )
 
 const (
-	ProfileBasic  string = "Default"
-	ProfileZeroDrift string = "Shield"
-
-	ProfileCrdBasic  string = "default"
-	ProfileCrdZeroDrift string = "shield"
+	ProfileDefault   string = "default" // (obsolete) it's equal to "zero-drift"
+	ProfileShield    string = "shield"  // (obsolete) it's equal to "zero-drift"
+	ProfileBasic     string = "basic"
+	ProfileZeroDrift string = "zero-drift"
 )
 
 const (


### PR DESCRIPTION
1. Use 'basic'/'zero-drift' as supported profile mode values. 
2. Obsolete values 'default'/'shield' are converted to 'zero-drift' internally. 
3. 'zero-drift' is the default profile mode except for 'nodes' group