### PR TITLE
ENABLE Setting DP Debug level at startup

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -264,6 +264,7 @@ func main() {
 
 	withCtlr := flag.Bool("c", false, "Coexist controller and ranger")
 	debug := flag.Bool("d", false, "Enable control path debug")
+	debug_level := flag.String("v", "", "debug level")
 	join := flag.String("j", "", "Cluster join address")
 	adv := flag.String("a", "", "Cluster advertise address")
 	bind := flag.String("b", "", "Cluster bind address")
@@ -281,6 +282,14 @@ func main() {
 	if *debug {
 		log.SetLevel(log.DebugLevel)
 		gInfo.agentConfig.Debug = []string{"ctrl"}
+	}
+
+	if *debug_level != "" {
+		levels := utils.NewSetFromSliceKind(append(gInfo.agentConfig.Debug, strings.Split(*debug_level, " ")...))
+		if !*debug && levels.Contains("ctrl") {
+			levels.Remove("ctrl")
+		}
+		gInfo.agentConfig.Debug = levels.ToStringSlice()
 	}
 
 	agentEnv.kvCongestCtrl = true

--- a/monitor/monitor.c
+++ b/monitor/monitor.c
@@ -30,6 +30,7 @@
 #define ENV_CTRL_SERVER_PORT   "CTRL_SERVER_PORT"
 #define ENV_FED_SERVER_PORT    "FED_SERVER_PORT"
 #define ENV_CTRL_PATH_DEBUG    "CTRL_PATH_DEBUG"
+#define ENV_DEBUG_LEVEL        "DEBUG_LEVEL"
 #define ENV_TAP_INTERFACE      "TAP_INTERFACE"
 #define ENV_TAP_ALL_CONTAINERS "TAP_ALL_CONTAINERS"
 #define ENV_DOCKER_URL         "DOCKER_URL"
@@ -194,7 +195,7 @@ static pid_t fork_exec(int i)
     char *args[PROC_ARGS_MAX], *join, *adv, *bind, *url, *iface, *subnets, *cnet_type;
     char *lan_port, *rpc_port, *grpc_port, *fed_port, *server_port, *join_port, *adv_port, *adm_port;
     char *license, *registry, *repository, *tag, *user, *pass, *base, *api_user, *api_pass, *enable;
-    char *on_demand, *pwd_valid_unit, *rancher_ep;
+    char *on_demand, *pwd_valid_unit, *rancher_ep, *debug_level;
     int a;
 
     switch (i) {
@@ -415,6 +416,10 @@ static pid_t fork_exec(int i)
             if (checkImplicitEnableFlag(enable) == 1) {
                 args[a ++] = "-d";
             }
+        }
+        if ((debug_level = getenv(ENV_DEBUG_LEVEL)) != NULL) {
+            args[a ++] = "-v";
+            args[a ++] = debug_level;
         }
         if ((cnet_type = getenv(ENV_CNET_TYPE)) != NULL) {
             args[a ++] = "-n";


### PR DESCRIPTION
This patch aims to support setting dp debug level at dp startup by
defining environment variable `DEBUG_LEVEL="ctrl error"` in addtiton to the API way.