### PR TITLE
Nv5225: host scan may fail after enforcer restarts

### DIFF
--- a/controller/cache/object.go
+++ b/controller/cache/object.go
@@ -1692,6 +1692,7 @@ func registerEventHandlers() {
 	})
 	evhdls.Register(EV_AGENT_DELETE, []eventHandlerFunc{
 		uniconfAgentDelete,
+		scanAgentDelete,
 	})
 	evhdls.Register(EV_AGENT_ONLINE, []eventHandlerFunc{
 		rpcAgentOnline,

--- a/controller/cache/scan.go
+++ b/controller/cache/scan.go
@@ -697,6 +697,20 @@ func scanHostDelete(id string, param interface{}) {
 	scanMapDelete(id)
 }
 
+func scanAgentDelete(id string, param interface{}) {
+	// purge incomplete scanning jobs but keep completed scans
+	scanMutexLock()
+	defer scanMutexUnlock()
+	for task, info := range scanMap {
+		if info.agentId == id {
+			if info.cveDBCreateTime ==  "" {	// incompleted, not done yet
+				log.WithFields(log.Fields{"task": task, "info": info}).Info()
+				delete(scanMap, task)
+			}
+		}
+	}
+}
+
 func scanConfigUpdate(nType cluster.ClusterNotifyType, key string, value []byte) {
 	switch nType {
 	case cluster.ClusterNotifyAdd, cluster.ClusterNotifyModify:


### PR DESCRIPTION
Those error messages were correct because the enforcer was deleted and the controller has not the "deleted" event yet.

The issue is not we can not add the scanning task while the new enforcer is up.