### PR TITLE
NVSHAS-5545, add system configuration network service toggle to select cluster wide network policy mode

### DIFF
--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -1530,6 +1530,8 @@ type RESTSystemConfigConfig struct {
 	IBMSAEpEnabled            *bool           `json:"ibmsa_ep_enabled,omitempty"`
 	IBMSAEpDashboardURL       *string         `json:"ibmsa_ep_dashboard_url,omitempty"`
 	XffEnabled                *bool           `json:"xff_enabled,omitempty"`
+	NetServiceStatus          *bool           `json:"net_service_status,omitempty"`
+	NetServicePolicyMode      *string         `json:"net_service_policy_mode,omitempty"`
 	// InternalSubnets      *[]string `json:"configured_internal_subnets,omitempty"`
 }
 
@@ -1586,6 +1588,8 @@ type RESTSystemConfig struct {
 	IBMSAEpDashboardURL       string        `json:"ibmsa_ep_dashboard_url"`
 	IBMSAEpConnectedAt        string        `json:"ibmsa_ep_connected_at"`
 	XffEnabled                bool          `json:"xff_enabled"`
+	NetServiceStatus          bool          `json:"net_service_status"`
+	NetServicePolicyMode      string        `json:"net_service_policy_mode"`
 }
 
 type RESTIBMSAConfig struct {

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -288,8 +288,13 @@ func deriveWorkloadState(cache *workloadCache) string {
 	} else if cache.workload.Inline {
 		return api.WorkloadStateProtect
 	}
+	//when getNetServiceStatus() is true, policymode
+	//is global so we use per group level profile mode
+	mode, profmode := getWorkloadPolicyMode(cache)
+	if getNetServiceStatus() {
+		mode = profmode
+	}
 
-	mode, _ := getWorkloadPolicyMode(cache)
 	switch mode {
 	case share.PolicyModeEvaluate:
 		return api.WorkloadStateMonitor

--- a/controller/cache/compliance.go
+++ b/controller/cache/compliance.go
@@ -403,7 +403,14 @@ func (m CacheMethod) GetRiskScoreMetrics(acc, accCaller *access.AccessControl) *
 				Apps:         cr.Apps,
 				Ports:        cr.Ports,
 			}
-			r.PolicyMode, _ = getWorkloadPolicyMode(cache)
+			//when getNetServiceStatus() is true, policymode
+			//is global so we use per group level profile mode
+			polmode, profmode := getWorkloadPolicyMode(cache)
+			if getNetServiceStatus() {
+				r.PolicyMode = profmode
+			} else {
+				r.PolicyMode = polmode
+			}
 			ins = append(ins, r)
 		}
 	}
@@ -425,7 +432,14 @@ func (m CacheMethod) GetRiskScoreMetrics(acc, accCaller *access.AccessControl) *
 				Apps:         cr.Apps,
 				Ports:        cr.Ports,
 			}
-			r.PolicyMode, _ = getWorkloadPolicyMode(cache)
+			//when getNetServiceStatus() is true, policymode
+			//is global so we use per group level profile mode
+			polmode, profmode := getWorkloadPolicyMode(cache)
+			if getNetServiceStatus() {
+				r.PolicyMode = profmode
+			} else {
+				r.PolicyMode = polmode
+			}
 			outs = append(outs, r)
 		}
 	}

--- a/controller/cache/config.go
+++ b/controller/cache/config.go
@@ -174,12 +174,28 @@ func getNewServicePolicyMode() string {
 	return systemConfigCache.NewServicePolicyMode
 }
 
+func getNetServiceStatus() bool {
+	return systemConfigCache.NetServiceStatus
+}
+
+func getNetServicePolicyMode() string {
+	return systemConfigCache.NetServicePolicyMode
+}
+
 func getNewServiceProfileBaseline() string {
 	return systemConfigCache.NewServiceProfileBaseline
 }
 
 func (m CacheMethod) GetNewServicePolicyMode() string {
 	return getNewServicePolicyMode()
+}
+
+func (m CacheMethod) GetNetServiceStatus() bool {
+	return getNetServiceStatus()
+}
+
+func (m CacheMethod) GetNetServicePolicyMode() string {
+	return getNetServicePolicyMode()
 }
 
 func (m CacheMethod) GetNewServiceProfileBaseline() string {
@@ -224,6 +240,8 @@ func (m CacheMethod) GetSystemConfig(acc *access.AccessControl) *api.RESTSystemC
 		IBMSAEpDashboardURL:       systemConfigCache.IBMSAConfigNV.EpDashboardURL,
 		IBMSAEpConnectedAt:        api.RESTTimeString(systemConfigCache.IBMSAConfigNV.EpConnectedAt),
 		XffEnabled:                systemConfigCache.XffEnabled,
+		NetServiceStatus:          systemConfigCache.NetServiceStatus,
+		NetServicePolicyMode:      systemConfigCache.NetServicePolicyMode,
 	}
 	if systemConfigCache.SyslogIP != nil {
 		rconf.SyslogServer = systemConfigCache.SyslogIP.String()
@@ -340,7 +358,14 @@ func systemConfigUpdate(nType cluster.ClusterNotifyType, key string, value []byt
 			// customer explicitly disables IBM SA endpoint
 			cctx.StartStopFedPingPollFunc(share.StopPostToIBMSA, 0, nil)
 		}
-
+		//if global network policy mode enabled/disabled or mode changes
+		//shedule policy calculation
+		if cfg.NetServiceStatus != systemConfigCache.NetServiceStatus {
+			scheduleIPPolicyCalculation(true)
+		} else if systemConfigCache.NetServiceStatus &&
+			cfg.NetServicePolicyMode != systemConfigCache.NetServicePolicyMode {
+				scheduleIPPolicyCalculation(true)
+		}
 	case cluster.ClusterNotifyDelete:
 		// Triggered at configuration import
 		cfg = common.DefaultSystemConfig

--- a/controller/cache/file_monitor.go
+++ b/controller/cache/file_monitor.go
@@ -366,7 +366,7 @@ func (m CacheMethod) GetFedFileMonitorProfileCache() ([]*share.CLUSFileMonitorPr
 		}
 		p := &share.CLUSFileMonitorProfile{
 			Group:   groupName,
-			Mode:    g.PolicyMode,
+			Mode:    g.ProfileMode,
 			Filters: fmfs,
 			CfgType: g.CfgType,
 		}

--- a/controller/cache/interface.go
+++ b/controller/cache/interface.go
@@ -208,6 +208,8 @@ type CacheInterface interface {
 	GetDlpRuleSensorGroupById(id uint32) (string, string, *[]string)
 	GetNewServicePolicyMode() string
 	GetUnusedGroupAging() uint8
+	GetNetServiceStatus() bool
+	GetNetServicePolicyMode() string
 
 	// Waf rule
 	GetAllWafSensors(acc *access.AccessControl) []*api.RESTWafSensor

--- a/controller/cache/object.go
+++ b/controller/cache/object.go
@@ -229,7 +229,14 @@ func workload2Filter(cache *workloadCache) *common.WorkloadFilter {
 		ImageID:      wl.ImageID,
 		Domain:       wl.Domain,
 	}
-	r.PolicyMode, _ = getWorkloadPolicyMode(cache)
+	//when getNetServiceStatus() is true, policymode
+	//is global so we use per group level profile mode
+	polmode, profmode := getWorkloadPolicyMode(cache)
+	if getNetServiceStatus() {
+		r.PolicyMode = profmode
+	} else {
+		r.PolicyMode = polmode
+	}
 	return r
 }
 
@@ -263,8 +270,12 @@ func workload2BriefREST(cache *workloadCache) *api.RESTWorkloadBrief {
 		RunAsRoot:          wl.RunAsRoot,
 	}
 
+	//when getNetServiceStatus() is true, policymode
+	//is global so we use per group level profile mode
 	r.PolicyMode, r.ProfileMode = getWorkloadPolicyMode(cache)
-
+	if getNetServiceStatus() {
+		r.PolicyMode = r.ProfileMode
+	}
 	if cache.scanBrief == nil {
 		r.ScanSummary = &api.RESTScanBrief{}
 	}

--- a/controller/cache/policy.go
+++ b/controller/cache/policy.go
@@ -406,10 +406,20 @@ func getHostPolicyMode(cache *hostCache) (string, string) {
 }
 
 func getWorkloadPolicyMode(wlCache *workloadCache) (string, string) {
-	if cache, ok := groupCacheMap[wlCache.learnedGroupName]; ok {
-		return cache.group.PolicyMode, cache.group.ProfileMode
+	//if global net service status is enabled, use global net service 
+	//policy mode, profile still use per group mode 
+	if getNetServiceStatus() {
+		if cache, ok := groupCacheMap[wlCache.learnedGroupName]; ok {
+			return getNetServicePolicyMode(), cache.group.ProfileMode
+		} else {
+			return getNetServicePolicyMode(), api.WorkloadStateDiscover
+		}
 	} else {
-		return api.WorkloadStateDiscover, api.WorkloadStateDiscover
+		if cache, ok := groupCacheMap[wlCache.learnedGroupName]; ok {
+			return cache.group.PolicyMode, cache.group.ProfileMode
+		} else {
+			return api.WorkloadStateDiscover, api.WorkloadStateDiscover
+		}
 	}
 }
 

--- a/controller/common/common.go
+++ b/controller/common/common.go
@@ -82,6 +82,8 @@ var DefaultSystemConfig = share.CLUSSystemConfig{
 	ControllerDebug: []string{},
 	TapProxymesh:    true,
 	XffEnabled:      true,
+	NetServiceStatus:     false,
+	NetServicePolicyMode: share.PolicyModeLearn,
 }
 
 func ActionString(action uint8) string {

--- a/controller/kv/create.go
+++ b/controller/kv/create.go
@@ -790,6 +790,14 @@ func EnforceXffEnabledSetting() {
 	}
 }
 
+func createDefaultNetServiceSetting() {
+	acc := access.NewReaderAccessControl()
+	cfg, rev := clusHelper.GetSystemConfigRev(acc)
+	cfg.NetServiceStatus = false
+	cfg.NetServicePolicyMode = share.PolicyModeLearn
+	clusHelper.PutSystemConfigRev(cfg, rev)
+}
+
 func createDefaultVulnerabilityProfile() {
 	key := share.CLUSVulnerabilityProfileKey(share.DefaultVulnerabilityProfileName)
 	profile := &share.CLUSVulnerabilityProfile{

--- a/controller/kv/upgrade.go
+++ b/controller/kv/upgrade.go
@@ -713,7 +713,9 @@ var phases []kvVersions = []kvVersions{
 
 	{"4665644B", addAdmCtrlStateStatusUri},
 
-	{"2C05EB31", nil},
+	{"2C05EB31", createDefaultNetServiceSetting},
+
+	{"4C746652", nil},
 }
 
 func latestKVVersion() string {

--- a/controller/rest/configmap.go
+++ b/controller/rest/configmap.go
@@ -428,6 +428,25 @@ func handlesystemcfg(yaml_data []byte, load bool, skip *bool, context *configMap
 		cconf.XffEnabled = *rc.XffEnabled
 	}
 
+	//global network service status
+	if rc.NetServiceStatus != nil {
+		cconf.NetServiceStatus = *rc.NetServiceStatus
+	}
+	// global network service policy mode
+	if rc.NetServicePolicyMode != nil {
+		if *rc.NetServicePolicyMode == share.PolicyModeEnforce &&
+			licenseAllowEnforce() == false {
+			return errors.New("Invalid network service license for protect mode")
+		}
+		switch *rc.NetServicePolicyMode {
+		case share.PolicyModeLearn, share.PolicyModeEvaluate, share.PolicyModeEnforce:
+			cconf.NetServicePolicyMode = *rc.NetServicePolicyMode
+		default:
+			log.WithFields(log.Fields{"net_service_policy_mode": *rc.NetServicePolicyMode}).Error("Invalid network service policy mode")
+			return errors.New("Invalid network service policy mode")
+		}
+	}
+
 	// registry proxy
 	if rc.RegistryHttpProxy != nil {
 		if rc.RegistryHttpProxy.URL != "" {

--- a/controller/rest/system.go
+++ b/controller/rest/system.go
@@ -1106,6 +1106,29 @@ func handlerSystemConfig(w http.ResponseWriter, r *http.Request, ps httprouter.P
 				cconf.XffEnabled = *rc.XffEnabled
 			}
 
+			//global network service status
+			if rc.NetServiceStatus != nil {
+				cconf.NetServiceStatus = *rc.NetServiceStatus
+			}
+
+			// global network service policy mode
+			if rc.NetServicePolicyMode != nil {
+				if *rc.NetServicePolicyMode == share.PolicyModeEnforce &&
+					licenseAllowEnforce() == false {
+					restRespError(w, http.StatusBadRequest, api.RESTErrLicenseFail)
+					return
+				}
+				switch *rc.NetServicePolicyMode {
+				case share.PolicyModeLearn, share.PolicyModeEvaluate, share.PolicyModeEnforce:
+					cconf.NetServicePolicyMode = *rc.NetServicePolicyMode
+				default:
+					e := "Invalid network service policy mode"
+					log.WithFields(log.Fields{"net_service_policy_mode": *rc.NetServicePolicyMode}).Error(e)
+					restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, e)
+					return
+				}
+			}
+
 			// registry proxy
 			if rc.RegistryHttpProxy != nil {
 				if rc.RegistryHttpProxy.URL != "" {

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -715,6 +715,8 @@ type CLUSSystemConfig struct {
 	IBMSAOnboardData     CLUSIBMSAOnboardData `json:"ibmsa_onboard_data"`
 	XffEnabled           bool                 `json:"xff_enabled"`
 	CfgType              TCfgType             `json:"cfg_type"`
+	NetServiceStatus     bool                 `json:"net_service_status"`
+	NetServicePolicyMode string               `json:"net_service_policy_mode"`
 }
 
 type CLUSEULA struct {


### PR DESCRIPTION
1. when global network service is enabled, the network policy mode will be globally set to discover/monitor/protect
2. at the per group level, user can still switch mode without behavior change, however per group level policy mode only applies to process profile, 
3. it is same for policy mode set by crd, it only applies to profile if global network service is enabled.
4. when global network service is disabled, per group level policy mode will apply to both network and profile.