### PR TITLE
NVSHAS-6593, fixing 'Missing policy mode for both src and dst' issue

### DIFF
--- a/controller/cache/policy.go
+++ b/controller/cache/policy.go
@@ -724,6 +724,11 @@ func fillAddrForGroup(name string, ports string, hostID string, apps []uint32, i
 			wlAddr := share.CLUSWorkloadAddr{
 				WlID: m.(string),
 			}
+			//set PolicyMode here to avoid 'Missing policy mode'
+			//errror at the adjustAction().
+			if wlCache1, ok1 := wlCacheMap[m.(string)]; ok1 {
+				wlAddr.PolicyMode, _ = getWorkloadEffectivePolicyMode(wlCache1)
+			}
 			if isDst {
 				fillPortsForWorkloadAddress(&wlAddr, ports, apps)
 			}


### PR DESCRIPTION
In the attached enforcer log there are many repeated errors as follows:

2022-07-28T20:06:40.543|ERRO|AGT|policy.adjustAction: Missing policy mode for both src and dst! - from=646230859bb90cc28e2f2ee32b90fba68279fc8ba7aedc1120ec4cd5bbd9554d id=10115 to=nv.address_group

this fix try to correct this issue.