### PR TITLE
NV6478: unexpected NV.Protect incident on grep command

### DIFF
--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -588,7 +588,11 @@ func (p *Probe) removeProcessInContainer(pid int, id string) {
 }
 
 func (p *Probe) isAgentNsOperation(proc *procInternal) bool {
-	// children of nstools
+	// children of nstools, bench script: nstools -> sh -> executables
+	if pproc, ok := p.pidProcMap[proc.ppid]; ok && pproc.ppath == "/usr/local/bin/nstools" {
+		return true
+	}
+	// bench script: work into a different mount namespace
 	return proc.ppath == "/usr/local/bin/nstools" || p.agentMntNsId != global.SYS.GetMntNamespaceId(proc.pid)
 }
 


### PR DESCRIPTION
It could be one of the bench commands executed in the worker node.

nstools -> sh -> grep

when the event came into the decision logic, it was gone. The insufficient information failed the skip decision.