### PR TITLE
NV6342: annotations is sometimes empty on one of oc 4.8 cluster nodes

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -1727,7 +1727,7 @@ func startWorkerThread() {
 							hostName = n.IBMCloudWorkerID // is like "kube-c40msj4d0tb4oeriggqg-atibmcluste-default-000001f1"
 						}
 						k8sCache, ok := k8sHostInfoMap[hostName]
-						if !ok || k8sCache == nil {
+						if !ok {
 							k8sCache = &k8sHostCache{}
 						}
 						k8sCache.labels = n.Labels

--- a/controller/resource/kubernetes_resource.go
+++ b/controller/resource/kubernetes_resource.go
@@ -1335,13 +1335,21 @@ func (d *kubernetes) GetResource(rt, namespace, name string) (interface{}, error
 	switch rt {
 	//case RscTypeMutatingWebhookConfiguration:
 	case RscTypeNamespace, RscTypeService, K8sRscTypeClusRole, K8sRscTypeClusRoleBinding, k8sRscTypeRoleBinding, RscTypeValidatingWebhookConfiguration,
-		RscTypeCrd, RscTypeConfigMap, RscTypeCrdSecurityRule, RscTypeCrdClusterSecurityRule, RscTypeCrdAdmCtrlSecurityRule, RscTypeCrdDlpSecurityRule, RscTypeCrdWafSecurityRule,
-		RscTypeNode:
+		RscTypeCrd, RscTypeConfigMap, RscTypeCrdSecurityRule, RscTypeCrdClusterSecurityRule, RscTypeCrdAdmCtrlSecurityRule, RscTypeCrdDlpSecurityRule, RscTypeCrdWafSecurityRule:
 		return d.getResource(rt, namespace, name)
 	case RscTypePod:
 		if r, err := d.getResource(rt, namespace, name); err == nil {
 			if _, p := xlatePod(r.(k8s.Resource)); p != nil {
 				return p, nil
+			}
+			return nil, common.ErrObjectNotFound
+		} else {
+			return nil, err
+		}
+	case RscTypeNode:
+		if r, err:= d.getResource(rt, namespace, name); err == nil {
+			if _, n := xlateNode(r.(k8s.Resource)); n != nil {
+				return n, nil
 			}
 			return nil, common.ErrObjectNotFound
 		} else {


### PR DESCRIPTION
NV6342:
(1) The k8sHostInfoMap has not been added at  "hostUpdate()".
(2) The "global.ORCH.GetResource()" could fail with empty metadata but is considered a false-positive result.
