### PR TITLE
NVSHAS-6560: Custom groups able to use Rancher's Namespace Tags

### DIFF
--- a/agent/bench.go
+++ b/agent/bench.go
@@ -977,10 +977,9 @@ func (b *Bench) runDockerContainerBench(containers map[string]string) ([]byte, e
 func (b *Bench) runCustomScript(wl *share.CLUSWorkload) []*benchItem {
 	items := make([]*benchItem, 0)
 	grpScripts := make(map[string]*share.CLUSCustomCheckGroup, 0)
-
 	groupMux.Lock()
 	for _, grp := range groups {
-		if grp.script != nil && share.IsGroupMember(grp.group, wl) {
+		if grp.script != nil && share.IsGroupMember(grp.group, wl, getDomainData(wl.Domain)) {
 			grpScripts[grp.group.Name] = grp.script
 		}
 	}

--- a/agent/cluster.go
+++ b/agent/cluster.go
@@ -772,6 +772,7 @@ func clusterLoop(existing utils.Set) {
 		cluster.RegisterStoreWatcher(share.CLUSNetworkStore, systemUpdateHandler, false)
 		cluster.RegisterStoreWatcher(share.CLUSNodeCommonProfileStore, systemUpdateHandler, agentEnv.kvCongestCtrl)
 		cluster.RegisterStoreWatcher(share.CLUSNodeProfileStoreKey(Host.ID), systemUpdateHandler, agentEnv.kvCongestCtrl)
+		cluster.RegisterStoreWatcher(share.CLUSConfigDomainStore, domainConfigUpdate, false)
 		cluster.RegisterLeadChangeWatcher(leadChangeHandler, leadAddr)
 	}()
 }

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1661,9 +1661,6 @@ func taskInterceptContainer(id string, info *container.ContainerMetaExtra) {
 
 	hostMode := isContainerNetHostMode(info, parent)
 	fillContainerProperties(c, parent, info, hostMode)
-
-	// entry to apply group policies
-	workloadJoinGroup(c)
 	prober.BuildProcessFamilyGroups(c.id, c.pid, parent == nil, info.Privileged)
 	prober.HandleAnchorModeChange(true, c.id, c.upperDir, c.pid)
 
@@ -1699,7 +1696,8 @@ func taskInterceptContainer(id string, info *container.ContainerMetaExtra) {
 		parent.pods.Add(id)
 		gInfoUnlock()
 	}
-
+	// entry to apply group policies
+	workloadJoinGroup(c)
 	updateAppPorts(c, parent)
 
 	notifyContainerChanges(c, parent, changeInit)

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -1799,7 +1799,7 @@ func startWorkerThread(ctx *Context) {
 					if o == nil && n != nil {
 						// ignore neuvector domain
 						if n.Name != localDev.Ctrler.Domain {
-							domainAdd(n.Name)
+							domainAdd(n.Name, n.Labels)
 						}
 					} else if o != nil && n == nil {
 						domainDelete(o.Name)
@@ -2151,7 +2151,7 @@ func (m CacheMethod) IsGroupMember(name, id string) bool {
 	defer cacheMutexRUnlock()
 	if groupCache, ok := groupCacheMap[name]; ok {
 		if wlCache, ok := wlCacheMap[id]; ok {
-			return share.IsGroupMember(groupCache.group, wlCache.workload)
+			return share.IsGroupMember(groupCache.group, wlCache.workload, getDomainData(wlCache.workload.Domain))
 		}
 	}
 	return true // unknown, but play safe here, it eventually flushed by other events

--- a/controller/cache/group.go
+++ b/controller/cache/group.go
@@ -1227,7 +1227,7 @@ func groupWorkloadJoin(id string, param interface{}) {
 			continue
 		}
 
-		if share.IsGroupMember(cache.group, wlc.workload) {
+		if share.IsGroupMember(cache.group, wlc.workload, getDomainData(wlc.workload.Domain)) && wlc.workload.ShareNetNS == "" { // POD-level only
 			if !cache.members.Contains(wl.ID) {
 				wlc.groups.Add(cache.group.Name)
 				cache.members.Add(wl.ID)
@@ -1339,7 +1339,8 @@ func refreshGroupMember(cache *groupCache) {
 		if !wlc.workload.Running {
 			continue
 		}
-		if share.IsGroupMember(cache.group, wlc.workload) {
+
+		if share.IsGroupMember(cache.group, wlc.workload, getDomainData(wlc.workload.Domain)) && wlc.workload.ShareNetNS == "" {	// POD-level only
 			cache.members.Add(wlc.workload.ID)
 			wlc.groups.Add(cache.group.Name)
 

--- a/controller/cache/group_test.go
+++ b/controller/cache/group_test.go
@@ -21,28 +21,28 @@ func TestGroupPosMatch(t *testing.T) {
 	wlc := workloadCache{
 		workload: &share.CLUSWorkload{Image: "redis", Domain: "billing"},
 	}
-	if share.IsWorkloadSelected(wlc.workload, cts) == false {
+	if share.IsWorkloadSelected(wlc.workload, cts, nil) == false {
 		t.Errorf("Workload %+v should be selected by %v.", *wlc.workload, cts)
 	}
 
 	wlc = workloadCache{
 		workload: &share.CLUSWorkload{Image: "mysql", Domain: "billing"},
 	}
-	if share.IsWorkloadSelected(wlc.workload, cts) == false {
+	if share.IsWorkloadSelected(wlc.workload, cts, nil) == false {
 		t.Errorf("Workload %+v should be selected by %v.", *wlc.workload, cts)
 	}
 
 	wlc = workloadCache{
 		workload: &share.CLUSWorkload{Image: "oracle", Domain: "billing"},
 	}
-	if share.IsWorkloadSelected(wlc.workload, cts) == true {
+	if share.IsWorkloadSelected(wlc.workload, cts, nil) == true {
 		t.Errorf("Workload %+v should not be selected by %v.", *wlc.workload, cts)
 	}
 
 	wlc = workloadCache{
 		workload: &share.CLUSWorkload{Image: "mysql", Domain: "sales"},
 	}
-	if share.IsWorkloadSelected(wlc.workload, cts) == true {
+	if share.IsWorkloadSelected(wlc.workload, cts, nil) == true {
 		t.Errorf("Workload %+v should not be selected by %v.", *wlc.workload, cts)
 	}
 
@@ -60,28 +60,28 @@ func TestGroupNegMatch(t *testing.T) {
 	wlc := workloadCache{
 		workload: &share.CLUSWorkload{Image: "redis", Domain: "billing"},
 	}
-	if share.IsWorkloadSelected(wlc.workload, cts) == true {
+	if share.IsWorkloadSelected(wlc.workload, cts, nil) == true {
 		t.Errorf("Workload %+v should not be selected by %v.", *wlc.workload, cts)
 	}
 
 	wlc = workloadCache{
 		workload: &share.CLUSWorkload{Image: "mysql", Domain: "billing"},
 	}
-	if share.IsWorkloadSelected(wlc.workload, cts) == true {
+	if share.IsWorkloadSelected(wlc.workload, cts, nil) == true {
 		t.Errorf("Workload %+v should not be selected by %v.", *wlc.workload, cts)
 	}
 
 	wlc = workloadCache{
 		workload: &share.CLUSWorkload{Image: "oracle", Domain: "billing"},
 	}
-	if share.IsWorkloadSelected(wlc.workload, cts) == false {
+	if share.IsWorkloadSelected(wlc.workload, cts, nil) == false {
 		t.Errorf("Workload %+v should be selected by %v.", *wlc.workload, cts)
 	}
 
 	wlc = workloadCache{
 		workload: &share.CLUSWorkload{Image: "oracle", Domain: "sales"},
 	}
-	if share.IsWorkloadSelected(wlc.workload, cts) == true {
+	if share.IsWorkloadSelected(wlc.workload, cts, nil) == true {
 		t.Errorf("Workload %+v should not be selected by %v.", *wlc.workload, cts)
 	}
 
@@ -99,28 +99,28 @@ func TestGroupMixMatch(t *testing.T) {
 	wlc := workloadCache{
 		workload: &share.CLUSWorkload{Image: "redis", Domain: "billing"},
 	}
-	if share.IsWorkloadSelected(wlc.workload, cts) == true {
+	if share.IsWorkloadSelected(wlc.workload, cts, nil) == true {
 		t.Errorf("Workload %+v should not be selected by %v.", *wlc.workload, cts)
 	}
 
 	wlc = workloadCache{
 		workload: &share.CLUSWorkload{Image: "mysql", Domain: "billing"},
 	}
-	if share.IsWorkloadSelected(wlc.workload, cts) == false {
+	if share.IsWorkloadSelected(wlc.workload, cts, nil) == false {
 		t.Errorf("Workload %+v should be selected by %v.", *wlc.workload, cts)
 	}
 
 	wlc = workloadCache{
 		workload: &share.CLUSWorkload{Image: "oracle", Domain: "billing"},
 	}
-	if share.IsWorkloadSelected(wlc.workload, cts) == false {
+	if share.IsWorkloadSelected(wlc.workload, cts, nil) == false {
 		t.Errorf("Workload %+v should be selected by %v.", *wlc.workload, cts)
 	}
 
 	wlc = workloadCache{
 		workload: &share.CLUSWorkload{Image: "oracle", Domain: "sales"},
 	}
-	if share.IsWorkloadSelected(wlc.workload, cts) == true {
+	if share.IsWorkloadSelected(wlc.workload, cts, nil) == true {
 		t.Errorf("Workload %+v should not be selected by %v.", *wlc.workload, cts)
 	}
 
@@ -138,14 +138,14 @@ func TestGroupEqualMatch(t *testing.T) {
 	wlc := workloadCache{
 		workload: &share.CLUSWorkload{Image: "redis", Domain: "billing"},
 	}
-	if share.IsWorkloadSelected(wlc.workload, cts) == false {
+	if share.IsWorkloadSelected(wlc.workload, cts, nil) == false {
 		t.Errorf("Workload %+v should be selected by %v.", *wlc.workload, cts)
 	}
 
 	wlc = workloadCache{
 		workload: &share.CLUSWorkload{Image: "redis.abc", Domain: "billing"},
 	}
-	if share.IsWorkloadSelected(wlc.workload, cts) == false {
+	if share.IsWorkloadSelected(wlc.workload, cts, nil) == false {
 		t.Errorf("Workload %+v should be selected by %v.", *wlc.workload, cts)
 	}
 
@@ -157,7 +157,7 @@ func TestGroupEqualMatch(t *testing.T) {
 	wlc = workloadCache{
 		workload: &share.CLUSWorkload{Image: "redis", Domain: "billing"},
 	}
-	if share.IsWorkloadSelected(wlc.workload, cts) == true {
+	if share.IsWorkloadSelected(wlc.workload, cts, nil) == true {
 		t.Errorf("Workload %+v should not be selected by %v.", *wlc.workload, cts)
 	}
 	postTest()

--- a/controller/kv/create.go
+++ b/controller/kv/create.go
@@ -917,9 +917,9 @@ func createDefaultComplianceProfile() {
 }
 
 func createDefaultDomains() {
-	clusHelper.PutDomain(&share.CLUSDomain{Name: api.DomainContainers, Dummy: true, Tags: []string{}}, 0)
-	clusHelper.PutDomain(&share.CLUSDomain{Name: api.DomainNodes, Dummy: true, Tags: []string{}}, 0)
-	clusHelper.PutDomain(&share.CLUSDomain{Name: api.DomainImages, Dummy: true, Tags: []string{}}, 0)
+	clusHelper.PutDomain(&share.CLUSDomain{Name: api.DomainContainers, Dummy: true, Tags: []string{}, Labels: map[string]string{}}, 0)
+	clusHelper.PutDomain(&share.CLUSDomain{Name: api.DomainNodes, Dummy: true, Tags: []string{}, Labels: map[string]string{}}, 0)
+	clusHelper.PutDomain(&share.CLUSDomain{Name: api.DomainImages, Dummy: true, Tags: []string{}, Labels: map[string]string{}}, 0)
 }
 
 func setDefaultUnusedGroupAging() {

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -974,10 +974,11 @@ type CLUSWorkload struct {
 }
 
 type CLUSDomain struct {
-	Name    string   `json:"name"`
-	Dummy   bool     `json:"dummy"`
-	Disable bool     `json:"disable"`
-	Tags    []string `json:"tags"`
+	Name    string            `json:"name"`
+	Dummy   bool              `json:"dummy"`
+	Disable bool              `json:"disable"`
+	Tags    []string          `json:"tags"`		// compliance tags
+	Labels  map[string]string `json:"labels"`	// from k8s
 }
 
 type CLUSCriteriaEntry struct {


### PR DESCRIPTION
To specify the matching criteria: ns labels and pod labels. When configuring a custom group,

"POD" label
environment=production

"NS" label ( "ns:" is a dedicated prefix for the ns tags)
ns.environment=production

Improvement: the process/file calculation at enforcers to handle correct calculations by timing causes. 