### PR TITLE
NV6348, NV6347: Improvement at the service group mode automation

### DIFF
--- a/controller/api/log_apis.go
+++ b/controller/api/log_apis.go
@@ -151,6 +151,7 @@ const (
 	EventNameMemoryPressureAgent         = "Agent.Memory.Pressure"
 	EventNameMemoryPressureController    = "Controller.Memory.Pressure"
 	EventNameK8sNvRBAC                   = "Kubenetes.NeuVector.RBAC"
+	EventNameGroupAutoPromote            = "Group.Auto.Promote"
 )
 
 // TODO: these are not events but incidents

--- a/controller/common/common.go
+++ b/controller/common/common.go
@@ -287,6 +287,7 @@ var LogEventMap = map[share.TLogEvent]LogEventInfo{
 	share.CLUSEvMemoryPressureAgent:         {api.EventNameMemoryPressureAgent, api.EventCatAgent, api.LogLevelWARNING},
 	share.CLUSEvMemoryPressureController:    {api.EventNameMemoryPressureController, api.EventCatController, api.LogLevelWARNING},
 	share.CLUSEvK8sNvRBAC:                   {api.EventNameK8sNvRBAC, api.EventCatConfig, api.LogLevelWARNING},
+	share.CLUSEvGroupAutoPromote:            {api.EventNameGroupAutoPromote, api.EventCatGroup, api.LogLevelINFO},
 }
 
 type LogIncidentInfo struct {

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -1206,6 +1206,7 @@ const (
 	CLUSEvMemoryPressureAgent
 	CLUSEvMemoryPressureController
 	CLUSEvK8sNvRBAC
+	CLUSEvGroupAutoPromote
 )
 
 const (


### PR DESCRIPTION
(1) m2p: add threats and violations as checking items.

(2) put log events for promoting policy mode.

(3) remove `^M` from  "controller/cache/automode.go"