### PR TITLE
NV6304, NV6380, NV6378: missing and false-positive processes

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1521,7 +1521,7 @@ func taskInterceptContainer(id string, info *container.ContainerMetaExtra) {
 
 	// entry to apply group policies
 	workloadJoinGroup(c)
-	prober.BuildProcessFamilyGroups(c.id, c.pid, parent == nil, hostMode && info.Privileged)
+	prober.BuildProcessFamilyGroups(c.id, c.pid, parent == nil, info.Privileged)
 	prober.HandleAnchorModeChange(true, c.id, c.upperDir, c.pid)
 
 	if parent == nil {

--- a/agent/group_profile.go
+++ b/agent/group_profile.go
@@ -1074,15 +1074,15 @@ func updateContainerFamilyTrees(name string) {
 	grpCacheLock.Unlock()
 
 	for _, cid := range cids {
-		bPrivHostmode := false
+		bPrivileged := false
 		gInfoRLock()
 		c, ok := gInfo.activeContainers[cid]
 		if ok && c.info != nil {
-			bPrivHostmode = c.hostMode && c.info.Privileged
+			bPrivileged = c.info.Privileged
 		}
 		gInfoRUnlock()
 		if ok {
-			prober.BuildProcessFamilyGroups(c.id, c.pid, false, bPrivHostmode)
+			prober.BuildProcessFamilyGroups(c.id, c.pid, false, bPrivileged)
 		}
 	}
 }

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -54,7 +54,7 @@ type procContainer struct {
 	portsMap         map[osutil.SocketInfo]*procApp
 	checkRemovedPort uint
 	fInfo            map[string]*fileInfo
-	bPrivHostmode 	 bool
+	bPrivileged 	 bool
 }
 
 type procInternal struct {
@@ -2294,9 +2294,9 @@ func (p *Probe) sendProcessIncident(bDenied bool, id, uuid, group, derivedGroup 
 
 	switch uuid {
 	case share.CLUSReservedUuidAnchorMode:	// zero-drift incident
-		s = p.makeProcessReport(id, proc, "Process profile violation, this file has been modified", nil, false, group, uuid)
+		s = p.makeProcessReport(id, proc, "Process profile violation, not from an image file", nil, false, group, uuid)
 	case share.CLUSReservedUuidShieldMode:	// zero-drift incident
-		s = p.makeProcessReport(id, proc, "Process profile violation, not from root process", nil, false, group, uuid)
+		s = p.makeProcessReport(id, proc, "Process profile violation, not from its root process", nil, false, group, uuid)
 	default: // rules-based incident
 		s = p.makeProcessReport(id, proc, "Process profile violation", nil, false, derivedGroup, uuid)
 	}
@@ -2409,24 +2409,24 @@ func (p *Probe) PutBeginningProcEventsBackToWork(id string) int {
 		elements := histProc.DumpExt()
 		for i := 0; i < len(elements); i++ {
 			proc := elements[i].(*procInternal)
+
 			// filter the docker run events since the path is not in the containers
-			if p.isDockerDaemonProcess(proc, id) {
-				// filter it out
-			} else {
-				// log.WithFields(log.Fields{"proc": proc, "id": id}).Debug("PROC:")
-				//  Skip the inherted actions from parents.
-				//  These processes has not been justified by policy, all the actions and riskinfo are default values
-				//  assume no ousiders during the initial stage, only justify insider processes
-				if p.isInsiderProcess(id, proc.pid) {
-					p.evaluateApplication(proc, id, true)
-					// update its results
-					if p, ok := p.pidProcMap[proc.pid]; ok {
-						p.reported = proc.reported
-						p.action = proc.action
-					}
-					cnt++
-				}
+			if global.RT.IsRuntimeProcess(proc.name, nil) {
+				// skip: runtime processes,  filter it out
+				continue
 			}
+
+			// log.WithFields(log.Fields{"proc": proc, "id": id}).Debug("PROC:")
+			//  Skip the inherted actions from parents.
+			//  These processes has not been justified by policy, all the actions and riskinfo are default values
+			//  assume no ousiders during the initial stage, only justify insider processes
+			p.evaluateApplication(proc, id, true)
+			// update its results
+			if p, ok := p.pidProcMap[proc.pid]; ok {
+				p.reported = proc.reported
+				p.action = proc.action
+			}
+			cnt++
 		}
 	}
 
@@ -2729,12 +2729,14 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 	bNotImageButNewlyAdded := false
 	bImageFile = true
 	if global.SYS.IsNotContainerFile(c.rootPid, ppe.Path) {
-		log.WithFields(log.Fields{"c.bPrivHostmode": c.bPrivHostmode}).Debug("SHD:")
-		if c.bPrivHostmode {
+		// We will not monitor files under the mounted folder
+		// The mounted condition: utils.IsContainerMountFile(c.rootPid, ppe.Path)
+		if c.bPrivileged {
 			log.WithFields(log.Fields{"file": ppe.Path, "id": id}).Debug("SHD: priviiged system pod")
 		} else {
 			// this file is not existed
 			bImageFile = false
+			log.WithFields(log.Fields{"file": ppe.Path, "pid": c.rootPid}).Debug("SHD: not in image")
 		}
 	} else {
 		if finfo, ok := p.fsnCtr.GetUpperFileInfo(id, ppe.Path); ok && finfo.bExec && finfo.length > 0 {
@@ -2766,6 +2768,10 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 					if i== 0 && err != nil {	// process left, pstree failed, trace back 8 entries, could be more restrictive
 						for j := 1; j <= 8; j++ {
 							ppid = proc.ppid - j
+							if ppid == c.rootPid {
+								mLog.WithFields(log.Fields{"pid": ppid}).Debug("SHD: rootPid")
+								break
+							}
 							if pp, ok := p.pidProcMap[ppid]; ok && len(pp.name) > 1 {	// "" or "."
 								if c, ok := p.pidContainerMap[ppid]; ok && c.id == "" { // only node process
 									bRuncChild = global.RT.IsRuntimeProcess(pp.name, nil)
@@ -2780,6 +2786,11 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 					break
 				} else {
 					var name string
+					if ppid == c.rootPid {
+						mLog.WithFields(log.Fields{"ppid": ppid}).Debug("SHD: rootPid")
+						break
+					}
+
 					if p, ok := p.pidProcMap[ppid]; ok && len(p.name) > 1 {	// "" or "."
 						name = p.name
 					} else if path, err := global.SYS.GetFilePath(ppid); err == nil { // exe path
@@ -2883,7 +2894,7 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 	return bPass
 }
 
-func (p *Probe) BuildProcessFamilyGroups(id string, rootPid int, bSandboxPod, bPrivilegedHostmode bool) {
+func (p *Probe) BuildProcessFamilyGroups(id string, rootPid int, bSandboxPod, bPrivileged bool) {
 	//log.WithFields(log.Fields{"id": id, "pid": rootPid}).Debug("SHD:")
 
 	p.lockProcMux()
@@ -2911,7 +2922,7 @@ func (p *Probe) BuildProcessFamilyGroups(id string, rootPid int, bSandboxPod, bP
 	}
 
 	c.rootPid = rootPid
-	c.bPrivHostmode = bPrivilegedHostmode
+	c.bPrivileged = bPrivileged
 	allPids := c.outsider.Union(c.children)
 	allPids.Add(rootPid) // all collections: add rootPid as a pivot point
 	c.outsider.Clear()   // reset
@@ -2977,18 +2988,6 @@ func (p *Probe) HandleAnchorModeChange(bAdd bool, id, cPath string, rootPid int)
 		}
 		p.unlockProcMux()
 	}
-}
-
-// already locked
-func (p *Probe) isInsiderProcess(id string, pid int) bool {
-	if id == "" {
-		return true // always
-	}
-
-	if c, ok := p.containerMap[id]; ok {
-		return c.children.Contains(pid)
-	}
-	return false
 }
 
 func (p *Probe) UpdateFromAllowRule(id, path string) {

--- a/share/utils/utils.go
+++ b/share/utils/utils.go
@@ -969,6 +969,20 @@ func IsMountPoint(path string) bool {
 	return stat.Sys().(*syscall.Stat_t).Dev != rootStat.Sys().(*syscall.Stat_t).Dev
 }
 
+func IsContainerMountFile(pid int, path string) bool {
+	rootPath := fmt.Sprintf("/proc/%d/root/.", pid)
+	stat, err := os.Stat(filepath.Join(rootPath, path))
+	if err != nil {
+		return false
+	}
+	rootStat, err := os.Lstat(rootPath)
+	if err != nil {
+		return false
+	}
+	// If the directory has the same device as parent, then it's not a mountpoint.
+	return stat.Sys().(*syscall.Stat_t).Dev != rootStat.Sys().(*syscall.Stat_t).Dev
+}
+
 // IsExecutableLinkableFile: explore ELF header
 func IsExecutableLinkableFile(path string) bool {
 	// checking ELF header


### PR DESCRIPTION
(1) The feeback path from process history storage is not correct. Thus, we might miss the learned processes at the beginning of the container additions.

(2) Change violation messages.

(3) The traceback processes should stop at root processes and put them as children processes.

(4) We will not monitor files under the mounted folders. Thus, we will not check them in zero-drift baseline profile.