### PR TITLE
NV6172: a new group is unable to create after rolling update on oc49 or rke2 setup

### DIFF
--- a/share/orchestration/noop.go
+++ b/share/orchestration/noop.go
@@ -37,6 +37,10 @@ func (d *noop) GetServiceSubnet(envs []string) *net.IPNet {
 	return nil
 }
 
+func (d *noop) GetServiceFromLabels(labels map[string]string) *Service {
+	return nil
+}
+
 func (d *noop) GetService(meta *container.ContainerMeta) *Service {
 	return nil
 }

--- a/share/orchestration/rancher.go
+++ b/share/orchestration/rancher.go
@@ -41,11 +41,17 @@ func (d *rancher) isDeployedBy(meta *container.ContainerMeta) bool {
 	return false
 }
 
-func (d *rancher) GetService(meta *container.ContainerMeta) *Service {
-	if service, _ := meta.Labels[container.RancherKeyStackServiceName]; service != "" {
+func (d *rancher) GetServiceFromLabels(labels map[string]string) *Service {
+	if service, _ := labels[container.RancherKeyStackServiceName]; service != "" {
 		return &Service{Name: service}
 	}
+	return nil
+}
 
+func (d *rancher) GetService(meta *container.ContainerMeta) *Service {
+	if svc := d.GetServiceFromLabels(meta.Labels); svc != nil {
+		return svc
+	}
 	return baseDriver.GetService(meta)
 }
 

--- a/share/orchestration/types.go
+++ b/share/orchestration/types.go
@@ -25,6 +25,7 @@ type Driver interface {
 	GetVersion(reGetK8sVersion, reGetOcVersion bool) (string, string)
 	SetIPAddrScope(ports map[string][]share.CLUSIPAddr, meta *container.ContainerMeta, nets map[string]*container.Network)
 	GetService(meta *container.ContainerMeta) *Service
+	GetServiceFromLabels(labels map[string]string) *Service
 	GetPlatformRole(meta *container.ContainerMeta) (string, bool) // return platform type and if container should be secured
 	GetDomain(labels map[string]string) string
 	GetServiceSubnet(envs []string) *net.IPNet

--- a/share/orchestration/unknown.go
+++ b/share/orchestration/unknown.go
@@ -12,6 +12,10 @@ type unknown struct {
 	envParser *utils.EnvironParser
 }
 
+func (d *unknown) GetServiceFromLabels(labels map[string]string) *Service {
+	return nil
+}
+
 func (d *unknown) GetService(meta *container.ContainerMeta) *Service {
 	return baseDriver.GetService(meta)
 }


### PR DESCRIPTION
The rolling update procedure will have a KV data fetching from the old setup, which had a bug about the group name generations. Thus, the workloads with the wrong group names will be accepted by the new controllers using the new group naming method. 

To prevent the miss-handling cases, the profile data of the obsolete groups will be moved into the new group. Then, the obsolete (profile) groups will be deleted.

This patch will be limited to a namespace: "kube-system". The observed cases from oc4.9 were all "task" types (short-lived, temporary pods). Thus, their old occurrences will have no change by the patch but the future tasks will be collected into a new common group holder.