### PR TITLE
NVSHAS-3842: add modules criteria to admssion control

### DIFF
--- a/controller/cache/admission.go
+++ b/controller/cache/admission.go
@@ -798,7 +798,7 @@ func isMapCriterionMet(crt *share.CLUSAdmRuleCriterion, propMap map[string]strin
 				value = strings.TrimSpace(crtValue[i+1:])
 				kvMap[key] = append(kvMap[key], value)
 			} else {
-				key = crtValue
+				key = strings.TrimSpace(crtValue)
 				kvMap[key] = append(kvMap[key], "")
 			}
 		}
@@ -873,7 +873,7 @@ func doesComplexMapContain(key, value string, propMap map[string][]string) bool 
 
 func isComplexMapCriterionMet(crt *share.CLUSAdmRuleCriterion, propMap map[string][]string) (bool, bool) {
 	if len(propMap) > 0 {
-		kvMap := make(map[string][]string, len(crt.ValueSlice)) // the key=value configured in criteria
+		kvMap := make(map[string][]string) // the key=value configured in criteria
 		for _, crtValue := range crt.ValueSlice {
 			var key, value string
 			if i := strings.Index(crtValue, "="); i >= 0 {
@@ -881,7 +881,7 @@ func isComplexMapCriterionMet(crt *share.CLUSAdmRuleCriterion, propMap map[strin
 				value = strings.TrimSpace(crtValue[i+1:])
 				kvMap[key] = append(kvMap[key], value)
 			} else {
-				key = crtValue
+				key = strings.TrimSpace(crtValue)
 				kvMap[key] = append(kvMap[key], "")
 			}
 		}
@@ -1136,6 +1136,15 @@ func isImageCriterionMet(crt *share.CLUSAdmRuleCriterion, c *nvsysadmission.AdmC
 	return false, true
 }
 
+func isModulesCriterionMet(crt *share.CLUSAdmRuleCriterion, modules []*share.ScanModule) (bool, bool) {
+	var nameVersionMap map[string][]string = make(map[string][]string)
+	for _, module := range modules {
+		nameVersionMap[module.Name] = append(nameVersionMap[module.Name], module.Version)
+	}
+
+	return isComplexMapCriterionMet(crt, nameVersionMap)
+}
+
 func mergeStringMaps(propFromYaml map[string]string, propFromImage map[string]string) map[string][]string {
 	size := len(propFromYaml)
 	if len(propFromImage) > size {
@@ -1279,6 +1288,8 @@ func isAdmissionRuleMet(admResObject *nvsysadmission.AdmResObject, c *nvsysadmis
 			}
 		case share.CriteriaKeyRequestLimit:
 			met, positive = isResourceLimitCriterionMet(crt, c)
+		case share.CriteriaKeyModules:
+			met, positive = isModulesCriterionMet(crt, scannedImage.Modules)
 		default:
 			met, positive = false, true
 		}

--- a/controller/cache/admission_test.go
+++ b/controller/cache/admission_test.go
@@ -257,6 +257,204 @@ func TestIsImageCriterionMet(t *testing.T) {
 	postTest()
 }
 
+func TestIsModulesCriterionMet(t *testing.T) {
+	preTest()
+
+	moduleSets := [][]*share.ScanModule{
+		/********************************************/
+		[]*share.ScanModule{
+			&share.ScanModule{
+				Name: "vim",
+				Version: "8.2.4081-1.cm1",
+			},
+		},
+		/********************************************/
+		[]*share.ScanModule{
+			&share.ScanModule{
+				Name: "vim",
+				Version: "8.2.4081-1.cm1",
+			},
+			&share.ScanModule{
+				Name: "curl",
+				Version: "9.9.9999-9.cm1",
+			},
+		},
+		/********************************************/
+		[]*share.ScanModule{
+			&share.ScanModule{
+				Name: "vim",
+				Version: "8.2.4081-1.cm1",
+			},
+			&share.ScanModule{
+				Name: "curl",
+				Version: "9.9.9999-9.cm1",
+			},
+			&share.ScanModule{
+				Name: "random-package",
+				Version: "1.0.0000-0.cm1",
+			},
+		},
+		/********************************************/
+		[]*share.ScanModule{
+			&share.ScanModule{
+				Name: "random-package",
+				Version: "1.0.0000-0.cm1",
+			},
+		},
+		/********************************************/
+		[]*share.ScanModule{
+			&share.ScanModule{
+				Name: "vim",
+				Version: "8.2.4081-1.cm1",
+			},
+			&share.ScanModule{
+				Name: "random-package",
+				Version: "1.0.0000-0.cm1",
+			},
+		},
+		/********************************************/
+	}
+
+	type criteriaTestCase struct {
+		Value string
+		Expected [][]bool // expected isModulesCriterionMet result for above moduleSets
+	}
+
+	cases := []criteriaTestCase{
+		criteriaTestCase{
+			Value: "vim",
+			Expected: [][]bool {
+				[]bool {true, true, true, false, true}, // first array is for CriteriaOpContainsAny
+				[]bool {true, true, true, false, true}, // second array is for CriteriaOpContainsAll
+				[]bool {false, true, true, true, true}, // third array is for CriteriaOpContainsOtherThan
+			},
+		},
+		criteriaTestCase{
+			Value: "vim, curl",
+			Expected: [][]bool {
+				[]bool {true, true, true, false, true},
+				[]bool {false, true, true, false, false},
+				[]bool {false, false, true, true, true},
+			},
+		},
+		criteriaTestCase{
+			Value: "curl",
+			Expected: [][]bool {
+				[]bool {false, true, true, false, false},
+				[]bool {false, true, true, false, false},
+				[]bool {true, true, true, true, true},
+			},
+		},
+		criteriaTestCase{
+			Value: "vim=8.2.4081-1.cm1",
+			Expected: [][]bool {
+				[]bool {true, true, true, false, true},
+				[]bool {true, true, true, false, true},
+				[]bool {false, true, true, true, true},
+			},
+		},
+		criteriaTestCase{
+			Value: "vim=8.2.4081-1.cm1, vim=9.9.9999-9.cm1",
+			Expected: [][]bool {
+				[]bool {true, true, true, false, true},
+				[]bool {false, false, false, false, false},
+				[]bool {false, true, true, true, true},
+			},
+		},
+		criteriaTestCase{
+			Value: "vim=9.9.9999-9.cm1",
+			Expected: [][]bool {
+				[]bool {false, false, false, false, false},
+				[]bool {false, false, false, false, false},
+				[]bool {true, true, true, true, true},
+			},
+		},
+		criteriaTestCase{
+			Value: "vim=8.2.4081-1.cm1, curl",
+			Expected: [][]bool {
+				[]bool {true, true, true, false, true},
+				[]bool {false, true, true, false, false},
+				[]bool {false, false, true, true, true},
+			},
+		},
+		criteriaTestCase{
+			Value: "vim=8.2.4081-1.cm1, vim=9.9.9999-9.cm1, curl",
+			Expected: [][]bool {
+				[]bool {true, true, true, false, true},
+				[]bool {false, false, false, false, false},
+				[]bool {false, false, true, true, true},
+			},
+		},
+		criteriaTestCase{
+			Value: "vim=9.9.9999-9.cm1, curl",
+			Expected: [][]bool {
+				[]bool {false, true, true, false, false},
+				[]bool {false, false, false, false, false},
+				[]bool {true, true, true, true, true},
+			},
+		},
+		criteriaTestCase{
+			Value: "vim=8.2.4081-1.cm1, curl=9.9.9999-9.cm1",
+			Expected: [][]bool {
+				[]bool {true, true, true, false, true},
+				[]bool {false, true, true, false, false},
+				[]bool {false, false, true, true, true},
+			},
+		},
+		criteriaTestCase{
+			Value: "vim=8.2.4081-1.cm1, vim=9.9.9999-9.cm1, curl=9.9.9999-9.cm1",
+			Expected: [][]bool {
+				[]bool {true, true, true, false, true},
+				[]bool {false, false, false, false, false},
+				[]bool {false, false, true, true, true},
+			},
+		},
+		criteriaTestCase{
+			Value: "vim=9.9.9999-9.cm1, curl=9.9.9999-9.cm1",
+			Expected: [][]bool {
+				[]bool {false, true, true, false, false},
+				[]bool {false, false, false, false, false},
+				[]bool {true, true, true, true, true},
+			},
+		},
+	}
+
+	criteriaOps := []string{
+		share.CriteriaOpContainsAny,
+		share.CriteriaOpContainsAll,
+		share.CriteriaOpContainsOtherThan,
+	}
+
+	for opIndex, op := range criteriaOps {
+		for modSetIndex, moduleSet := range moduleSets {
+			for _, testCase := range cases {
+				met, _ := isModulesCriterionMet(
+					&share.CLUSAdmRuleCriterion{
+						Name: share.CriteriaKeyModules,
+						Op: op,
+						Value: testCase.Value,
+						ValueSlice: strings.Split(testCase.Value, ","),
+					},
+					moduleSet,
+				)
+				if met != testCase.Expected[opIndex][modSetIndex] {
+					t.Errorf(
+						"Unexpected isModulesCriterionMet result: (%+v) expected: (%+v)\n\toperation: (%s)\n\tcriterion value: (%s)\n\tmodule set: (%+v)\n",
+						// "Unexpected isModulesCriterionMet result(%+v) expected: (%v) for criterion value: %s (testCaseIndex: %d), and module set: %+v\n",
+						met,
+						testCase.Expected[opIndex][modSetIndex],
+						op,
+						testCase.Value,
+						moduleSet,
+					)
+				}
+			}
+		}
+	}
+
+	postTest()
+}
+
 func TestIsMapCriterionMet(t *testing.T) {
 	preTest()
 
@@ -301,25 +499,30 @@ func TestIsMapCriterionMet(t *testing.T) {
 			Op:    share.CriteriaOpContainsOtherThan,
 			Value: "label2=value1,label2=value2",
 		},
+		&share.CLUSAdmRuleCriterion{
+			Name:  share.CriteriaKeyLabels,
+			Op:    share.CriteriaOpContainsAny,
+			Value: "label1",
+		},
 	}
-	expected1 := []bool{true, false, true, true, true, true, true, true}
+	expected1 := []bool{true, false, true, true, true, true, true, true, true}
 	ctnerLabels1 := map[string]string{
 		"token":  "100",
 		"label1": "value1",
 	}
-	expected2 := []bool{true, false, false, false, true, false, false, true}
+	expected2 := []bool{true, false, false, false, true, false, false, true, true}
 	ctnerLabels2 := map[string]string{
 		"label1": "",
 		"label2": "value2",
 	}
-	expected3 := []bool{true, false, false, false, true, false, false, false}
+	expected3 := []bool{true, false, false, false, true, false, false, false, false}
 	ctnerLabels3 := map[string]string{
 		"label2": "value2",
 	}
-	expected4 := []bool{false, false, true, false, false, false, false, false}
+	expected4 := []bool{false, false, true, false, false, false, false, false, false}
 	ctnerLabels4 := map[string]string{}
 
-	expected5 := []bool{false, false, true, true, true, true, false, true}
+	expected5 := []bool{false, false, true, true, true, true, false, true, false}
 	ctnerLabels5 := map[string]string{
 		"token": "100",
 	}

--- a/controller/nvk8sapi/nvvalidatewebhookcfg/admission/admission.go
+++ b/controller/nvk8sapi/nvvalidatewebhookcfg/admission/admission.go
@@ -55,6 +55,7 @@ type ScannedImageSummary struct {
 	LowVulInfo      []share.CLUSScannedVulInfoSimple    // only care about score
 	SetIDPermCnt    int                                 // setuid and set gid from image scan
 	SecretsCnt      int                                 // secrets from image scan
+	Modules         []*share.ScanModule
 }
 
 type AdmContainerInfo struct {
@@ -380,6 +381,11 @@ func getAdmK8sDenyRuleOptions() map[string]*api.RESTAdmissionRuleOption {
 					},
 				},
 			},
+			share.CriteriaKeyModules: &api.RESTAdmissionRuleOption{
+				Name:     share.CriteriaKeyModules,
+				Ops:      allSetOps,
+				MatchSrc: api.MatchSrcImage,
+			},
 		}
 	}
 	return admK8sDenyRuleOptions
@@ -493,6 +499,11 @@ func getAdmK8sExceptRuleOptions() map[string]*api.RESTAdmissionRuleOption { // f
 				Ops:      []string{share.CriteriaOpEqual},
 				Values:   boolOps,
 				MatchSrc: api.MatchSrcYaml,
+			},
+			share.CriteriaKeyModules: &api.RESTAdmissionRuleOption{
+				Name:     share.CriteriaKeyModules,
+				Ops:      allSetOps,
+				MatchSrc: api.MatchSrcImage,
 			},
 		}
 	}

--- a/controller/scan/interface.go
+++ b/controller/scan/interface.go
@@ -188,6 +188,7 @@ func GetScannedImageSummary(reqImgRegistry utils.Set, reqImgRepo, reqImgTag stri
 			Labels:          make(map[string]string, len(s.cache.labels)),
 			SecretsCnt:      len(s.cache.secrets),
 			SetIDPermCnt:    len(s.cache.setIDPerm),
+			Modules:		 s.cache.modules,
 		}
 		for _, v := range s.cache.vulTraits {
 			if !v.IsFiltered() {

--- a/share/criteria.go
+++ b/share/criteria.go
@@ -45,6 +45,7 @@ const (
 	CriteriaKeyAllowPrivEscalation string = "allowPrivEscalation"
 	CriteriaKeyPspCompliance       string = "pspCompliance" // psp compliance violation
 	CriteriaKeyRequestLimit        string = "resourceLimit"
+	CriteriaKeyModules			   string = "modules"
 )
 
 const (


### PR DESCRIPTION
Adds the ability for users to create admission control rules based on module information in scanned images.

The new `modules` criterion follows the `key[=value]` schema that other admission rules use.

Examples:

The following will deny any deployment that contains the "curl" module/package in its scanned image at any version
```
criterion: modules
type: deny
operation: containsAny
value: curl
```

The following will deny any deployment that contains the "curl" module package with the specific version "1.1.1.1" in its scanned image
```
criterion: modules
type: deny
operation: containsAny
value: curl=1.1.1.1
```

The following will deny any deployment that contains the "curl" module package with the specific version "1.1.1.1" in its scanned image, or the "openssl" package at any version
```
criterion: modules
type: deny
operation: containsAny
value: curl=1.1.1.1,openssl
```