### PR TITLE
NV6413: unexpected Process.Profile.Violation incident on consul process

### DIFF
--- a/agent/policy/process.go
+++ b/agent/policy/process.go
@@ -475,7 +475,7 @@ func buildControllerProfileList(serviceGroup string) *share.CLUSProcessProfile {
 	var whtLst []ProcProfileBrief = []ProcProfileBrief{
 		/////////////////////////////////
 		// /usr/local/bin
-		{"consul", "/usr/local/bin/consul"},
+		{"consul", "*"},				// monitor also calls it through a shell command
 		{"controller", "/usr/local/bin/controller"},
 		{"monitor", "/usr/local/bin/monitor"},
 		{"nstools", "/usr/local/bin/nstools"},
@@ -538,7 +538,7 @@ func buildEnforcerProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		/////////////////////////////////
 		// /usr/local/bin
 		{"agent", "/usr/local/bin/agent"},
-		{"consul", "/usr/local/bin/consul"},
+		{"consul", "*"},			// monitor also calls it through a shell command
 		{"dp", "/usr/local/bin/dp"},
 		{"monitor", "/usr/local/bin/monitor"},
 		{"nstools", "/usr/local/bin/nstools"},
@@ -618,7 +618,7 @@ func buildAllinOneProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		// /usr/local/bin
 		//  {"*", "/usr/local/bin/*"}, // wildcard for below commented execs
 		{"agent", "/usr/local/bin/agent"},
-		{"consul", "/usr/local/bin/consul"},
+		{"consul", "*"},			// monitor also calls it through a shell command
 		{"controller", "/usr/local/bin/controller"},
 		{"dp", "/usr/local/bin/dp"},
 		{"monitor", "/usr/local/bin/monitor"},


### PR DESCRIPTION
When the NV pod exits, the monitor calls to execute a script to terminate its consul process. The paired set was ("consul", "/bin/busybox"),  -- the "consul" process is under the shell process --, especially when they are running on the latest coreos (oc410) environment. 