### PR TITLE
NVSHAS-6635: unable to detect interface for app containers in oc 4.9

### DIFF
--- a/agent/group_profile.go
+++ b/agent/group_profile.go
@@ -830,7 +830,7 @@ func applyFileGroupProfile(c *containerData) bool {
 
 		//
 		fileWatcher.ContainerCleanup(c.pid)
-		if len(file.Filters) > 0 {
+		if len(file.Filters) > 0 && c.pid != 0 {
 			fileWatcher.StartWatch(c.id, c.pid, config, c.capBlock, false)
 		}
 		return true

--- a/agent/probe/netlink/socket.go
+++ b/agent/probe/netlink/socket.go
@@ -161,7 +161,7 @@ func (ns *NetlinkSocket) EPollReceive(tv *syscall.Timeval) ([]syscall.NetlinkMes
 	timeout := int(tv.Nano() / 1000000)
 	n, err = syscall.EpollWait(epfd, events[:], timeout)
 	if err != nil {
-		return nil, fmt.Errorf("epoll_wait: %v", err)
+		return nil, err
 	} else if n > 0 {
 		return ns.Receive()
 	}


### PR DESCRIPTION
For k8s systems, the POD's Pid is 0 and its network setting is not configured in host mode. 

(1)  Inspect one of the app containers to obtain the network interface information.
(2)  Remove unnecessary monitorings on the containers whose root Pid is 0.