### PR TITLE
hotfix: fixes leading or trailing spaces breaking certain admission control criterion values

### DIFF
--- a/controller/cache/admission.go
+++ b/controller/cache/admission.go
@@ -798,7 +798,7 @@ func isMapCriterionMet(crt *share.CLUSAdmRuleCriterion, propMap map[string]strin
 				value = strings.TrimSpace(crtValue[i+1:])
 				kvMap[key] = append(kvMap[key], value)
 			} else {
-				key = crtValue
+				key = strings.TrimSpace(crtValue)
 				kvMap[key] = append(kvMap[key], "")
 			}
 		}
@@ -881,7 +881,7 @@ func isComplexMapCriterionMet(crt *share.CLUSAdmRuleCriterion, propMap map[strin
 				value = strings.TrimSpace(crtValue[i+1:])
 				kvMap[key] = append(kvMap[key], value)
 			} else {
-				key = crtValue
+				key = strings.TrimSpace(crtValue)
 				kvMap[key] = append(kvMap[key], "")
 			}
 		}


### PR DESCRIPTION
When a criterion value for an admission control rule is something like `firstKey=firstValue, secondKey` the `secondKey` value would have a leading space that throws off comparison later in the logic. This just trims it out, a detail that was missed when fixing a previous bug.