### PR TITLE
NV6433: Enforcer is not becoming operational on k8s 1.24, 1.64 containerd cluster

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -222,24 +222,39 @@ func dumpGoroutineStack() {
 	}
 }
 
-// TODO: sidecar implementation might have two app pods
-func adjustContainerPod(selfID string, containers []*container.ContainerMeta) string {
-	for _, c := range containers {
-		if v, ok := c.Labels["io.kubernetes.sandbox.id"]; ok {
-			if v == selfID {
-				log.WithFields(log.Fields{"Pod": selfID, "ID": c.ID}).Debug("Update")
-				return c.ID
-			}
-		}
+func lookupK8sContainerID(id, role string, containers []*container.ContainerMeta) (string, error) {
+	var podname string
 
-		if c.Sandbox != c.ID { // a child
-			if c.Sandbox == selfID {
-				log.WithFields(log.Fields{"Pod": selfID, "ID": c.ID}).Debug("Update ")
-				return c.ID
+	// (1) identify it is a POD or container
+	for _, c := range containers {
+		if strings.HasPrefix(c.Name, "k8s_POD") {
+			// parent: POD
+			if c.ID == id {
+				podname, _ = c.Labels[container.KubeKeyPodName]
+				break
+			}
+		} else {
+			// found: it is a child, container
+			if c.ID == id {
+				return c.ID, nil
 			}
 		}
 	}
-	return selfID
+
+	// (2) search its child pod
+	for _, c := range containers {
+		if !strings.HasPrefix(c.Name, "k8s_POD") {
+			if name, ok := c.Labels[container.KubeKeyPodName]; ok && (name == podname) {
+				if v, ok := c.Labels[share.NeuVectorLabelRole]; ok {
+					if strings.Contains(v, role) {
+						// neuvector image role: it might have more than one children
+						return c.ID, nil
+					}
+				}
+			}
+		}
+	}
+	return id, fmt.Errorf("failed to find container")
 }
 
 func main() {
@@ -352,7 +367,9 @@ func main() {
 	}
 
 	if platform == share.PlatformKubernetes {
-		selfID = adjustContainerPod(selfID, containers)
+		if selfID, err = lookupK8sContainerID(selfID, share.NeuVectorRoleEnforcer, containers); err != nil {
+			log.WithFields(log.Fields{"selfID": selfID, "error": err}).Error("lookup")
+		}
 	}
 
 	// Container port can be injected after container is up. Wait for at least one.


### PR DESCRIPTION
k8s 1.24, containerd 1.6.4, and cgroup v2

The lookup self-container-identifier method fails with different pod labels. Implement more common elements to find the absent container identifier from the cgroup system.