### PR TITLE
NV6274: k8s probe commands: process violation reported for calico controller pod

### DIFF
--- a/controller/resource/kubernetes_resource.go
+++ b/controller/resource/kubernetes_resource.go
@@ -664,6 +664,7 @@ func xlatePod(obj k8s.Resource) (string, interface{}) {
 			UID:    meta.GetUid(),
 			Name:   meta.GetName(),
 			Domain: meta.GetNamespace(),
+			Labels: meta.GetLabels(),
 		}
 		if len(meta.OwnerReferences) >= 1 {
 			if owner := meta.OwnerReferences[0]; owner != nil {

--- a/controller/resource/types.go
+++ b/controller/resource/types.go
@@ -113,6 +113,7 @@ type Pod struct {
 	ReadinessCmds []string
 	SA            string // service account of this pod
 	ContainerID   string // workload id
+	Labels        map[string]string
 }
 
 type ImageTag struct {

--- a/share/orchestration/docker.go
+++ b/share/orchestration/docker.go
@@ -70,6 +70,10 @@ type base struct {
 	noop
 }
 
+func (d *base) GetServiceFromPodLabels(namespace, pod string, labels map[string]string) *Service {
+	return nil
+}
+
 func (d *base) GetService(meta *container.ContainerMeta) *Service {
 	project, _ := meta.Labels[container.DockerComposeProjectKey]
 	service, _ := meta.Labels[container.DockerComposeServiceKey]

--- a/share/orchestration/ecs.go
+++ b/share/orchestration/ecs.go
@@ -22,6 +22,10 @@ func (d *ecs) isDeployedBy(meta *container.ContainerMeta) bool {
 	return false
 }
 
+func (d *ecs) GetServiceFromPodLabels(namespace, pod string, labels map[string]string) *Service {
+	return nil
+}
+
 func (d *ecs) GetService(meta *container.ContainerMeta) *Service {
 	cluster, _ := meta.Labels[container.ECSCluster]
 	task, _ := meta.Labels[container.ECSTaskDefinition]

--- a/share/orchestration/noop.go
+++ b/share/orchestration/noop.go
@@ -37,6 +37,10 @@ func (d *noop) GetServiceSubnet(envs []string) *net.IPNet {
 	return nil
 }
 
+func (d *noop) GetServiceFromPodLabels(namespace, pod string, labels map[string]string) *Service {
+	return nil
+}
+
 func (d *noop) GetService(meta *container.ContainerMeta) *Service {
 	return nil
 }

--- a/share/orchestration/rancher.go
+++ b/share/orchestration/rancher.go
@@ -41,6 +41,10 @@ func (d *rancher) isDeployedBy(meta *container.ContainerMeta) bool {
 	return false
 }
 
+func (d *rancher) GetServiceFromPodLabels(namespace, pod string, labels map[string]string) *Service {
+	return nil
+}
+
 func (d *rancher) GetService(meta *container.ContainerMeta) *Service {
 	if service, _ := meta.Labels[container.RancherKeyStackServiceName]; service != "" {
 		return &Service{Name: service}

--- a/share/orchestration/types.go
+++ b/share/orchestration/types.go
@@ -24,6 +24,7 @@ type Service struct {
 type Driver interface {
 	GetVersion(reGetK8sVersion, reGetOcVersion bool) (string, string)
 	SetIPAddrScope(ports map[string][]share.CLUSIPAddr, meta *container.ContainerMeta, nets map[string]*container.Network)
+	GetServiceFromPodLabels(namespace, pod string, labels map[string]string) *Service
 	GetService(meta *container.ContainerMeta) *Service
 	GetPlatformRole(meta *container.ContainerMeta) (string, bool) // return platform type and if container should be secured
 	GetDomain(labels map[string]string) string

--- a/share/orchestration/unknown.go
+++ b/share/orchestration/unknown.go
@@ -12,6 +12,10 @@ type unknown struct {
 	envParser *utils.EnvironParser
 }
 
+func (d *unknown) GetServiceFromPodLabels(namespace, pod string, labels map[string]string) *Service {
+	return nil
+}
+
 func (d *unknown) GetService(meta *container.ContainerMeta) *Service {
 	return baseDriver.GetService(meta)
 }


### PR DESCRIPTION
It is not sufficient to capture a service group name from the pod information.  Add labels information from pods to clarify the relationship between pod names and service group names.