### PR TITLE
NVSHAS-6663: part#1, controller, new label on namespace is not added in kv consul

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -1800,13 +1800,12 @@ func startWorkerThread(ctx *Context) {
 					if ev.ResourceOld != nil {
 						o = ev.ResourceOld.(*resource.Namespace)
 					}
-					if o == nil && n != nil {
-						// ignore neuvector domain
-						if n.Name != localDev.Ctrler.Domain {
-							domainAdd(n.Name, n.Labels)
+					if n == nil {
+						if o != nil {
+							domainDelete(o.Name)
 						}
-					} else if o != nil && n == nil {
-						domainDelete(o.Name)
+					} else {
+						domainAdd(n.Name, n.Labels)
 					}
 					if n != nil {
 						if skip := atomic.LoadUint32(&nvDeployDeleted); skip == 0 && isLeader() && admission.IsNsSelectorSupported() {


### PR DESCRIPTION
Part#1 controller side:  fix the correct PODs selected by the updated namespace labels.

This is from the k8s namespace resource watcher. It should not have our predefined domain, like "_images", "_containers" or "_nodes". Thus, the namespace data can be always updated during runtime. 


TODO: 
Part#2: enforcer side: re-calculate process/file profiles.