### PR TITLE
NV6398: process profile rule is unable to learn a complete rule set if they are inside a k8s probe commands.

### DIFF
--- a/agent/policy/process.go
+++ b/agent/policy/process.go
@@ -172,12 +172,14 @@ func (e *Engine) ProcessPolicyLookup(name, id string, proc *share.CLUSProcessPro
 	if ok {
 		var matchedEntry *share.CLUSProcessProfileEntry
 		for _, p := range profile.Process {
-			if len(p.ProbeCmds) > 0 && p.Name == "sh" && p.Path == "*" {
-				// replace
-				if ok, app, _ := global.SYS.DefaultShellCmd(pid, "sh"); ok {
-					p.Name = "*"
-					p.Path = app
-				}
+			if len(p.ProbeCmds) > 0 {
+			//	if p.Name == "sh" && p.Path == "*" {		// replace
+			//		if ok, app, _ := global.SYS.DefaultShellCmd(pid, "sh"); ok {
+			//			p.Name = "*"
+			//			p.Path = app
+			//		}
+			//	}
+				continue  // trigger a learning event
 			}
 
 			if MatchProfileProcess(p, proc) {


### PR DESCRIPTION
(1) The process rules can not be learned because the controller has inserted some probe command rules. 

(2) Double-checking the relationship between process name and path.