### PR TITLE
NV6362, NV6363, NV6365: Unexpected Process.Profile.Violation events

### DIFF
--- a/agent/policy/process.go
+++ b/agent/policy/process.go
@@ -413,6 +413,7 @@ func buildManagerProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		{"nc", "/bin/busybox"},
 		{"tee", "/usr/bin/tee"},
 		{"stat", "/usr/bin/stat"}, // bench scripts
+		{"stty", "/bin/busybox"},  // python3.9
 
 		// k8s or openshift environment
 		{"pause", "/pause"},     // k8s, pause
@@ -653,6 +654,7 @@ func buildAllinOneProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		{"cat", "*"},                     // k8s readiness and openshift operations
 		{"configure.sh", "/bin/busybox"}, // monitor tool
 		{"teardown.sh", "/bin/busybox"},  // monitor tool
+		{"stty", "/bin/busybox"},         // python3.9
 
 		// below entries for debug purpose : docker exec -ti allinone sh
 		{"sh", "/bin/dash"},

--- a/agent/probe/fsn.go
+++ b/agent/probe/fsn.go
@@ -561,7 +561,7 @@ func (fsn *FileNotificationCtr) IsNotExistingImageFile(id, file string) (*fileIn
 			// Stat: returns a FileInfo describing the named "target" file.
 			// Lstat: If the file is a symbolic link, the returned FileInfodescribes the symbolic link. Lstat makes no attempt to follow the link
 			if _, err := os.Stat(filepath.Join(procPath, file)); os.IsNotExist(err) {
-				mLog.WithFields(log.Fields{"id": id, "file": file}).Debug("FSN: not the in image")
+				// mLog.WithFields(log.Fields{"id": id, "file": file}).Debug("FSN: not the in image")
 				finfo.fileType = file_not_exist
 				finfo.bExec = true
 				return finfo, true // not existed in image layers

--- a/share/osutil/process_linux.go
+++ b/share/osutil/process_linux.go
@@ -419,6 +419,8 @@ func GetProcessUIDs(pid int) (name string, ppid, ruid, euid int) {
 					}
 				}
 			}
+
+			name = filepath.Base(name)
 			if i := strings.IndexAny(name, "/: ;,"); i > 0 {
 				name = name[:i]
 			}


### PR DESCRIPTION
(1) NvPRotect: add allowed process rules for python3.9

(2) ZeroDrift: always allow rootPid.

(3) Update process name by removing its unnecessary prefix, "/" ,