### PR TITLE
NV6449: goroutine crash at probe.isSudoCommand

### DIFF
--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -821,7 +821,7 @@ func isSudoCommand(cmds []string) bool {
 				return false
 			}
 		} else {
-			if cmd[:1] == "-" { // skip option
+			if strings.HasPrefix(cmd, "-") { // skip option
 				continue
 			} else {	// it could be "su -c /bin/ps neuvector"
 				if cmd == "root" {


### PR DESCRIPTION
The cmd length was 1 and caused the invalid slice index.