### PR TITLE
Zerodrift: allow learning processes for pods which have k8s probe setting

### DIFF
--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -2808,7 +2808,7 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 		}
 
 		if bRuncChild {
-			bCanBeLearned = false
+		//	bCanBeLearned = false
 			c.outsider.Remove(proc.pid)
 			c.children.Add(proc.pid)
 		}


### PR DESCRIPTION
Zerodrift: allow learning processes from "kubectl exec" commands for pods which have k8s probe seting.