### PR TITLE
Automode: reset m2p counter when any security event occurs.

### DIFF
--- a/controller/atmo/atmo_tasks.go
+++ b/controller/atmo/atmo_tasks.go
@@ -50,7 +50,10 @@ func (t *task) Expire() {
 		t.runs++
 		// log.WithFields(log.Fields{"group": t.id, "runs": t.runs}).Debug("ATMO:")
 	} else {
-		//log.WithFields(log.Fields{"group": t.id}).Debug("ATMO: invalid")
+		//log.WithFields(log.Fields{"group": t.id}).Debug("ATMO:")
+		if t.mover == Monitor2Protect {
+			t.runs = 0		// reset counters
+		}
 	}
 
 	if t.runs >= t.lifeFunc(t.mover) {


### PR DESCRIPTION
For the mode promotion from monitor to protect, it is the "quiet" time period AFTER no security event associated with this service group.