### PR TITLE
NV6264: unexpected Process.Profile.Violation incident on calico-node process if it triggered by readinessProbe

### DIFF
--- a/agent/policy/process.go
+++ b/agent/policy/process.go
@@ -159,6 +159,7 @@ func (e *Engine) ProcessPolicyLookup(name, id string, proc *share.CLUSProcessPro
 				matchedEntry = p
 				proc.Action = p.Action
 				proc.AllowFileUpdate = p.AllowFileUpdate
+				proc.ProbeCmd = p.ProbeCmd
 				break
 			}
 		}

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -2729,6 +2729,18 @@ func (p *Probe) IsAllowedShieldProcess(id, mode string, proc *procInternal, ppe 
 		}
 	}
 
+	if bFromPmon && global.RT.IsRuntimeProcess(proc.pname, nil) {
+		// k8s probe app command: treat it as an insider process
+		if ppe.Action == share.PolicyActionAllow && ppe.ProbeCmd != "" {
+			// meet the qualification
+			if ppe.Name == proc.name && ppe.ProbeCmd == strings.TrimSuffix(strings.Join(proc.cmds, ","), ",") {
+				c.outsider.Remove(proc.pid)
+				c.children.Add(proc.pid)
+				mLog.WithFields(log.Fields{"id": id, "pid": proc.pid}).Debug("SHD:")
+			}
+		}
+	}
+
 	// mLog.WithFields(log.Fields{"ppe": ppe, "pid": proc.pid, "id": id}).Debug("SHD:")
 	// ZeroDrift: allow a family member of the root process
 	if isFamilyProcess(c.children, proc) {

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -181,6 +181,14 @@ type Context struct {
 	StartStopFedPingPollFunc func(cmd, interval uint32, param1 interface{}) error
 }
 
+type k8sPodEvent struct {
+	pod      resource.Pod
+	group    string     // group name, index
+	groupAlt string     // likely group name
+	cmds     [][]string // k8s probe commands
+	cleanAt  int64      // terminated time
+}
+
 var cctx *Context
 var localDev *common.LocalDevice
 
@@ -196,6 +204,7 @@ type CacheMethod struct {
 	isScanner       bool
 	leaderElectedAt time.Time
 	disablePCAP     bool
+	k8sPodEvents    map[string]*k8sPodEvent
 }
 
 var cacher CacheMethod
@@ -1716,6 +1725,7 @@ func startWorkerThread() {
 					if ev.ResourceOld != nil {
 						o = ev.ResourceOld.(*resource.Pod)
 					}
+
 					// Assume IP doesn't change. Ignore host mode containers.
 					if (o == nil || o.IPNet.IP == nil) && (n != nil && !n.HostNet && n.IPNet.IP != nil) {
 						addrOrchWorkloadAdd(&n.IPNet, n.Node)
@@ -1731,6 +1741,13 @@ func startWorkerThread() {
 								resource.SetK8sVersion(k8sVer)
 								scanMapDelete(common.ScanPlatformID)
 								scanMapAdd(common.ScanPlatformID, "", nil, share.ScanObjectType_PLATFORM)
+							}
+						}
+						if o == nil { // create
+							if !isNeuvectorContainerName(n.Name) {
+								if len(n.LivenessCmds) > 0 || len(n.ReadinessCmds) > 0 {
+									addK8sPodEvent(*n)
+								}
 							}
 						}
 					}
@@ -1897,6 +1914,7 @@ func Init(ctx *Context, leader bool, leadAddr string) CacheInterface {
 	cctx.k8sVersion, cctx.ocVersion = global.ORCH.GetVersion(false, false)
 	cacher.isLeader = leader
 	cacher.leadAddr = leadAddr
+	cacher.k8sPodEvents = make(map[string]*k8sPodEvent)
 
 	clusHelper = kv.GetClusterHelper()
 	cfgHelper = kv.GetConfigHelper()

--- a/controller/cache/group.go
+++ b/controller/cache/group.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -1196,6 +1197,7 @@ func groupWorkloadJoin(id string, param interface{}) {
 
 	// warning: avoid cacheMutexLock() before calling below function
 	if bHasGroupProfile {
+		updateK8sPodEvent(wlc.learnedGroupName)
 		dispatchHelper.WorkloadJoin(wlc.workload.HostID, wlc.learnedGroupName, id, dptCustomGrpAdds, isLeader())
 	}
 }
@@ -1770,4 +1772,11 @@ func (m CacheMethod) GetService(name string, view string, withCap bool, acc *acc
 		return group2Service(cache, view, withCap), nil
 	}
 	return nil, common.ErrObjectNotFound
+}
+
+func isNeuvectorContainerName(name string) bool {
+	if matched, err := regexp.MatchString(`^neuvector-(controller|enforcer|manager|allinone|updater|scanner)-pod`, name); err == nil {
+		return matched
+	}
+	return false
 }

--- a/controller/common/common.go
+++ b/controller/common/common.go
@@ -552,6 +552,13 @@ func MergeProcess(list []*share.CLUSProcessProfileEntry, p *share.CLUSProcessPro
 			}
 		}
 
+		if p.ProbeCmd != "" {
+			if pp.ProbeCmd != p.ProbeCmd {
+				pp.ProbeCmd = p.ProbeCmd // updated with the latest fetching result
+				changed = true
+			}
+		}
+
 		//  New data, exclude from comparing different UID(s) to avoid duplicate entries
 		//	if p.Uid > 0 && p.Uid != pp.Uid {
 		//		pp.Uid = p.Uid

--- a/controller/resource/kubernetes_resource.go
+++ b/controller/resource/kubernetes_resource.go
@@ -670,6 +670,22 @@ func xlatePod(obj k8s.Resource) (string, interface{}) {
 		if o.Spec != nil {
 			r.Node = o.Spec.GetNodeName()
 			r.HostNet = o.Spec.GetHostNetwork()
+			for _, c := range o.Spec.GetContainers() {
+				liveness := c.GetLivenessProbe()
+				readiness := c.GetReadinessProbe()
+				if liveness != nil || readiness != nil {
+					if handler := liveness.GetHandler(); handler != nil {
+						if exec := handler.GetExec(); exec != nil {
+							r.LivenessCmds = exec.GetCommand()
+						}
+					}
+					if handler := readiness.GetHandler(); handler != nil {
+						if exec := handler.GetExec(); exec != nil {
+							r.ReadinessCmds = exec.GetCommand()
+						}
+					}
+				}
+			}
 		}
 		if o.Status != nil {
 			if ip := net.ParseIP(o.Status.GetPodIP()); ip != nil {

--- a/controller/resource/types.go
+++ b/controller/resource/types.go
@@ -109,6 +109,8 @@ type Pod struct {
 	OwnerUID  string
 	OwnerName string
 	OwnerType string
+	LivenessCmds  []string
+	ReadinessCmds []string
 }
 
 type ImageTag struct {

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -1491,6 +1491,7 @@ type CLUSProcessProfileEntry struct {
 	Uuid            string    `json:"uuid"`
 	DerivedGroup    string    `json:"dgroup"`
 	AllowFileUpdate bool      `json:"allow_update"`
+	ProbeCmd        string	  `json:"probe_cmd"`
 }
 
 type CLUSProcessProfile struct {

--- a/share/container/containerd.go
+++ b/share/container/containerd.go
@@ -88,7 +88,7 @@ func containerdConnect(endpoint string, sys *system.SystemTools) (Runtime, error
 		sysInfo: sys.GetSystemInfo(), nodeHostname: sys.GetHostname(1), snapshotter: snapshotter,
 	}
 
-	driver.rtProcMap = utils.NewSet("runc", "containerd", "containerd-shim")
+	driver.rtProcMap = utils.NewSet("runc", "containerd", "containerd-shim", "containerd-shim-runc-v1", "containerd-shim-runc-v2")
 	return &driver, nil
 }
 


### PR DESCRIPTION
Patch for the Zero-drift baseline process profile

(1) The k8s probe process commands (like Liveness, Readiness, and Startup Probes) are added as allowing process rules by default.

(2) The Probe's children processes are allowed if their executables are not modified.