### PR TITLE
NVSHAS-6422: fixed containsAny admission control operation ignoring multiple values for same key

### DIFF
--- a/controller/cache/admission_test.go
+++ b/controller/cache/admission_test.go
@@ -291,25 +291,30 @@ func TestIsMapCriterionMet(t *testing.T) {
 			Op:    share.CriteriaOpContainsOtherThan,
 			Value: "label1,label2=value2,label3=value3",
 		},
+		&share.CLUSAdmRuleCriterion{
+			Name:  share.CriteriaKeyLabels,
+			Op:    share.CriteriaOpContainsAny,
+			Value: "label1=value1,label1=value2",
+		},
 	}
-	expected1 := []bool{true, false, true, true, true, true}
+	expected1 := []bool{true, false, true, true, true, true, true}
 	ctnerLabels1 := map[string]string{
 		"token":  "100",
 		"label1": "value1",
 	}
-	expected2 := []bool{true, false, false, false, true, false}
+	expected2 := []bool{true, false, false, false, true, false, false}
 	ctnerLabels2 := map[string]string{
 		"label1": "",
 		"label2": "value2",
 	}
-	expected3 := []bool{true, false, false, false, true, false}
+	expected3 := []bool{true, false, false, false, true, false, false}
 	ctnerLabels3 := map[string]string{
 		"label2": "value2",
 	}
-	expected4 := []bool{false, false, true, false, false, false}
+	expected4 := []bool{false, false, true, false, false, false, false}
 	ctnerLabels4 := map[string]string{}
 
-	expected5 := []bool{false, false, true, true, true, true}
+	expected5 := []bool{false, false, true, true, true, true, false}
 	ctnerLabels5 := map[string]string{
 		"token": "100",
 	}

--- a/controller/cache/compliance.go
+++ b/controller/cache/compliance.go
@@ -451,7 +451,7 @@ func readBenchFromCluster(id string, bench share.BenchType) []byte {
 	key := share.CLUSBenchReportKey(id, bench)
 	if value, err := cluster.Get(key); err != nil || len(value) == 0 {
 		// not all bench type exist, for example custom check, so use INFO level debug
-		log.WithFields(log.Fields{"error": err, "key": key}).Info("Benchmark report not found")
+		// log.WithFields(log.Fields{"error": err, "key": key}).Info("Benchmark report not found")
 		return nil
 	} else {
 		return value

--- a/share/osutil/process_linux.go
+++ b/share/osutil/process_linux.go
@@ -14,10 +14,10 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"golang.org/x/sys/unix"
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/global"
 	"github.com/neuvector/neuvector/share/utils"
+	"golang.org/x/sys/unix"
 )
 
 const maxStatCmdLen = 15
@@ -201,12 +201,13 @@ func getListenPortsByFile(listens utils.Set, fileName string, inodes utils.Set, 
 	}
 }
 
-func getCGroupSocketTable(rootPid int, tbl map[uint32]SocketInfo, file string, tcp bool)  {
+func getCGroupSocketTable(rootPid int, tbl map[uint32]SocketInfo, file string, tcp bool) {
 	fileName := filepath.Join("/proc", strconv.Itoa(rootPid), "root/proc/1/net", file)
 	// log.WithFields(log.Fields{"filename": fileName}).Debug()
 	f, err := os.Open(fileName)
 	if err != nil {
-		log.WithFields(log.Fields{"error": err}).Error("open net/tcp,udp")
+		// Suppresss the log message
+		// log.WithFields(log.Fields{"error": err, "filename": filename}).Error()
 		return
 	}
 	defer f.Close()
@@ -239,9 +240,9 @@ func getCGroupSocketTable(rootPid int, tbl map[uint32]SocketInfo, file string, t
 			ip_port := strings.Split(tokens[1], ":")
 			port, _ := strconv.ParseUint(ip_port[1], 16, 16)
 			if tcp {
-				tbl[inode] = SocketInfo{ Port: uint16(port), IPProto: syscall.IPPROTO_TCP, INode: inode,}
+				tbl[inode] = SocketInfo{Port: uint16(port), IPProto: syscall.IPPROTO_TCP, INode: inode}
 			} else {
-				tbl[inode] = SocketInfo{ Port: uint16(port), IPProto: syscall.IPPROTO_UDP, INode: inode,}
+				tbl[inode] = SocketInfo{Port: uint16(port), IPProto: syscall.IPPROTO_UDP, INode: inode}
 			}
 		}
 	}
@@ -256,10 +257,10 @@ func GetContainerSocketTable(rootPid int) map[uint32]SocketInfo {
 	getCGroupSocketTable(rootPid, tbl, "udp", false)
 	getCGroupSocketTable(rootPid, tbl, "udp6", false)
 
-//	log.WithFields(log.Fields{"rootPid": rootPid, "tbl": len(tbl)}).Debug()
-//	for inode, pport := range tbl {
-//		log.WithFields(log.Fields{"inode": inode, "pport": pport}).Debug()
-//	}
+	//	log.WithFields(log.Fields{"rootPid": rootPid, "tbl": len(tbl)}).Debug()
+	//	for inode, pport := range tbl {
+	//		log.WithFields(log.Fields{"inode": inode, "pport": pport}).Debug()
+	//	}
 	return tbl
 }
 


### PR DESCRIPTION
Previously the "containsAny" operation in admission control would incorrectly resolve to false when given a criteria that contained multiple key/value pairs (formatted as "key=value"). It was due to the map implementation for the lower level functions only allowing one value per key. This change alters that map to allow multiple potential values per key to be checked.