### PR TITLE
NV6461: After installing a package in a container, the rescan is not triggered

### DIFF
--- a/agent/probe/incident_reporter.go
+++ b/agent/probe/incident_reporter.go
@@ -152,8 +152,8 @@ func (p *Probe) SendAggregateProbeReport(pmsg *ProbeMessage, bExtOp bool) bool {
 }
 
 /////
-// dpkg[ubuntu, debian], yum[centos,fedora] , dnf[centos, coreos,fedora], rpm[redhat], apk[busybox]
-var pkgCmds utils.Set = utils.NewSet("dpkg", "yum", "dnf", "rpm", "apk")
+// dpkg[ubuntu, debian], yum[centos,fedora] , dnf[centos, coreos,fedora], rpm[redhat], apk[busybox], zypper[bci]
+var pkgCmds utils.Set = utils.NewSet("dpkg", "yum", "dnf", "rpm", "apk", "zypper")
 const (
 	fsPackageUpdate = "Software packages were updated."
 	fsComboAction   = "Files were modified or deleted."

--- a/share/fsmon/monitor.go
+++ b/share/fsmon/monitor.go
@@ -34,7 +34,8 @@ const inodeChangeMask = syscall.IN_CLOSE_WRITE |
 var packageFile utils.Set = utils.NewSet(
 	"/var/lib/dpkg/status",
 	"/var/lib/rpm/Packages",
-	"/lib/apk/db/installed")
+	"/var/lib/rpm/Packages.db",
+	"/lib/apk/db/installed",)
 
 type SendAggregateReportCallback func(fsmsg *MonitorMessage) bool
 
@@ -42,6 +43,7 @@ var ImportantFiles []share.CLUSFileMonitorFilter = []share.CLUSFileMonitorFilter
 	share.CLUSFileMonitorFilter{Behavior: share.FileAccessBehaviorMonitor, Path: "/var/lib/dpkg/status", Regex: ""},
 	share.CLUSFileMonitorFilter{Behavior: share.FileAccessBehaviorMonitor, Path: "/var/lib/rpm/Packages", Regex: ""},
 	share.CLUSFileMonitorFilter{Behavior: share.FileAccessBehaviorMonitor, Path: "/lib/apk/db/installed", Regex: ""},
+	share.CLUSFileMonitorFilter{Behavior: share.FileAccessBehaviorMonitor, Path: "/var/lib/rpm/Packages.db", Regex: ""},
 	share.CLUSFileMonitorFilter{Behavior: share.FileAccessBehaviorMonitor, Path: "/etc/hosts", Regex: ""},
 	share.CLUSFileMonitorFilter{Behavior: share.FileAccessBehaviorMonitor, Path: "/etc/passwd", Regex: ""},
 	share.CLUSFileMonitorFilter{Behavior: share.FileAccessBehaviorMonitor, Path: "/etc/shadow", Regex: ""},

--- a/share/fsmon/notify.go
+++ b/share/fsmon/notify.go
@@ -24,6 +24,7 @@ type IFile struct {
 	protect bool // access control
 	learnt  bool // discover mode
 	userAdd bool
+	lastChg int64	// unix time
 }
 
 type fNotify struct {

--- a/share/osutil/file_linux.go
+++ b/share/osutil/file_linux.go
@@ -25,6 +25,7 @@ const (
 var packageFiles utils.Set = utils.NewSet(
 	"/var/lib/dpkg/status",
 	"/var/lib/rpm/Packages",
+	"/var/lib/rpm/Packages.db",
 	"/lib/apk/db/installed",
 )
 


### PR DESCRIPTION
It was a new package installation method for the "bci" containers.

(1) Add package installation monitor for "zypper"/"rpm".

(2) Add 3 minutes report detection gap among installations. ( before that we only report once and then removed the monitor file mark)