### PR TITLE
NVSHAS-6654 fix >= and <= operators in module admission control rule

### DIFF
--- a/controller/cache/admission_test.go
+++ b/controller/cache/admission_test.go
@@ -264,58 +264,58 @@ func TestIsModulesCriterionMet(t *testing.T) {
 		/********************************************/
 		[]*share.ScanModule{
 			&share.ScanModule{
-				Name: "vim",
+				Name:    "vim",
 				Version: "8.2.4081-1.cm1",
 			},
 		},
 		/********************************************/
 		[]*share.ScanModule{
 			&share.ScanModule{
-				Name: "vim",
+				Name:    "vim",
 				Version: "8.2.4081-1.cm1",
 			},
 			&share.ScanModule{
-				Name: "curl",
+				Name:    "curl",
 				Version: "9.9.9999-9.cm1",
 			},
 		},
 		/********************************************/
 		[]*share.ScanModule{
 			&share.ScanModule{
-				Name: "vim",
+				Name:    "vim",
 				Version: "8.2.4081-1.cm1",
 			},
 			&share.ScanModule{
-				Name: "curl",
+				Name:    "curl",
 				Version: "9.9.9999-9.cm1",
 			},
 			&share.ScanModule{
-				Name: "random-package",
+				Name:    "random-package",
 				Version: "1.0.0000-0.cm1",
 			},
 		},
 		/********************************************/
 		[]*share.ScanModule{
 			&share.ScanModule{
-				Name: "random-package",
+				Name:    "random-package",
 				Version: "1.0.0000-0.cm1",
 			},
 		},
 		/********************************************/
 		[]*share.ScanModule{
 			&share.ScanModule{
-				Name: "vim",
+				Name:    "vim",
 				Version: "8.2.4081-1.cm1",
 			},
 			&share.ScanModule{
-				Name: "random-package",
+				Name:    "random-package",
 				Version: "1.0.0000-0.cm1",
 			},
 		},
 		/********************************************/
 		[]*share.ScanModule{
 			&share.ScanModule{
-				Name: "vim",
+				Name:    "vim",
 				Version: "2.0.0",
 			},
 		},
@@ -323,113 +323,121 @@ func TestIsModulesCriterionMet(t *testing.T) {
 	}
 
 	type criteriaTestCase struct {
-		Value string
+		Value    string
 		Expected [][]bool // expected isModulesCriterionMet result for above moduleSets
 	}
 
 	cases := []criteriaTestCase{
 		criteriaTestCase{
 			Value: "vim",
-			Expected: [][]bool {
-				[]bool {true, true, true, false, true, true}, // first array is for CriteriaOpContainsAny
-				[]bool {true, true, true, false, true, true}, // second array is for CriteriaOpContainsAll
-				[]bool {false, true, true, true, true, false}, // third array is for CriteriaOpContainsOtherThan
+			Expected: [][]bool{
+				[]bool{true, true, true, false, true, true},  // first array is for CriteriaOpContainsAny
+				[]bool{true, true, true, false, true, true},  // second array is for CriteriaOpContainsAll
+				[]bool{false, true, true, true, true, false}, // third array is for CriteriaOpContainsOtherThan
 			},
 		},
 		criteriaTestCase{
 			Value: "vim, curl",
-			Expected: [][]bool {
-				[]bool {true, true, true, false, true, true},
-				[]bool {false, true, true, false, false, false},
-				[]bool {false, false, true, true, true, false},
+			Expected: [][]bool{
+				[]bool{true, true, true, false, true, true},
+				[]bool{false, true, true, false, false, false},
+				[]bool{false, false, true, true, true, false},
 			},
 		},
 		criteriaTestCase{
 			Value: "curl",
-			Expected: [][]bool {
-				[]bool {false, true, true, false, false, false},
-				[]bool {false, true, true, false, false, false},
-				[]bool {true, true, true, true, true, true},
+			Expected: [][]bool{
+				[]bool{false, true, true, false, false, false},
+				[]bool{false, true, true, false, false, false},
+				[]bool{true, true, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim=8.2.4081-1.cm1",
-			Expected: [][]bool {
-				[]bool {true, true, true, false, true, false},
-				[]bool {true, true, true, false, true, false},
-				[]bool {false, true, true, true, true, true},
+			Expected: [][]bool{
+				[]bool{true, true, true, false, true, false},
+				[]bool{true, true, true, false, true, false},
+				[]bool{false, true, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim=8.2.4081-1.cm1, vim=9.9.9999-9.cm1",
-			Expected: [][]bool {
-				[]bool {true, true, true, false, true, false},
-				[]bool {false, false, false, false, false, false},
-				[]bool {false, true, true, true, true, true},
+			Expected: [][]bool{
+				[]bool{true, true, true, false, true, false},
+				[]bool{false, false, false, false, false, false},
+				[]bool{false, true, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim=9.9.9999-9.cm1",
-			Expected: [][]bool {
-				[]bool {false, false, false, false, false, false},
-				[]bool {false, false, false, false, false, false},
-				[]bool {true, true, true, true, true, true},
+			Expected: [][]bool{
+				[]bool{false, false, false, false, false, false},
+				[]bool{false, false, false, false, false, false},
+				[]bool{true, true, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim=8.2.4081-1.cm1, curl",
-			Expected: [][]bool {
-				[]bool {true, true, true, false, true, false},
-				[]bool {false, true, true, false, false, false},
-				[]bool {false, false, true, true, true, true},
+			Expected: [][]bool{
+				[]bool{true, true, true, false, true, false},
+				[]bool{false, true, true, false, false, false},
+				[]bool{false, false, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim=8.2.4081-1.cm1, vim=9.9.9999-9.cm1, curl",
-			Expected: [][]bool {
-				[]bool {true, true, true, false, true, false},
-				[]bool {false, false, false, false, false, false},
-				[]bool {false, false, true, true, true, true},
+			Expected: [][]bool{
+				[]bool{true, true, true, false, true, false},
+				[]bool{false, false, false, false, false, false},
+				[]bool{false, false, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim=9.9.9999-9.cm1, curl",
-			Expected: [][]bool {
-				[]bool {false, true, true, false, false, false},
-				[]bool {false, false, false, false, false, false},
-				[]bool {true, true, true, true, true, true},
+			Expected: [][]bool{
+				[]bool{false, true, true, false, false, false},
+				[]bool{false, false, false, false, false, false},
+				[]bool{true, true, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim=8.2.4081-1.cm1, curl=9.9.9999-9.cm1",
-			Expected: [][]bool {
-				[]bool {true, true, true, false, true, false},
-				[]bool {false, true, true, false, false, false},
-				[]bool {false, false, true, true, true, true},
+			Expected: [][]bool{
+				[]bool{true, true, true, false, true, false},
+				[]bool{false, true, true, false, false, false},
+				[]bool{false, false, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim=8.2.4081-1.cm1, vim=9.9.9999-9.cm1, curl=9.9.9999-9.cm1",
-			Expected: [][]bool {
-				[]bool {true, true, true, false, true, false},
-				[]bool {false, false, false, false, false, false},
-				[]bool {false, false, true, true, true, true},
+			Expected: [][]bool{
+				[]bool{true, true, true, false, true, false},
+				[]bool{false, false, false, false, false, false},
+				[]bool{false, false, true, true, true, true},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim>1.0.0",
-			Expected: [][]bool {
-				[]bool {true, true, true, false, true, true},
-				[]bool {true, true, true, false, true, true},
-				[]bool {false, true, true, true, true, false},
+			Expected: [][]bool{
+				[]bool{true, true, true, false, true, true},
+				[]bool{true, true, true, false, true, true},
+				[]bool{false, true, true, true, true, false},
 			},
 		},
 		criteriaTestCase{
 			Value: "vim<5.0.0",
-			Expected: [][]bool {
-				[]bool {false, false, false, false, false, true},
-				[]bool {false, false, false, false, false, true},
-				[]bool {true, true, true, true, true, false},
+			Expected: [][]bool{
+				[]bool{false, false, false, false, false, true},
+				[]bool{false, false, false, false, false, true},
+				[]bool{true, true, true, true, true, false},
+			},
+		},
+		criteriaTestCase{
+			Value: "vim<=2.0.0",
+			Expected: [][]bool{
+				[]bool{false, false, false, false, false, true},
+				[]bool{false, false, false, false, false, true},
+				[]bool{true, true, true, true, true, false},
 			},
 		},
 	}
@@ -445,9 +453,9 @@ func TestIsModulesCriterionMet(t *testing.T) {
 			for _, testCase := range cases {
 				met, _ := isModulesCriterionMet(
 					&share.CLUSAdmRuleCriterion{
-						Name: share.CriteriaKeyModules,
-						Op: op,
-						Value: testCase.Value,
+						Name:       share.CriteriaKeyModules,
+						Op:         op,
+						Value:      testCase.Value,
 						ValueSlice: strings.Split(testCase.Value, ","),
 					},
 					moduleSet,

--- a/share/utils/version_test.go
+++ b/share/utils/version_test.go
@@ -1,34 +1,130 @@
 package utils
 
 import (
+	"fmt"
 	"testing"
 )
 
+type versionCompareTestCase struct {
+	versionA       string
+	versionB       string
+	expectedResult int
+}
+
+func (tc *versionCompareTestCase) FailureMessage() string {
+	var expectationMessage string
+	switch tc.expectedResult {
+	case -1:
+		expectationMessage = "an earlier version than"
+	case 0:
+		expectationMessage = "an equal version to"
+	case 1:
+		expectationMessage = "a later version than"
+	}
+	return fmt.Sprintf("%s should be considered %s %s", tc.versionA, expectationMessage, tc.versionB)
+}
+
 func TestVersionCompare(t *testing.T) {
-	// The first element should be less than the second
-	cases := [][]string{
-		[]string{"2.9.1-6.el7_2.2", "2.9.1-6.el7.4"},
-		[]string{"4.18.0-193.19.1.el8", "4.18.0-193.19.1.el8_2"},
-		[]string{"4.18.0-193.el8", "4.18.0-193.19.1.el8_2"},
-		[]string{"4.18.0-193.19.1.el8", "4.18.0-193.19.1.el8_2"},
-		[]string{"4.18.0.el8", "4.18.0.el8_2"},
-		[]string{"1.6_rc1-r0", "1.6-r1"},
-		[]string{"1.2.2_pre2-r0", "1.2.2-r0"},
-		[]string{"2:svn28991.0-45.el7", "2:svn28991.1-45.el7"},
-		[]string{"2:svn28991.0-45.el7", "3:svn28991.0-45.el7"},
+	testCases := []versionCompareTestCase{
+		{
+			versionA:       "2.9.1-6.el7_2.2",
+			versionB:       "2.9.1-6.el7.4",
+			expectedResult: -1,
+		},
+		{
+			versionA:       "4.18.0-193.19.1.el8",
+			versionB:       "4.18.0-193.19.1.el8_2",
+			expectedResult: -1,
+		},
+		{
+			versionA:       "4.18.0-193.el8",
+			versionB:       "4.18.0-193.19.1.el8_2",
+			expectedResult: -1,
+		},
+		{
+			versionA:       "4.18.0-193.19.1.el8",
+			versionB:       "4.18.0-193.19.1.el8_2",
+			expectedResult: -1,
+		},
+		{
+			versionA:       "4.18.0.el8",
+			versionB:       "4.18.0.el8_2",
+			expectedResult: -1,
+		},
+		{
+			versionA:       "1.6_rc1-r0",
+			versionB:       "1.6-r1",
+			expectedResult: -1,
+		},
+		{
+			versionA:       "1.2.2_pre2-r0",
+			versionB:       "1.2.2-r0",
+			expectedResult: -1,
+		},
+		{
+			versionA:       "2:svn28991.0-45.el7",
+			versionB:       "2:svn28991.1-45.el7",
+			expectedResult: -1,
+		},
+		{
+			versionA:       "2:svn28991.0-45.el7",
+			versionB:       "3:svn28991.0-45.el7",
+			expectedResult: -1,
+		},
+		{
+			versionA:       "1.2.2-r0",
+			versionB:       "1.2.2-r0",
+			expectedResult: 0,
+		},
+		{
+			versionA:       "1.2.3",
+			versionB:       "1.2.2",
+			expectedResult: 1,
+		},
+		// Since our version type implementation is based on debian versions, and not
+		// exactly the semantic version protocol, "1.2.2-r0" is actually a later
+		// version than "1.2.2" since the "-r0" component in a debian version implies
+		// that this is a revision of a package for the debian environment
+		// (in semantic versioning, the hyphen actually denotes a prerelease tag)
+		{
+			versionA:       "1.2.2-r0",
+			versionB:       "1.2.2",
+			expectedResult: 1,
+		},
+		{
+			versionA:       "7.2_p2-r0",
+			versionB:       "7.2_p2-r0",
+			expectedResult: 0,
+		},
+		{
+			versionA:       "7.3",
+			versionB:       "7.2_p2-r0",
+			expectedResult: 1,
+		},
+		{
+			versionA:       "4.20.0",
+			versionB:       "4.18.0.el8_2",
+			expectedResult: 1,
+		},
 	}
 
-	for i, _ := range cases {
-		c1, err := NewVersion(cases[i][0])
+	for i, testCase := range testCases {
+		c1, err := NewVersion(testCase.versionA)
 		if err != nil {
 			t.Errorf("%d: %s - %s", i, c1, err)
 		}
-		c2, err := NewVersion(cases[i][1])
+		c2, err := NewVersion(testCase.versionB)
 		if err != nil {
 			t.Errorf("%d: %s - %s", i, c2, err)
 		}
-		if c1.Compare(c2) >= 0 {
-			t.Errorf("%d: %s should be smaller than %s", i, c1, c2)
+		if got := c1.Compare(c2); got != testCase.expectedResult {
+			t.Errorf(
+				"failed version compare test case %d, got %d expected %d: %s",
+				i,
+				got,
+				testCase.expectedResult,
+				testCase.FailureMessage(),
+			)
 		}
 	}
 }


### PR DESCRIPTION
The issue was the way I was "finding" the operator.

When a user enters a criterion value such as `myKey<=myExample`, the code previously resolved the operator as `=`. These changes establish hard checks for those possibilities, and may be worth extracting into its own type upon further expansion.