### PR TITLE
NV5818: Mode automation upgrader

### DIFF
--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -1537,6 +1537,10 @@ type RESTSystemConfigConfig struct {
 	IBMSAEpDashboardURL       *string         `json:"ibmsa_ep_dashboard_url,omitempty"`
 	XffEnabled                *bool           `json:"xff_enabled,omitempty"`
 	// InternalSubnets      *[]string `json:"configured_internal_subnets,omitempty"`
+	ModeAutoD2M               *bool           `json:"mode_auto_d2m"`
+	ModeAutoD2MDuration       *int64          `json:"mode_auto_d2m_duration"`
+	ModeAutoM2P               *bool           `json:"mode_auto_m2p"`
+	ModeAutoM2PDuration       *int64          `json:"mode_auto_m2p_duration"`
 }
 
 type RESTSysNetConfigConfig struct {
@@ -1602,6 +1606,10 @@ type RESTSystemConfig struct {
 	XffEnabled                bool          `json:"xff_enabled"`
 	NetServiceStatus          bool          `json:"net_service_status"`
 	NetServicePolicyMode      string        `json:"net_service_policy_mode"`
+	ModeAutoD2M               bool          `json:"mode_auto_d2m"`
+	ModeAutoD2MDuration       int64         `json:"mode_auto_d2m_duration"`
+	ModeAutoM2P               bool          `json:"mode_auto_m2p"`
+	ModeAutoM2PDuration       int64         `json:"mode_auto_m2p_duration"`
 }
 
 type RESTIBMSAConfig struct {

--- a/controller/atmo/atmo.go
+++ b/controller/atmo/atmo.go
@@ -1,0 +1,206 @@
+package atmo
+
+import (
+	"time"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/neuvector/neuvector/share/utils"
+)
+
+const (
+	Discover2Monitor = 0
+	Monitor2Protect  = 1
+)
+
+type AutoModeHelper interface {
+	ConfigureCompleteDuration(mover int, dComplete time.Duration)
+	AddGroup(mover int, group string) bool
+	RemoveGroup(group string)
+	Counts(mover int) int
+	Enabled() (bool, bool)
+	List(mover int) []string
+}
+
+//////
+type testFunc	  func(mover int, group string, probeDuration time.Duration) (bool, error)
+type decisionFunc func(mover int, group string, err error) error
+type automode_ctx struct {
+	bD2M		bool
+	bM2P		bool
+
+	// controls
+	mutex		sync.Mutex
+	timerWheel  *utils.TimerWheel
+
+	// data
+	d2m_members	map[string]*task
+	m2p_members map[string]*task
+
+	// parameters
+	d2m_cmpl    time.Duration	// complete period
+	m2p_cmpl    time.Duration
+	d2m_itl     time.Duration	// probe interval
+	m2p_itl     time.Duration
+	d2m_life    int			// maximum probe counts
+	m2p_life    int
+
+	// callbacks
+	probefn  	probeFunc
+
+	// test functions
+	testfn		testFunc
+	decidefn	decisionFunc
+}
+
+//
+var atmo_ctx 	*automode_ctx
+
+const discover_probe = time.Second * 60		// interval: 1 minute
+const discover_complete = time.Hour * 6		// convert into counters
+const monitor_probe = time.Minute * 5 		// interval: 5
+const monitor_complete = time.Hour * 12		// convert into counters
+
+///
+func Init(timerWheel *utils.TimerWheel, test_cb testFunc, decision_cb decisionFunc) (*automode_ctx) {
+	log.Debug("ATMO:")
+	atmo_ctx = &automode_ctx {
+		d2m_members: make(map[string]*task),
+		m2p_members: make(map[string]*task),
+		timerWheel:  timerWheel,
+		d2m_cmpl:    discover_complete,		// complete period
+		m2p_cmpl:    monitor_complete,
+		d2m_itl:     discover_probe,		// probe interval
+		m2p_itl:     monitor_probe,
+		testfn:	  	 test_cb,
+		decidefn:    decision_cb,
+	}
+
+	// prepare counters
+	atmo_ctx.d2m_life = (int)(atmo_ctx.d2m_cmpl/atmo_ctx.d2m_itl)
+	atmo_ctx.m2p_life = (int)(int64(atmo_ctx.m2p_cmpl/atmo_ctx.m2p_itl))
+	return atmo_ctx
+}
+
+func GetAutoModeHelper() AutoModeHelper {
+	return atmo_ctx
+}
+
+///////////////////////////////////////////////////////
+func (ctx *automode_ctx) lock() {
+	ctx.mutex.Lock()
+}
+
+func (ctx *automode_ctx) unlock() {
+	ctx.mutex.Unlock()
+}
+
+////////////////////////////////////////////////////////////////////////////
+// internal testing purpose: do before the first Configure() function
+func (ctx *automode_ctx) ConfigProbeTime(mover int, probe time.Duration) {
+	log.WithFields(log.Fields{"probe": probe, "mover": mover}).Info("ATMO:")
+	switch mover {
+	case Discover2Monitor:
+		ctx.d2m_itl = probe
+		ctx.d2m_life =  (int)(ctx.d2m_cmpl/ctx.d2m_itl)
+	case Monitor2Protect:
+		ctx.m2p_itl = probe
+		ctx.m2p_life =  (int)(int64(ctx.m2p_cmpl/ctx.m2p_itl))
+	default:
+		log.WithFields(log.Fields{"probe": probe, "mover": mover}).Error("ATMO:")
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////
+func (ctx *automode_ctx) ConfigureCompleteDuration(mover int, dComplete time.Duration) {
+	log.WithFields(log.Fields{"complete": dComplete, "mover": mover}).Debug("ATMO:")
+	switch mover {
+	case Discover2Monitor:
+		if dComplete == 0 {	// disabled
+			ctx.pruneMembers(Discover2Monitor)
+			ctx.bD2M = false
+		} else {
+			if ctx.d2m_cmpl != dComplete {
+				ctx.d2m_cmpl = dComplete
+				ctx.d2m_life = (int)(ctx.d2m_cmpl/ctx.d2m_itl)
+			}
+			ctx.bD2M = true
+		}
+	case Monitor2Protect:
+		if dComplete == 0 {	// disabled
+			ctx.pruneMembers(Monitor2Protect)
+			ctx.bM2P = false
+		} else {
+			if ctx.m2p_cmpl != dComplete {
+				ctx.m2p_cmpl = dComplete
+				ctx.m2p_life = (int)(int64(ctx.m2p_cmpl/ctx.m2p_itl))
+			}
+			ctx.bM2P = true
+		}
+	}
+}
+
+func (ctx *automode_ctx) AddGroup(mover int, group string) bool {
+	switch mover {
+		case Discover2Monitor:
+			ctx.removeMember(Monitor2Protect, group)
+			if !ctx.bD2M {
+				return false
+			}
+		case Monitor2Protect:
+			ctx.removeMember(Discover2Monitor, group)
+			if !ctx.bM2P {
+				return false
+			}
+		default:
+			return false
+	}
+	return ctx.addMember(mover, group)
+}
+
+func (ctx *automode_ctx) RemoveGroup(group string) {
+	// log.WithFields(log.Fields{"group": group}).Debug("ATMO:")
+
+	// where is it?
+	ctx.removeMember(Discover2Monitor, group)
+	ctx.removeMember(Monitor2Protect, group)
+}
+
+func (ctx *automode_ctx) Counts(mover int) int {
+	ctx.lock()
+	defer ctx.unlock()
+	switch mover {
+	case Discover2Monitor:
+		return len(ctx.d2m_members)
+	case Monitor2Protect:
+		return len(ctx.m2p_members)
+	}
+	return 0
+}
+
+func (ctx *automode_ctx) List(mover int) []string {
+	var list []string
+	var members map[string]*task
+
+	ctx.lock()
+	defer ctx.unlock()
+	switch mover {
+	case Discover2Monitor:
+		members = ctx.d2m_members
+	case Monitor2Protect:
+		members = ctx.m2p_members
+	default:
+		return list
+	}
+
+	for n, _ := range members {
+		list = append(list, n)
+	}
+	return list
+}
+
+func (ctx *automode_ctx) Enabled() (bool, bool) {
+	// log.WithFields(log.Fields{"d2m": ctx.bD2M, "m2p": ctx.bM2P}).Debug("ATMO:")
+	return ctx.bD2M, ctx.bM2P
+}

--- a/controller/atmo/atmo_tasks.go
+++ b/controller/atmo/atmo_tasks.go
@@ -1,0 +1,168 @@
+package atmo
+
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/neuvector/neuvector/share/utils"
+)
+
+////////////////////
+type probeFunc func(mover int, id string, probeDuration time.Duration) (bool, error)
+type lifeCntFunc func(mover int) int
+type completeFunc func(mover int, group string, err error) error
+type task struct {
+	mover		int
+	id       	string			// group name
+	timer    	string
+	timerWheel 	*utils.TimerWheel
+	runs     	int				// good counter
+	interval 	time.Duration	// probe interval
+	testFunc 	probeFunc
+	lifeFunc    lifeCntFunc
+	cmplFunc 	completeFunc
+}
+
+///////////////////////////////////////////////////////////////////
+func (t *task) StartTimer() {
+	t.timer, _ = t.timerWheel.AddTask(t, t.interval)
+}
+
+func (t *task) CancelTimer() {
+	if t.timer != "" {
+		t.timerWheel.RemoveTask(t.timer)
+		t.timer = ""
+	}
+}
+
+func (t *task) Expire() {
+	ok, err := t.testFunc(t.mover, t.id, t.interval)
+	if err != nil {
+		// remove the task
+		t.CancelTimer()
+		go t.cmplFunc(t.mover, t.id, err)
+		return
+	}
+
+	if ok {
+		// accumlated amount
+		t.runs++
+		// log.WithFields(log.Fields{"group": t.id, "runs": t.runs}).Debug("ATMO:")
+	} else {
+		//log.WithFields(log.Fields{"group": t.id}).Debug("ATMO: invalid")
+	}
+
+	if t.runs >= t.lifeFunc(t.mover) {
+		// completed
+		t.CancelTimer()
+		go t.cmplFunc(t.mover, t.id, nil)
+	} else {
+		// re-queued
+		t.StartTimer()
+	}
+}
+
+///////////////////////////////////////////////////////////////////
+func (ctx *automode_ctx) prober(mover int, group string, dur time.Duration) (bool, error) {
+	return ctx.testfn(mover, group, dur)
+}
+
+func (ctx *automode_ctx) life(mover int) int {
+	switch mover {
+	case Discover2Monitor:
+		return ctx.d2m_life
+	case Monitor2Protect:
+		return ctx.m2p_life
+	}
+	return 0 // kick-out unknown
+}
+
+func (ctx *automode_ctx) finisher(mover int, group string, err error) error {
+	ctx.lock()
+	switch mover {
+	case Discover2Monitor:
+		delete(ctx.d2m_members, group)
+	case Monitor2Protect:
+		delete(ctx.m2p_members, group)
+	}
+	ctx.unlock()
+	return ctx.decidefn(mover, group, err)
+}
+
+func (ctx *automode_ctx) addMember(mover int, group string) bool {
+	var members map[string]*task
+	var interval time.Duration
+
+	ctx.lock()
+	defer ctx.unlock()
+	switch mover {
+	case Discover2Monitor:
+		members = ctx.d2m_members
+		interval =  ctx.d2m_itl
+	case Monitor2Protect:
+		members = ctx.m2p_members
+		interval =  ctx.m2p_itl
+	default:
+		return false
+	}
+
+	if _, ok := members[group]; !ok {
+		log.WithFields(log.Fields{"group": group, "mover": mover}).Debug("ATMO:")
+		t := &task {
+			id:	      	group,
+			mover:    	mover,
+			interval: 	interval,
+			timerWheel: ctx.timerWheel,
+			testFunc: 	ctx.prober,
+			lifeFunc:   ctx.life,
+			cmplFunc: 	ctx.finisher,
+		}
+		members[group] = t
+		t.StartTimer()
+		return true
+	}
+	return false
+}
+
+func (ctx *automode_ctx) removeMember(mover int, group string) {
+	var members map[string]*task
+
+	ctx.lock()
+	defer ctx.unlock()
+	switch mover {
+	case Discover2Monitor:
+		members = ctx.d2m_members
+	case Monitor2Protect:
+		members = ctx.m2p_members
+	default:
+		return
+	}
+
+	if task, ok := members[group]; ok {
+		log.WithFields(log.Fields{"group": group, "mover": mover}).Debug("ATMO:")
+		task.CancelTimer()
+		delete(members, group)
+	}
+}
+
+func (ctx *automode_ctx) pruneMembers(mover int) {
+	var members map[string]*task
+
+	ctx.lock()
+	defer ctx.unlock()
+	switch mover {
+	case Discover2Monitor:
+		members = ctx.d2m_members
+	case Monitor2Protect:
+		members = ctx.m2p_members
+	default:
+		return
+	}
+
+	for group, task := range members {
+		task.CancelTimer()
+		delete(members, group)
+	}
+	log.WithFields(log.Fields{"mover": mover, "d2m_members": len(ctx.d2m_members), "m2p_members": len(ctx.m2p_members)}).Debug("ATMO:")
+}

--- a/controller/atmo/atmo_test.go
+++ b/controller/atmo/atmo_test.go
@@ -1,0 +1,99 @@
+package atmo
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/neuvector/neuvector/controller/common"
+	"github.com/neuvector/neuvector/share/utils"
+)
+
+func my_test_func(mover int, group string, probeDuration time.Duration) (bool, error) {
+	switch mover {
+	case Discover2Monitor:
+		return true, nil
+	case Monitor2Protect:
+		return true, nil
+	}
+	return false, common.ErrUnsupported
+}
+
+func my_decision_func(mover int, group string, err error) error {
+	if err != nil {
+		log.WithFields(log.Fields{"mover": mover, "error": err}).Debug("ATMO: member left")
+		return nil
+	}
+
+	switch mover {
+	case Discover2Monitor:
+		return nil
+	case Monitor2Protect:
+		return nil
+	}
+	return common.ErrUnsupported
+}
+
+func my_completed(mover int, group string, err error) bool {
+	log.WithFields(log.Fields{"group": group, "mover": mover, "error": err}).Debug("ATMO:")
+	switch mover {
+	case Discover2Monitor:
+		return true		// promote Discover to Monitor
+	case Monitor2Protect:
+		return true		// promote Monitor to Protect
+	}
+	return false
+}
+
+func initEnv() *automode_ctx {
+	log.SetOutput(os.Stdout)
+	log.SetLevel(log.DebugLevel) // change it later: log.InfoLevel
+	log.SetFormatter(&utils.LogFormatter{Module: "ATMO"})
+	timerWheel := utils.NewTimerWheel()
+	timerWheel.Start()
+	ctx := Init(timerWheel, my_test_func, my_decision_func)
+	// testing purpose
+	ctx.ConfigProbeTime(Discover2Monitor, time.Second*5)
+	ctx.ConfigProbeTime(Monitor2Protect, time.Second*5)
+	return ctx
+}
+
+func testAddGroups(t *testing.T) {
+	ctx := initEnv()
+	ctx.ConfigureCompleteDuration(Discover2Monitor, time.Second * 30)
+	ctx.ConfigureCompleteDuration(Monitor2Protect, time.Second * 60)
+
+	for i := 0; i < 2; i++ {
+		name := fmt.Sprintf("m2d%d", i)
+		if ok := ctx.AddGroup(Monitor2Protect, name); !ok {
+			t.Errorf("Error: failed to add %s\n", name)
+			break
+		}
+		time.Sleep(time.Second * 10)
+	}
+
+	for i := 0; i < 5; i++ {
+		name := fmt.Sprintf("d2m%d", i)
+		if ok := ctx.AddGroup(Discover2Monitor, name); !ok {
+			t.Errorf("Error: failed to add %s\n", name)
+			break
+		}
+		time.Sleep(time.Second * 10)
+	}
+
+	cnt := 12
+	for {
+		time.Sleep(time.Second * 10)
+		if ctx.Counts(Discover2Monitor) == 0 && ctx.Counts(Monitor2Protect) == 0 {
+			break
+		}
+		cnt--
+		if cnt == 0 {
+			t.Errorf("Error: failed to stop\n")
+			break
+		}
+	}
+}

--- a/controller/cache/automode.go
+++ b/controller/cache/automode.go
@@ -1,0 +1,293 @@
+package cache
+import (
+	"math/rand"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/neuvector/neuvector/controller/access"
+	"github.com/neuvector/neuvector/controller/api"
+	"github.com/neuvector/neuvector/controller/atmo"
+	"github.com/neuvector/neuvector/controller/common"
+	"github.com/neuvector/neuvector/share"
+	"github.com/neuvector/neuvector/share/utils"
+)
+
+var atmoHelper atmo.AutoModeHelper
+
+func automode_init(ctx *Context) {
+	atmo.Init(ctx.TimerWheel, automode_test_func, automode_decision_func)
+	atmoHelper = atmo.GetAutoModeHelper()
+}
+
+func automode_d2m_test_func(group string) (bool, error) {
+	cacheMutexRLock()
+	defer cacheMutexRUnlock()
+	if cache, ok := groupCacheMap[group]; ok {
+		// member count > 0
+		return (cache.members.Cardinality() > 0), nil
+	}
+	return false, common.ErrObjectNotFound
+}
+
+func automode_m2p_test_func(group string, probeDuration int64) (bool, error) {
+	cacheMutexRLock()
+	defer cacheMutexRUnlock()
+	if cache, ok := groupCacheMap[group]; ok {
+		if cache.members.Cardinality() == 0 {
+			return false, nil	// TBD
+		}
+
+		var count int
+		var last *api.Incident
+
+		// trace back to last probe duration - 10 seconds
+		traceback := time.Now().Unix() - probeDuration - 10
+		for i, incd := range incidentCache {
+			if i == curIncidentIndex {
+				break
+			}
+
+			if incd == nil || incd.AggregationFrom < traceback {
+				continue
+			}
+
+			if incd.Group == group {
+				count++
+				last = incd
+			}
+		}
+
+		if count > 0 {
+			log.WithFields(log.Fields{"incident": count, "group": group, "last": last}).Debug("ATMO:")
+		}
+		return (count == 0), nil
+	}
+	return false, common.ErrObjectNotFound
+}
+
+func automode_test_func(mover int, group string, probeDuration time.Duration) (bool, error) {
+	switch mover {
+	case atmo.Discover2Monitor:
+		return automode_d2m_test_func(group)
+	case atmo.Monitor2Protect:
+		return automode_m2p_test_func(group, int64(probeDuration.Seconds()))
+	}
+	return false, common.ErrUnsupported
+}
+
+func automode_promote_mode(group, mode string) error {
+	if strings.HasPrefix(group, api.LearnedSvcGroupPrefix) {
+		return common.ErrUnsupported
+	}
+
+	grp, _, _ := clusHelper.GetGroup(group, access.NewAdminAccessControl())
+	if grp == nil {
+		log.WithFields(log.Fields{"group": group, "promote": mode}).Info("ATMO: no exist")
+		return common.ErrObjectNotFound
+	}
+
+	if grp.CfgType != share.Learned {
+		log.WithFields(log.Fields{"group": group, "type": grp.CfgType, "promote": mode}).Info("ATMO: ignored")
+		return common.ErrUnsupported
+	}
+
+	log.WithFields(log.Fields{"group": group, "mode": mode}).Debug("ATMO:")
+	// sync both policy and profile modes together
+	switch mode {
+	case share.PolicyModeEvaluate:
+		if grp.ProfileMode != share.PolicyModeLearn {
+			return nil
+		}
+	case share.PolicyModeEnforce:
+		if grp.PolicyMode != share.PolicyModeEvaluate {
+			return nil
+		}
+	default:
+		return common.ErrUnsupported
+	}
+
+	// promote
+	grp.ProfileMode = mode
+	grp.PolicyMode = mode
+	if pp := clusHelper.GetProcessProfile(group); pp != nil {
+		pp.Mode = mode
+		clusHelper.PutProcessProfile(group, pp)
+	}
+	if pp, rev := clusHelper.GetFileMonitorProfile(group); pp != nil {
+		pp.Mode = grp.ProfileMode
+		clusHelper.PutFileMonitorProfile(group, pp, rev)
+	}
+	log.WithFields(log.Fields{"group": group, "mode": mode}).Info("ATMO: upgraded")
+	clusHelper.PutGroup(grp, false)
+	return nil
+}
+
+func automode_decision_func(mover int, group string, err error) error {
+	if err != nil {
+		log.WithFields(log.Fields{"mover": mover, "error": err}).Debug("ATMO: member left")
+		return nil
+	}
+
+	var targetMode string
+	switch mover {
+	case atmo.Discover2Monitor:
+		targetMode = share.PolicyModeEvaluate
+	case atmo.Monitor2Protect:
+		targetMode = share.PolicyModeEnforce
+	default:
+		return common.ErrUnsupported
+	}
+
+	if isLeader() {
+		automode_promote_mode(group, targetMode)
+	} else {
+		go func() {
+			r1 := rand.New(rand.NewSource(time.Now().UnixNano()))
+			wait_sec := 3 * 60 + r1.Intn(100)	// separating controller actions. no promoting when it has been already promoted
+			time.Sleep(time.Second * time.Duration(wait_sec))
+			lock, err := clusHelper.AcquireLock(share.CLUSLockPolicyKey, time.Duration(time.Second * 60))
+			if err != nil {
+				log.WithFields(log.Fields{"group": group, "mode": targetMode}).Error("failed: delay changed")
+				return
+			}
+			defer clusHelper.ReleaseLock(lock)
+			automode_promote_mode(group, targetMode)
+		}()
+	}
+
+	return common.ErrUnsupported
+}
+
+func automode_configure_d2m(enabled bool, dur int64) {
+	var dComplete time.Duration = 0
+	if enabled {
+		dComplete = time.Duration(dur) * time.Second
+	}
+	atmoHelper.ConfigureCompleteDuration(atmo.Discover2Monitor, dComplete)
+}
+
+func automode_configure_m2p(enabled bool, dur int64) {
+	var dComplete time.Duration = 0
+	if enabled {
+		dComplete = time.Duration(dur) * time.Second
+	}
+	atmoHelper.ConfigureCompleteDuration(atmo.Monitor2Protect, dComplete)
+}
+
+func automode_init_trigger(mover int) {
+	var mode string
+	switch mover {
+	case atmo.Discover2Monitor:
+		mode = share.PolicyModeLearn
+	case atmo.Monitor2Protect:
+		mode = share.PolicyModeEvaluate
+	default:
+		return
+	}
+
+	now := time.Now().Unix()
+	cacheMutexRLock()
+	defer cacheMutexRUnlock()
+	for name, cache := range groupCacheMap {
+		if !utils.DoesGroupHavePolicyMode(name) || name == api.AllHostGroup || cache.group == nil{
+			continue
+		}
+
+		// log.WithFields(log.Fields{"group": name, "mode": mode}).Debug("ATMO:")
+		if cache.group.ProfileMode == mode {
+			atmoHelper.AddGroup(mover, name)
+			switch mover {
+			case atmo.Discover2Monitor:
+				cache.atmo_d2m = now
+			case atmo.Monitor2Protect:
+				cache.atmo_m2p = now
+			}
+		}
+	}
+}
+
+func automode_trigger_d2m() {
+	//log.Debug("ATMO:")
+	automode_init_trigger(atmo.Discover2Monitor)
+}
+
+func automode_trigger_m2p() {
+	//log.Debug("ATMO:")
+	automode_init_trigger(atmo.Monitor2Protect)
+}
+
+var firstUpdated bool
+func automodeConfigUpdate(cfg, cache share.CLUSSystemConfig) {
+	// log.WithFields(log.Fields{"cfg": cfg, "cache": cache}).Debug("ATMO:")
+	if firstUpdated {
+		if cfg.ModeAutoD2M != cache.ModeAutoD2M ||
+			cfg.ModeAutoD2MDuration != cache.ModeAutoD2MDuration {
+			automode_configure_d2m(cfg.ModeAutoD2M, cfg.ModeAutoD2MDuration)
+			if cfg.ModeAutoD2M && !cache.ModeAutoD2M {
+				automode_trigger_d2m()
+			}
+		}
+		if cfg.ModeAutoM2P != cache.ModeAutoM2P ||
+			cfg.ModeAutoM2PDuration != cache.ModeAutoM2PDuration {
+			automode_configure_m2p(cfg.ModeAutoM2P, cfg.ModeAutoM2PDuration)
+			if cfg.ModeAutoM2P && !cache.ModeAutoM2P {
+				automode_trigger_m2p()
+			}
+		}
+	} else {
+		firstUpdated = true
+		if cfg.ModeAutoD2M {
+			automode_configure_d2m(cfg.ModeAutoD2M, cfg.ModeAutoD2MDuration)
+			automode_trigger_d2m()
+		}
+		if cfg.ModeAutoM2P {
+			automode_configure_m2p(cfg.ModeAutoM2P, cfg.ModeAutoM2PDuration)
+			automode_trigger_m2p()
+		}
+	}
+}
+
+//////////////////////
+func automodeGroupDelete(name string, param interface{}) {
+	log.WithFields(log.Fields{"group": name}).Debug("ATMO:")
+	if bD2M, bM2P := atmoHelper.Enabled(); bD2M || bM2P {
+		atmoHelper.RemoveGroup(name)
+	}
+}
+
+func automodeGroupAdd(name string, param interface{}) {
+	cache := param.(*groupCache)
+	if bD2M, bM2P := atmoHelper.Enabled(); bD2M || bM2P {
+		var mover int
+		if !utils.DoesGroupHavePolicyMode(name) || name == api.AllHostGroup || cache.group == nil {
+			return
+		}
+
+		// log.WithFields(log.Fields{"name": name, "cache": cache, "group": cache.group}).Debug("ATMO:")
+		now := time.Now().Unix()
+		switch(cache.group.ProfileMode) {
+		case share.PolicyModeLearn:
+			mover = atmo.Discover2Monitor
+			if cache.atmo_d2m > 0 {
+				return
+			}
+			cache.atmo_d2m = now
+			cache.atmo_m2p = 0
+		case share.PolicyModeEvaluate:
+			mover = atmo.Monitor2Protect
+			if cache.atmo_m2p > 0 {
+				return
+			}
+			cache.atmo_m2p = now
+			cache.atmo_d2m = 0
+		default:
+			return
+		}
+		atmoHelper.AddGroup(mover, name)
+	} else {
+		cache.atmo_m2p = 0	// reset all
+		cache.atmo_d2m = 0
+	}
+}

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -1928,6 +1928,7 @@ func Init(ctx *Context, leader bool, leadAddr string) CacheInterface {
 	licenseInit()
 	ruleid.SetGetGroupWithoutLockFunc(getGroupWithoutLock)
 	clusHelper.SetCtrlState(share.CLUSCtrlNodeAdmissionKey)
+	automode_init(ctx)
 
 	go ProcReportBkgSvc()
 	go FileReportBkgSvc()

--- a/controller/cache/config.go
+++ b/controller/cache/config.go
@@ -212,6 +212,22 @@ func (m CacheMethod) GetUnusedGroupAging() uint8 {
 	return getUnusedGroupAging()
 }
 
+func getModeAutoD2M() (bool, int64) {
+	return systemConfigCache.ModeAutoD2M, systemConfigCache.ModeAutoD2MDuration
+}
+
+func (m CacheMethod) GetModeAutoD2M() (bool, int64) {
+	return getModeAutoD2M()
+}
+
+func getModeAutoM2P() (bool, int64) {
+	return systemConfigCache.ModeAutoM2P, systemConfigCache.ModeAutoM2PDuration
+}
+
+func (m CacheMethod) GetModeAutoM2P() (bool, int64) {
+	return getModeAutoM2P()
+}
+
 func (m CacheMethod) GetSystemConfig(acc *access.AccessControl) *api.RESTSystemConfig {
 	if !acc.Authorize(&systemConfigCache, nil) {
 		return nil
@@ -245,6 +261,10 @@ func (m CacheMethod) GetSystemConfig(acc *access.AccessControl) *api.RESTSystemC
 		XffEnabled:                systemConfigCache.XffEnabled,
 		NetServiceStatus:          systemConfigCache.NetServiceStatus,
 		NetServicePolicyMode:      systemConfigCache.NetServicePolicyMode,
+		ModeAutoD2M:               systemConfigCache.ModeAutoD2M,
+		ModeAutoD2MDuration:  	   systemConfigCache.ModeAutoD2MDuration,
+		ModeAutoM2P:               systemConfigCache.ModeAutoM2P,
+		ModeAutoM2PDuration:       systemConfigCache.ModeAutoM2PDuration,
 	}
 	if systemConfigCache.SyslogIP != nil {
 		rconf.SyslogServer = systemConfigCache.SyslogIP.String()
@@ -369,6 +389,7 @@ func systemConfigUpdate(nType cluster.ClusterNotifyType, key string, value []byt
 			cfg.NetServicePolicyMode != systemConfigCache.NetServicePolicyMode {
 				scheduleIPPolicyCalculation(true)
 		}
+		automodeConfigUpdate(cfg, systemConfigCache)
 	case cluster.ClusterNotifyDelete:
 		// Triggered at configuration import
 		cfg = common.DefaultSystemConfig

--- a/controller/cache/group.go
+++ b/controller/cache/group.go
@@ -37,6 +37,8 @@ type groupCache struct {
 	ingressDMZ          int
 	egressDMZ           int
 	timerTask           string
+	atmo_d2m            int64
+	atmo_m2p            int64
 }
 
 func isIPSvcGrpInternal(group *share.CLUSGroup) bool {

--- a/controller/cache/object.go
+++ b/controller/cache/object.go
@@ -1543,10 +1543,12 @@ func registerEventHandlers() {
 	})
 	evhdls.Register(EV_GROUP_ADD, []eventHandlerFunc{
 		connectGroupAdd,
+		automodeGroupAdd,
 	})
 	evhdls.Register(EV_GROUP_DELETE, []eventHandlerFunc{
 		connectGroupDelete,
 		customGroupDelete,
+		automodeGroupDelete,
 	})
 	evhdls.Register(EV_WORKLOAD_AGENT_CHANGE, []eventHandlerFunc{
 		scanWorkloadAgentChange,

--- a/controller/rest/configmap.go
+++ b/controller/rest/configmap.go
@@ -456,6 +456,16 @@ func handlesystemcfg(yaml_data []byte, load bool, skip *bool, context *configMap
 		}
 	}
 
+	if rc.ModeAutoD2M != nil && rc.ModeAutoD2MDuration != nil {
+		cconf.ModeAutoD2M = *rc.ModeAutoD2M
+		cconf.ModeAutoD2MDuration = *rc.ModeAutoD2MDuration
+	}
+
+	if rc.ModeAutoM2P != nil && rc.ModeAutoM2PDuration != nil {
+		cconf.ModeAutoM2P = *rc.ModeAutoM2P
+		cconf.ModeAutoM2PDuration = *rc.ModeAutoM2PDuration
+	}
+
 	// registry proxy
 	if rc.RegistryHttpProxy != nil {
 		if rc.RegistryHttpProxy.URL != "" {

--- a/controller/rest/system.go
+++ b/controller/rest/system.go
@@ -1146,6 +1146,16 @@ func handlerSystemConfig(w http.ResponseWriter, r *http.Request, ps httprouter.P
 				cconf.XffEnabled = *rc.XffEnabled
 			}
 
+			if rc.ModeAutoD2M != nil && rc.ModeAutoD2MDuration != nil {
+				cconf.ModeAutoD2M = *rc.ModeAutoD2M
+				cconf.ModeAutoD2MDuration = *rc.ModeAutoD2MDuration
+			}
+
+			if rc.ModeAutoM2P != nil && rc.ModeAutoM2PDuration != nil {
+				cconf.ModeAutoM2P = *rc.ModeAutoM2P
+				cconf.ModeAutoM2PDuration = *rc.ModeAutoM2PDuration
+			}
+
 			// registry proxy
 			if rc.RegistryHttpProxy != nil {
 				if rc.RegistryHttpProxy.URL != "" {

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -718,6 +718,10 @@ type CLUSSystemConfig struct {
 	CfgType              TCfgType             `json:"cfg_type"`
 	NetServiceStatus     bool                 `json:"net_service_status"`
 	NetServicePolicyMode string               `json:"net_service_policy_mode"`
+	ModeAutoD2M          bool                 `json:"mode_auto_d2m"`
+	ModeAutoD2MDuration  int64                `json:"mode_auto_d2m_duration"`
+	ModeAutoM2P          bool                 `json:"mode_auto_m2p"`
+	ModeAutoM2PDuration  int64                `json:"mode_auto_m2p_duration"`
 }
 
 type CLUSEULA struct {


### PR DESCRIPTION
Continuous protection upgrades (mode automation): 
Discover -> Monitor -> Protect
	
(1) Discover -> Monitor
    Live service [members > 0] for a program-able period (minimum 60 seconds). It works as accumulated counters,
	
(2) Monitor -> Protect
    No per-group process incidents  for a program-able period. (minimum 5 minutes)

* Not affecting the CRD groups and the global setting of the network mode.	
* Both default options are disabled, 
* Use timer wheel instead of loops through groups periodically.
