### PR TITLE
NV6411: sometimes the platform info is missing in /v1/host api on native docker setup

### DIFF
--- a/share/container/docker.go
+++ b/share/container/docker.go
@@ -119,12 +119,10 @@ func (d *dockerDriver) ListContainerIDs() (utils.Set, utils.Set) {
 }
 
 func (d *dockerDriver) ListContainers(runningOnly bool) ([]*ContainerMeta, error) {
-	var containers []dockerclient.Container
-
-	if runningOnly {
-		containers, _ = d.client.ListContainers(false, false, "")
-	} else {
-		containers, _ = d.client.ListContainers(true, false, "")
+	containers, err := d.client.ListContainers( !runningOnly, false, "")
+	if err != nil {
+		log.WithFields(log.Fields{"error": err, "runningOnly": runningOnly}).Error("Fail to list containers")
+		return nil, err
 	}
 
 	metas := make([]*ContainerMeta, len(containers))


### PR DESCRIPTION
When we can not obtain a running container list, we can not decide on the platform and its subsystem. Give it more tries until it receives a non-empty container list. 