### PR TITLE
NV6502: enforcer is unable to start successfully sometimes

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -340,6 +340,11 @@ func main() {
 	platform, flavor, network, containers, err := global.SetGlobalObjects(*rtSock, nil)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Failed to initialize")
+		if err == global.ErrEmptyContainerList {
+			// Temporary get container list error
+			// => exit the process but the container doesn't need to be restarted
+			os.Exit(-1)
+		}
 		os.Exit(-2)
 	}
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -304,6 +304,11 @@ func main() {
 	platform, flavor, network, containers, err := global.SetGlobalObjects(*rtSock, resource.Register)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Failed to initialize")
+		if err == global.ErrEmptyContainerList {
+			// Temporary get container list error
+			// => exit the process but the container doesn't need to be restarted
+			os.Exit(-1)
+		}
 		os.Exit(-2)
 	}
 

--- a/share/global/global.go
+++ b/share/global/global.go
@@ -18,6 +18,8 @@ type orchHub struct {
 	orchAPI.ResourceDriver
 }
 
+var ErrEmptyContainerList = errors.New("Container list is empty")
+
 type RegisterDriverFunc func(platform, flavor, network string) orchAPI.ResourceDriver
 
 var SYS *system.SystemTools
@@ -44,7 +46,7 @@ func SetGlobalObjects(rtSocket string, regResource RegisterDriverFunc) (string, 
 	}
 
 	if len(containers) == 0 {
-		return "", "", "", nil, errors.New("Container list is empty")
+		return "", "", "", nil, ErrEmptyContainerList
 	}
 
 	platform, flavor, network := getPlatform(containers)


### PR DESCRIPTION
Cause: the docker service was not responsive for a period of time, because we got an empty "docker ps" list (3 tries). The agent went into a non-recoverable failed state. Then, the container exited.

Patch: instead of the container's exit, let the monitor recover it by restarting the agent process until the agent obtains the correct result.