### PR TITLE
NV6484: new added files for file monitor and file rule is not migrate d from old version

### DIFF
--- a/controller/kv/helper.go
+++ b/controller/kv/helper.go
@@ -1538,6 +1538,9 @@ func (m clusterHelper) PutFileMonitorProfile(name string, conf *share.CLUSFileMo
 	key := share.CLUSFileMonitorKey(name)
 	value, _ := json.Marshal(conf)
 	m.DuplicateNetworkKey(key, value)
+	if rev == 0 {
+		return cluster.Put(key, value)
+	}
 	return cluster.PutRev(key, value, rev)
 }
 

--- a/controller/kv/upgrade.go
+++ b/controller/kv/upgrade.go
@@ -754,7 +754,9 @@ var phases []kvVersions = []kvVersions{
 
 	{"825C9419", createDefWafRuleSensor},
 
-	{"7B3D205C", nil},
+	{"7B3D205C", addFmonRpmPackageDB},
+
+	{"168EE3FA", nil},
 }
 
 func latestKVVersion() string {
@@ -1569,4 +1571,9 @@ func upgradeDlpSensor(cfg *share.CLUSDlpSensor) (bool, bool) {
 func resetDlpCfgType() {
 	clusHelper.GetAllDlpSensors()
 	clusHelper.GetAllGroups(share.ScopeLocal, access.NewReaderAccessControl())
+}
+
+func addFmonRpmPackageDB(){
+	// additional file monitor entry
+	addPredefinedFileRule(share.FileAccessBehaviorMonitor, "/var/lib/rpm/Packages.db", "")
 }


### PR DESCRIPTION
Add a one-time upgrade function for the new predefined file monitor entry.