### PR TITLE
6124,5833: Add Microsoft Teams support for WebHook notification

### DIFF
--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -1494,6 +1494,7 @@ const (
 	WebhookDefaultName = "default"
 	WebhookTypeSlack   = "Slack"
 	WebhookTypeJSON    = "JSON"
+	WebhookTypeTeams   = "Teams"
 )
 
 type RESTWebhook struct {

--- a/controller/common/output.go
+++ b/controller/common/output.go
@@ -238,6 +238,12 @@ func (w *Webhook) Notify(elog interface{}, target, level, category, cluster, tit
 			fields["text"] = logText
 			fields["username"] = fmt.Sprintf("NeuVector - %s", cluster)
 			data, _ = json.Marshal(fields)
+		} else if target == api.WebhookTypeTeams {
+			fields := make(map[string]string)
+			fields["title"] = fmt.Sprintf("%s: %s level", strings.Title(category), strings.ToUpper(LevelToString(level)))
+			logText = fmt.Sprintf("%s=%s,%s", notificationHeader, category, logText)
+			fields["text"] = fmt.Sprintf("%s\n> %s", title, logText)
+			data, _ = json.Marshal(fields)
 		} else if target == api.WebhookTypeJSON {
 			extra := fmt.Sprintf("{\"level\":\"%s\",\"cluster\":\"%s\",", strings.ToUpper(LevelToString(level)), cluster)
 			data, _ = json.Marshal(elog)


### PR DESCRIPTION
This is to support Microsoft Teams support for WebHook notification, it has similar approach with Slack but with different JSON key. We still needs to add an option on the Web console for user to choose Teams. 