### PR TITLE
NV6308, NV6305, NV6313: k8s probe commands improvement.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -531,6 +531,7 @@ func main() {
 		NotifyFsTaskChan:     fsmonTaskChan,
 		PolicyLookupFunc:     hostPolicyLookup,
 		ProcPolicyLookupFunc: processPolicyLookup,
+		IsK8sGroupWithProbe:  pe.IsK8sGroupWithProbe,
 		ReportLearnProc:      addLearnedProcess,
 		ContainerInContainer: agentEnv.containerInContainer,
 		GetContainerPid:      cbGetContainerPid,

--- a/agent/probe/types.go
+++ b/agent/probe/types.go
@@ -18,6 +18,7 @@ type ProbeConfig struct {
 	NotifyFsTaskChan     chan *fsmon.MonitorMessage
 	PolicyLookupFunc     func(conn *dp.Connection) (uint32, uint8, bool)
 	ProcPolicyLookupFunc func(id, riskType, pname, ppath string, pid, pgid, shellCmd int, proc *share.CLUSProcessProfileEntry) (string, string, string, string, bool, error)
+	IsK8sGroupWithProbe  func(svcGroup string) bool
 	ReportLearnProc      func(svcGroup string, proc *share.CLUSProcessProfileEntry)
 	ContainerInContainer bool
 	GetContainerPid      func(id string) int

--- a/controller/cache/object.go
+++ b/controller/cache/object.go
@@ -1153,7 +1153,7 @@ func setServiceAccount(node, wlID, wlName string, wlCache *workloadCache) {
 	}
 }
 
-func appendProbeCmds(cmds []string) *k8sProbeCmd {
+func appendProbeCmds(cmds []string) (bool, string, string, string) {
 	if len(cmds) > 0 {
 		exe := filepath.Base(cmds[0])
 		path := filepath.Clean(cmds[0])
@@ -1162,13 +1162,13 @@ func appendProbeCmds(cmds []string) *k8sProbeCmd {
 			path = "*"
 		}
 		cmd := strings.TrimSuffix(strings.Join(cmds, ","), ",")
-		return &k8sProbeCmd{app: exe, path: path, cmds: []string{cmd}}
+		return true, exe, path, cmd
 	}
-	return nil
+	return false, "", "", ""
 }
 
-func appendProbeSubCmds(cmds []string) []k8sProbeCmd {
-	var subcmds []k8sProbeCmd
+func appendProbeSubCmds(cmds []string) []*k8sProbeCmd {
+	var subcmds []*k8sProbeCmd
 	if len(cmds) > 0 {
 		line := strings.Join(cmds, " ")
 		items := strings.Split(line, " exec ")
@@ -1177,8 +1177,9 @@ func appendProbeSubCmds(cmds []string) []k8sProbeCmd {
 				continue
 			}
 			if index := strings.Index(item, ";"); index > 0 {
-				if pcmd := appendProbeCmds(strings.Split(item[0:index], " ")); pcmd != nil {
-					subcmds = append(subcmds, *pcmd)
+				if ok, app, path, cmdline := appendProbeCmds(strings.Split(item[0:index], " ")); ok {
+					p := &k8sProbeCmd{app: app, path: path, cmds: []string{cmdline,}}
+					subcmds = append(subcmds, p)
 				}
 			}
 		}
@@ -1186,40 +1187,47 @@ func appendProbeSubCmds(cmds []string) []k8sProbeCmd {
 	return subcmds
 }
 
-func addK8sPodEvent(pod resource.Pod) {
+func mergeProbeCommands(cmds [][]string) []k8sProbeCmd {
+	pp := make(map[string]*k8sProbeCmd)
+	for _, cmd := range cmds {
+		if ok, app, path, cmdline  := appendProbeCmds(cmd); ok {
+			if p, ok := pp[app]; ok {
+				p.path = "*"
+				p.cmds = append(p.cmds, cmdline)
+			} else {
+				pp[app] = &k8sProbeCmd{app: app, path: path, cmds: []string{cmdline,}}
+			}
+
+			if app == "sh" || app == "bash" || app == "ash" {
+				if pcmds := appendProbeSubCmds(cmd); pcmds != nil {
+					for _, pcmd := range pcmds {
+						if p, ok := pp[pcmd.app]; ok {
+							p.path = "*"
+							p.cmds = append(p.cmds, pcmd.cmds...)
+						} else {
+							pp[pcmd.app] = pcmd
+						}
+					}
+				}
+			}
+		}
+	}
+
 	var probes []k8sProbeCmd
-	if pcmd := appendProbeCmds(pod.LivenessCmds); pcmd != nil {
-		probes = append(probes, *pcmd)
-		if pcmd.app == "sh" || pcmd.app == "bash" || pcmd.app == "ash" {
-			if pcmds := appendProbeSubCmds(pod.LivenessCmds); pcmds != nil {
-				probes = append(probes, pcmds...)
-			}
-		}
+	for _, p := range pp {
+		probes = append(probes, *p)
 	}
+	return probes
+}
 
-	if pcmd := appendProbeCmds(pod.ReadinessCmds); pcmd != nil {
-		if len(probes) > 0 && probes[0].app == pcmd.app { // liveness exists
-			if probes[0].path != pcmd.path {
-				probes[0].path = "*" // mixed together
-			}
-			probes[0].cmds = append(probes[0].cmds, pcmd.cmds[0])
-		} else {
-			probes = append(probes, *pcmd)
-		}
-
-		if pcmd.app == "sh" || pcmd.app == "bash" || pcmd.app == "ash" {
-			if pcmds := appendProbeSubCmds(pod.ReadinessCmds); pcmds != nil {
-				probes = append(probes, pcmds...)
-			}
-		}
-	}
-
+func addK8sPodEvent(pod resource.Pod) {
+	probes := mergeProbeCommands(append(pod.LivenessCmds, pod.ReadinessCmds...))
 	groupName := fmt.Sprintf("nv.%s.%s", pod.Name, pod.Domain)
 	if svc := global.ORCH.GetServiceFromPodLabels(pod.Domain, pod.Name, pod.Labels); svc != nil {
 		groupName = api.LearnedGroupPrefix + utils.NormalizeForURL(utils.MakeServiceName(svc.Domain, svc.Name))
 	}
-	log.WithFields(log.Fields{"Name": pod.Name, "groupName": groupName, "probes": probes}).Debug()
 
+	//log.WithFields(log.Fields{"Name": pod.Name, "groupName": groupName, "probes": probes}).Debug()
 	var name_alt string
 	if pos := strings.LastIndex(pod.Name, "-"); pos != -1 {
 		name_alt = fmt.Sprintf("nv.%s.%s", pod.Name[:pos], pod.Domain)
@@ -1241,7 +1249,7 @@ func addK8sPodEvent(pod resource.Pod) {
 			log.WithFields(log.Fields{"group": group}).Debug()
 			bFound = true
 			addK8sProbeApps(group, p.probes)
-			delete(cacher.k8sPodEvents, p.group)
+			// delete(cacher.k8sPodEvents, p.group)
 			break
 		}
 	}
@@ -1251,19 +1259,36 @@ func addK8sPodEvent(pod resource.Pod) {
 	}
 }
 
-func updateK8sPodEvent(group string) {
+// The cacheMutex is locked by callers
+func updateK8sPodEvent(group, podname, domain string) {
+	var bFound bool
 	now := time.Now().Unix()
-	cacheMutexLock()
-	defer cacheMutexUnlock()
 	for name, p := range cacher.k8sPodEvents {
 		if group == p.group || group == p.groupAlt {
 			addK8sProbeApps(group, p.probes)
+			// delete(cacher.k8sPodEvents, name)
+			bFound = true
+			break
+		}
+		if now > p.cleanAt {
+			log.WithFields(log.Fields{"name": name}).Debug("Clean-up")
 			delete(cacher.k8sPodEvents, name)
+		}
+	}
+
+	if !bFound {
+		if obj, err := global.ORCH.GetResource(resource.RscTypePod, domain, podname); err != nil {
+			log.WithFields(log.Fields{"error": err, "group": group, "pod": podname, "domain": domain}).Error("get ressource")
+			return
 		} else {
-			if now > p.cleanAt {
-				log.WithFields(log.Fields{"name": name}).Debug("Clean")
-				delete(cacher.k8sPodEvents, name)
+			pod := obj.(*resource.Pod)
+			probes := mergeProbeCommands(append(pod.LivenessCmds, pod.ReadinessCmds...))
+			if len(probes) == 0 {
+				return
 			}
+
+			// log.WithFields(log.Fields{"probes": probes, "group": group, "pod": podname, "domain": domain}).Debug()
+			addK8sProbeApps(group, probes)
 		}
 	}
 }

--- a/controller/cache/profile.go
+++ b/controller/cache/profile.go
@@ -422,6 +422,10 @@ func addK8sProbeApps(group string, probeCmds []k8sProbeCmd) {
 
 	if len(procs) > 0 {
 		gproc[group] = procs
-		AddProcessReport(gproc)
+		if isLeader() {
+			handleProfileReport(gproc)
+		} else {
+			AddProcessReport(gproc)	// put into a queue
+		}
 	}
 }

--- a/controller/resource/kubernetes_resource.go
+++ b/controller/resource/kubernetes_resource.go
@@ -683,12 +683,12 @@ func xlatePod(obj k8s.Resource) (string, interface{}) {
 				if liveness != nil || readiness != nil {
 					if handler := liveness.GetHandler(); handler != nil {
 						if exec := handler.GetExec(); exec != nil {
-							r.LivenessCmds = exec.GetCommand()
+							r.LivenessCmds = append(r.LivenessCmds, exec.GetCommand())
 						}
 					}
 					if handler := readiness.GetHandler(); handler != nil {
 						if exec := handler.GetExec(); exec != nil {
-							r.ReadinessCmds = exec.GetCommand()
+							r.ReadinessCmds = append(r.ReadinessCmds, exec.GetCommand())
 						}
 					}
 				}
@@ -1332,6 +1332,15 @@ func (d *kubernetes) GetResource(rt, namespace, name string) (interface{}, error
 		RscTypeCrd, RscTypeConfigMap, RscTypeCrdSecurityRule, RscTypeCrdClusterSecurityRule, RscTypeCrdAdmCtrlSecurityRule, RscTypeCrdDlpSecurityRule, RscTypeCrdWafSecurityRule,
 		RscTypeNode:
 		return d.getResource(rt, namespace, name)
+	case RscTypePod:
+		if r, err:= d.getResource(rt, namespace, name); err == nil {
+			if _, p := xlatePod(r.(k8s.Resource)); p != nil {
+				return p, nil
+			}
+			return nil, common.ErrObjectNotFound
+		} else {
+			return nil, err
+		}
 	}
 	return nil, ErrResourceNotSupported
 }

--- a/controller/resource/types.go
+++ b/controller/resource/types.go
@@ -109,8 +109,8 @@ type Pod struct {
 	OwnerUID      string
 	OwnerName     string
 	OwnerType     string
-	LivenessCmds  []string
-	ReadinessCmds []string
+	LivenessCmds  [][]string
+	ReadinessCmds [][]string
 	SA            string // service account of this pod
 	ContainerID   string // workload id
 	Labels        map[string]string


### PR DESCRIPTION
(1) Add Get k8s pod resource API calls.

(2) Special cases for the zero-drift baseline process profile: if the pod has k8s probe command configuration, we allow "kubectl exec" executions but will not learn their external processes. We still treat modified/added binaries as suspicious processes if the binaries have been added or modified.