### PR TITLE
NV6586: false-negative Process.Profile.Violation incidents on non-image processes

### DIFF
--- a/agent/probe/fsn.go
+++ b/agent/probe/fsn.go
@@ -522,8 +522,9 @@ func (fsn *FileNotificationCtr) GetUpperFileInfo(id, file string) (*fileInfo, bo
 			}
 
 			if fsn.storageDrv != drv_btrfs {
-				if fi, err := os.Stat(filepath.Join(root.cLayer, file)); err == nil {
-					finfo.bExec, finfo.length, finfo.hashValue = calculateFileInfo(fi, file)
+				fpath := filepath.Join(root.cLayer, file)
+				if fi, err := os.Stat(fpath); err == nil {
+					finfo.bExec, finfo.length, finfo.hashValue = calculateFileInfo(fi, fpath)
 					finfo.fileType = file_added
 					root.files[file] = finfo
 					// mLog.WithFields(log.Fields{"id": id, "file": file}).Debug("FSN: patch")


### PR DESCRIPTION
There are two procedures to verify the non-image files. One of these uses a wrong file path and causes false-negative cases.