### PR TITLE
NVSHAS-6576: Add Semantic Version Comparison to Modules Admission Rule

### DIFF
--- a/controller/cache/admission_test.go
+++ b/controller/cache/admission_test.go
@@ -313,6 +313,13 @@ func TestIsModulesCriterionMet(t *testing.T) {
 			},
 		},
 		/********************************************/
+		[]*share.ScanModule{
+			&share.ScanModule{
+				Name: "vim",
+				Version: "2.0.0",
+			},
+		},
+		/********************************************/
 	}
 
 	type criteriaTestCase struct {
@@ -324,97 +331,105 @@ func TestIsModulesCriterionMet(t *testing.T) {
 		criteriaTestCase{
 			Value: "vim",
 			Expected: [][]bool {
-				[]bool {true, true, true, false, true}, // first array is for CriteriaOpContainsAny
-				[]bool {true, true, true, false, true}, // second array is for CriteriaOpContainsAll
-				[]bool {false, true, true, true, true}, // third array is for CriteriaOpContainsOtherThan
+				[]bool {true, true, true, false, true, true}, // first array is for CriteriaOpContainsAny
+				[]bool {true, true, true, false, true, true}, // second array is for CriteriaOpContainsAll
+				[]bool {false, true, true, true, true, false}, // third array is for CriteriaOpContainsOtherThan
 			},
 		},
 		criteriaTestCase{
 			Value: "vim, curl",
 			Expected: [][]bool {
-				[]bool {true, true, true, false, true},
-				[]bool {false, true, true, false, false},
-				[]bool {false, false, true, true, true},
+				[]bool {true, true, true, false, true, true},
+				[]bool {false, true, true, false, false, false},
+				[]bool {false, false, true, true, true, false},
 			},
 		},
 		criteriaTestCase{
 			Value: "curl",
 			Expected: [][]bool {
-				[]bool {false, true, true, false, false},
-				[]bool {false, true, true, false, false},
-				[]bool {true, true, true, true, true},
+				[]bool {false, true, true, false, false, false},
+				[]bool {false, true, true, false, false, false},
+				[]bool {true, true, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim=8.2.4081-1.cm1",
 			Expected: [][]bool {
-				[]bool {true, true, true, false, true},
-				[]bool {true, true, true, false, true},
-				[]bool {false, true, true, true, true},
+				[]bool {true, true, true, false, true, false},
+				[]bool {true, true, true, false, true, false},
+				[]bool {false, true, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim=8.2.4081-1.cm1, vim=9.9.9999-9.cm1",
 			Expected: [][]bool {
-				[]bool {true, true, true, false, true},
-				[]bool {false, false, false, false, false},
-				[]bool {false, true, true, true, true},
+				[]bool {true, true, true, false, true, false},
+				[]bool {false, false, false, false, false, false},
+				[]bool {false, true, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim=9.9.9999-9.cm1",
 			Expected: [][]bool {
-				[]bool {false, false, false, false, false},
-				[]bool {false, false, false, false, false},
-				[]bool {true, true, true, true, true},
+				[]bool {false, false, false, false, false, false},
+				[]bool {false, false, false, false, false, false},
+				[]bool {true, true, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim=8.2.4081-1.cm1, curl",
 			Expected: [][]bool {
-				[]bool {true, true, true, false, true},
-				[]bool {false, true, true, false, false},
-				[]bool {false, false, true, true, true},
+				[]bool {true, true, true, false, true, false},
+				[]bool {false, true, true, false, false, false},
+				[]bool {false, false, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim=8.2.4081-1.cm1, vim=9.9.9999-9.cm1, curl",
 			Expected: [][]bool {
-				[]bool {true, true, true, false, true},
-				[]bool {false, false, false, false, false},
-				[]bool {false, false, true, true, true},
+				[]bool {true, true, true, false, true, false},
+				[]bool {false, false, false, false, false, false},
+				[]bool {false, false, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim=9.9.9999-9.cm1, curl",
 			Expected: [][]bool {
-				[]bool {false, true, true, false, false},
-				[]bool {false, false, false, false, false},
-				[]bool {true, true, true, true, true},
+				[]bool {false, true, true, false, false, false},
+				[]bool {false, false, false, false, false, false},
+				[]bool {true, true, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim=8.2.4081-1.cm1, curl=9.9.9999-9.cm1",
 			Expected: [][]bool {
-				[]bool {true, true, true, false, true},
-				[]bool {false, true, true, false, false},
-				[]bool {false, false, true, true, true},
+				[]bool {true, true, true, false, true, false},
+				[]bool {false, true, true, false, false, false},
+				[]bool {false, false, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim=8.2.4081-1.cm1, vim=9.9.9999-9.cm1, curl=9.9.9999-9.cm1",
 			Expected: [][]bool {
-				[]bool {true, true, true, false, true},
-				[]bool {false, false, false, false, false},
-				[]bool {false, false, true, true, true},
+				[]bool {true, true, true, false, true, false},
+				[]bool {false, false, false, false, false, false},
+				[]bool {false, false, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
-			Value: "vim=9.9.9999-9.cm1, curl=9.9.9999-9.cm1",
+			Value: "vim>1.0.0",
 			Expected: [][]bool {
-				[]bool {false, true, true, false, false},
-				[]bool {false, false, false, false, false},
-				[]bool {true, true, true, true, true},
+				[]bool {true, true, true, false, true, true},
+				[]bool {true, true, true, false, true, true},
+				[]bool {false, true, true, true, true, false},
+			},
+		},
+		criteriaTestCase{
+			Value: "vim<5.0.0",
+			Expected: [][]bool {
+				[]bool {false, false, false, false, false, true},
+				[]bool {false, false, false, false, false, true},
+				[]bool {true, true, true, true, true, false},
 			},
 		},
 	}


### PR DESCRIPTION
Version `5.1`

This change implements comparison operators for modules with semantic versions. A user, when creating an admission control rule for modules, will be able to use the new operators in the value field. For example, a module criterion value field of `vim>1.0.0` will check whether a scanned image has a the vim module with a greater version than `1.0.0`. These can be composed and combined in a number of powerful ways.

For example, to blacklist certain modules older than a certain version:
```
ruleType: "deny"
name: "module"
op: "containsAny"
value: "vim<2.0.0, curl<3.0.0, ssh<4.0.0"
```

The following operators are implemented: `>, <, >=, <=`

If a version comparison operator is used and either the criteria or module has an version that doesn't follow the semantic versioning syntax, then the comparison will automatically resolve to `false`.

All other behavior has been preserved, only some refactoring to reduce redundant logic.