### PR TITLE
NVSHAS-6606: keep showing wait for parent for nv enforcer pod

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -254,6 +254,10 @@ func isNeuvectorFunctionRole(role string, rootPid int) bool {
 			if strings.HasPrefix(cmd, entryPtSig) { // matched at least two criteria
 				return true
 			}
+
+			if strings.HasPrefix(cmd, "/usr/local/bin/monitor") { // last matching
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
Extending nv pod identifications.