### PR TITLE
Enforcer: add no cis/docker benchmark flag: env "ENF_NO_AUTO_BENCHMARK"

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -191,7 +191,7 @@ func checkAntiAffinity(containers []*container.ContainerMeta, skips ...string) e
 
 func cbRerunKube(cmd, cmdRemap string) {
 	if Host.CapKubeBench {
-		bench.RerunKube(cmd, cmdRemap)
+		bench.RerunKube(cmd, cmdRemap, false)
 	}
 }
 
@@ -257,6 +257,7 @@ func main() {
 	show_monitor_trace := flag.Bool("m", false, "Show process/file monitor traces")
 	disable_kv_congest_ctl := flag.Bool("no_kvc", false, "disable kv congestion control")
 	disable_scan_secrets := flag.Bool("no_scrt", false, "disable secret scans")
+	disable_auto_benchmark := flag.Bool("no_auto_benchmark", false, "disable auto benchmark")
 	flag.Parse()
 
 	if *debug {
@@ -282,6 +283,12 @@ func main() {
 	if *disable_scan_secrets {
 		log.Info("Scanning secrets on containers is disabled")
 		agentEnv.scanSecrets = false
+	}
+
+	agentEnv.autoBenchmark = true
+	if *disable_auto_benchmark {
+		log.Info("Auto benchmark is disabled")
+		agentEnv.autoBenchmark = false
 	}
 
 	if *join != "" {
@@ -506,7 +513,7 @@ func main() {
 	go bench.BenchLoop()
 
 	if Host.CapDockerBench {
-		bench.RerunDocker()
+		bench.RerunDocker(false)
 	} else {
 		// If the older version write status into the cluster, clear it.
 		bench.ResetDockerStatus()

--- a/agent/bench.go
+++ b/agent/bench.go
@@ -399,7 +399,12 @@ func (b *Bench) triggerHostCustomCheck(script *share.CLUSCustomCheckGroup) {
 	b.customHostTimer.Reset(scriptTimerStart)
 }
 
-func (b *Bench) RerunDocker() {
+func (b *Bench) RerunDocker(forced bool) {
+	if agentEnv.autoBenchmark == false && forced == false {
+		log.Info("ignored")
+		return
+	}
+
 	log.Info("")
 
 	if err := b.dockerCheckPrerequisites(); err != nil {
@@ -413,7 +418,12 @@ func (b *Bench) RerunDocker() {
 	}
 }
 
-func (b *Bench) RerunKube(cmd, cmdRemap string) {
+func (b *Bench) RerunKube(cmd, cmdRemap string, forced bool) {
+	if agentEnv.autoBenchmark == false && forced == false {
+		log.Info("ignored")
+		return
+	}
+
 	log.Info("")
 
 	if cmd != "" && cmdRemap != "" {

--- a/agent/cluster.go
+++ b/agent/cluster.go
@@ -680,10 +680,10 @@ func leadChangeHandler(newLead, oldLead string) {
 			clusterFailed = false
 			uploadCurrentInfo()
 			if Host.CapDockerBench {
-				bench.RerunDocker()
+				bench.RerunDocker(false)
 			}
 			if Host.CapKubeBench {
-				bench.RerunKube("", "")
+				bench.RerunKube("", "", false)
 			}
 			cluster.ResumeAllWatchers()
 		}

--- a/agent/service.go
+++ b/agent/service.go
@@ -903,14 +903,14 @@ func (rs *RPCService) GetContainerLogs(f *share.CLUSContainerLogReq, stream shar
 
 func (rs *RPCService) RunDockerBench(ctx context.Context, v *share.RPCVoid) (*share.RPCVoid, error) {
 	if Host.CapDockerBench {
-		bench.RerunDocker()
+		bench.RerunDocker(true)
 	}
 	return &share.RPCVoid{}, nil
 }
 
 func (rs *RPCService) RunKubernetesBench(ctx context.Context, v *share.RPCVoid) (*share.RPCVoid, error) {
 	if Host.CapKubeBench {
-		bench.RerunKube("", "")
+		bench.RerunKube("", "", true)
 	}
 	return &share.RPCVoid{}, nil
 }

--- a/agent/types.go
+++ b/agent/types.go
@@ -19,6 +19,7 @@ type AgentEnvInfo struct {
 	cgroupCPUAcct        string
 	kvCongestCtrl        bool
 	scanSecrets          bool
+	autoBenchmark        bool
 }
 
 const (

--- a/monitor/monitor.c
+++ b/monitor/monitor.c
@@ -42,6 +42,7 @@
 #define ENV_SHOW_MONITOR_TRACE "ENF_MONITOR_TRACE"
 #define ENV_NO_KV_CONGEST_CTL  "ENF_NO_KV_CONGESTCTL"
 #define ENV_NO_SCAN_SECRETS    "ENF_NO_SECRET_SCANS"
+#define ENV_NO_AUTO_BENCHMARK  "ENF_NO_AUTO_BENCHMARK"
 #define ENV_PWD_VALID_UNIT     "PWD_VALID_UNIT"
 #define ENV_RANCHER_EP         "RANCHER_EP"
 #define ENV_RANCHER_SSO        "RANCHER_SSO"
@@ -436,6 +437,9 @@ static pid_t fork_exec(int i)
         }
         if (getenv(ENV_NO_SCAN_SECRETS)) {
             args[a ++] = "-no_scrt";
+        }
+        if (getenv(ENV_NO_AUTO_BENCHMARK)) {
+            args[a ++] = "-no_auto_benchmark";
         }
         args[a] = NULL;
         break;


### PR DESCRIPTION
It allows disabling CIS/docker bench tests on the hosts by providing an environment variable in the YAML file, like:

  env:      
       - name: ENF_NO_AUTO_BENCHMARK
                value: "1"
