### PR TITLE
NV6435: Add modules for container scan

### DIFF
--- a/controller/cache/interface.go
+++ b/controller/cache/interface.go
@@ -147,7 +147,7 @@ type CacheInterface interface {
 	GetScanConfig(acc *access.AccessControl) (*api.RESTScanConfig, error)
 	GetScanStatus(acc *access.AccessControl) (*api.RESTScanStatus, error)
 	GetScanPlatformSummary(acc *access.AccessControl) (*api.RESTScanPlatformSummary, error)
-	GetVulnerabilityReport(id string, showTag string) ([]*api.RESTVulnerability, error)
+	GetVulnerabilityReport(id string, showTag string) ([]*api.RESTVulnerability, []*api.RESTScanModule, error)
 
 	// Compliance
 	GetComplianceProfile(name string, acc *access.AccessControl) (*api.RESTComplianceProfile, map[string][]string, error)

--- a/controller/cache/scan.go
+++ b/controller/cache/scan.go
@@ -61,6 +61,7 @@ type scanInfo struct {
 	vulTraits       []*scanUtils.VulTrait // Full list of vuls. There is a filtered flag on each entry.
 	filteredTime    time.Time
 	idns            []api.RESTIDName
+	modules         []*share.ScanModule
 }
 
 type scanTaskInfo struct {
@@ -455,6 +456,7 @@ func scanDone(id string, objType share.ScanObjectType, report *share.CLUSScanRep
 		info.baseOS = report.Namespace
 		info.version = report.Version
 		info.cveDBCreateTime = report.CVEDBCreateTime
+		info.modules = report.Modules
 
 		// Filter and count vulnerabilities
 		vpf := cacher.GetVulnerabilityProfileInterface(share.DefaultVulnerabilityProfileName)
@@ -1128,7 +1130,7 @@ func scanBrief2REST(info *scanInfo) *api.RESTScanBrief {
 	return &r
 }
 
-func (m CacheMethod) GetVulnerabilityReport(id, showTag string) ([]*api.RESTVulnerability, error) {
+func (m CacheMethod) GetVulnerabilityReport(id, showTag string) ([]*api.RESTVulnerability, []*api.RESTScanModule, error) {
 	scanMutexRLock()
 	defer scanMutexRUnlock()
 
@@ -1140,9 +1142,13 @@ func (m CacheMethod) GetVulnerabilityReport(id, showTag string) ([]*api.RESTVuln
 
 		sdb := scanUtils.GetScannerDB()
 		vuls := scanUtils.FillVulDetails(sdb.CVEDB, info.baseOS, info.vulTraits, showTag)
-		return vuls, nil
+		modules := make([]*api.RESTScanModule, len(info.modules))
+		for i, m := range info.modules {
+			modules[i] = scanUtils.ScanModule2REST(m)
+		}
+		return vuls, modules, nil
 	} else {
-		return nil, common.ErrObjectNotFound
+		return nil, nil,common.ErrObjectNotFound
 	}
 }
 

--- a/controller/rest/scanner.go
+++ b/controller/rest/scanner.go
@@ -214,14 +214,14 @@ func handlerScanWorkloadReport(w http.ResponseWriter, r *http.Request, ps httpro
 
 	var resp *api.RESTScanReportData
 
-	vuls, _ := cacher.GetVulnerabilityReport(id, showTag)
+	vuls, modules, _ := cacher.GetVulnerabilityReport(id, showTag)
 	if vuls == nil {
 		// Return an empty list if workload has not been scanned
 		resp = &api.RESTScanReportData{Report: &api.RESTScanReport{
-			Vuls: make([]*api.RESTVulnerability, 0),
+			Vuls: make([]*api.RESTVulnerability, 0), Modules: modules,
 		}}
 	} else {
-		resp = &api.RESTScanReportData{Report: &api.RESTScanReport{Vuls: vuls}}
+		resp = &api.RESTScanReportData{Report: &api.RESTScanReport{Vuls: vuls, Modules: modules}}
 	}
 
 	restRespSuccess(w, r, resp, acc, login, nil, "Get container scan report")
@@ -258,7 +258,7 @@ func handlerScanImageReport(w http.ResponseWriter, r *http.Request, ps httproute
 	if brief == nil {
 		restRespError(w, http.StatusNotFound, api.RESTErrObjectNotFound)
 	} else {
-		vuls, err := cacher.GetVulnerabilityReport(brief.ID, showTag)
+		vuls, _, err := cacher.GetVulnerabilityReport(brief.ID, showTag)
 		if vuls == nil {
 			restRespNotFoundLogAccessDenied(w, login, err)
 			return
@@ -423,7 +423,7 @@ func handlerScanHostReport(w http.ResponseWriter, r *http.Request, ps httprouter
 
 	var resp *api.RESTScanReportData
 
-	vuls, err := cacher.GetVulnerabilityReport(id, showTag)
+	vuls, _, err := cacher.GetVulnerabilityReport(id, showTag)
 	if vuls == nil {
 		// Return an empty list if node has not been scanned
 		resp = &api.RESTScanReportData{Report: &api.RESTScanReport{
@@ -455,7 +455,7 @@ func handlerScanPlatformReport(w http.ResponseWriter, r *http.Request, ps httpro
 		showTag = api.QueryValueShowAccepted
 	}
 
-	vuls, err := cacher.GetVulnerabilityReport(common.ScanPlatformID, showTag)
+	vuls, _, err := cacher.GetVulnerabilityReport(common.ScanPlatformID, showTag)
 	if vuls == nil {
 		restRespNotFoundLogAccessDenied(w, login, err)
 		return
@@ -606,7 +606,7 @@ func getAllVulnerabilities(acc *access.AccessControl) (map[string]*vulAsset, *ap
 
 	if acc.HasGlobalPermissions(share.PERMS_RUNTIME_SCAN, 0) {
 		platform, _, _ := cacher.GetPlatform()
-		vuls, _ := cacher.GetVulnerabilityReport(common.ScanPlatformID, "")
+		vuls, _, _ := cacher.GetVulnerabilityReport(common.ScanPlatformID, "")
 		if vuls != nil {
 			for _, vul := range vuls {
 				va := addVulAsset(all, vul)


### PR DESCRIPTION
(1) Support "/v1/scan/workload/:id" to include the complete module and cve list.

(2) Combined with scanner PR#32