### PR TITLE
NV6158: enforcer's info is sometimes from parent container

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -222,41 +222,6 @@ func dumpGoroutineStack() {
 	}
 }
 
-func lookupK8sContainerID(id, role string, containers []*container.ContainerMeta) (string, error) {
-	var podname string
-
-	// (1) identify it is a POD or container
-	for _, c := range containers {
-		if strings.HasPrefix(c.Name, "k8s_POD") {
-			// parent: POD
-			if c.ID == id {
-				podname, _ = c.Labels[container.KubeKeyPodName]
-				break
-			}
-		} else {
-			// found: it is a child, container
-			if c.ID == id {
-				return c.ID, nil
-			}
-		}
-	}
-
-	// (2) search its child pod
-	for _, c := range containers {
-		if !strings.HasPrefix(c.Name, "k8s_POD") {
-			if name, ok := c.Labels[container.KubeKeyPodName]; ok && (name == podname) {
-				if v, ok := c.Labels[share.NeuVectorLabelRole]; ok {
-					if strings.Contains(v, role) {
-						// neuvector image role: it might have more than one children
-						return c.ID, nil
-					}
-				}
-			}
-		}
-	}
-	return id, fmt.Errorf("failed to find container")
-}
-
 func main() {
 	var joinAddr, advAddr, bindAddr string
 	var err error
@@ -381,7 +346,7 @@ func main() {
 	}
 
 	if platform == share.PlatformKubernetes {
-		if selfID, err = lookupK8sContainerID(selfID, share.NeuVectorRoleEnforcer, containers); err != nil {
+		if selfID, err = global.IdentifyK8sContainerID(selfID); err != nil {
 			log.WithFields(log.Fields{"selfID": selfID, "error": err}).Error("lookup")
 		}
 	}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"net"
 	"os"
 	"os/signal"
@@ -190,41 +189,6 @@ func getConfigKvData(key string) ([]byte, bool) {
 	return cacher.GetConfigKvData(key)
 }
 
-func lookupK8sContainerID(id, role string, containers []*container.ContainerMeta) (string, error) {
-	var podname string
-
-	// (1) identify it is a POD or container
-	for _, c := range containers {
-		if strings.HasPrefix(c.Name, "k8s_POD") {
-			// parent: POD
-			if c.ID == id {
-				podname, _ = c.Labels[container.KubeKeyPodName]
-				break
-			}
-		} else {
-			// found: it is a child, container
-			if c.ID == id {
-				return c.ID, nil
-			}
-		}
-	}
-
-	// (2) search its child pod
-	for _, c := range containers {
-		if !strings.HasPrefix(c.Name, "k8s_POD") {
-			if name, ok := c.Labels[container.KubeKeyPodName]; ok && (name == podname) {
-				if v, ok := c.Labels[share.NeuVectorLabelRole]; ok {
-					if strings.Contains(v, role) {
-						// neuvector image role: it might have more than one children
-						return c.ID, nil
-					}
-				}
-			}
-		}
-	}
-	return id, fmt.Errorf("failed to find container")
-}
-
 func main() {
 	var joinAddr, advAddr, bindAddr string
 	var err error
@@ -341,7 +305,7 @@ func main() {
 	}
 
 	if platform == share.PlatformKubernetes {
-		if selfID, err = lookupK8sContainerID(selfID, share.NeuVectorRoleEnforcer, containers); err != nil {
+		if selfID, err = global.IdentifyK8sContainerID(selfID); err != nil {
 			log.WithFields(log.Fields{"selfID": selfID, "error": err}).Error("lookup")
 		}
 	}


### PR DESCRIPTION
For k8s clusters with the cgroup v2 subsystem, we sometimes can not locate a correct nv containers' ID.  

(1) Remove the image role criteria from the matching method since the image label is absent in the rke2.
(2) Consolidate the lookup function into a common package.
