### PR TITLE
NVSHAS-6477 add simple psa admission rule

### DIFF
--- a/controller/nvk8sapi/nvvalidatewebhookcfg/admission/admission.go
+++ b/controller/nvk8sapi/nvvalidatewebhookcfg/admission/admission.go
@@ -169,6 +169,7 @@ var allSetOps = []string{share.CriteriaOpContainsAll, share.CriteriaOpContainsAn
 var setOps1 = []string{share.CriteriaOpContainsAny, share.CriteriaOpNotContainsAny}
 var boolOps = []string{"true", "false"}
 var boolTrueOp = []string{"true"}
+var psaPolicies = []string{share.PsaPolicyRestricted, share.PsaPolicyBaseline}
 
 func (info AdmContainerInfo) MarshalJSON() ([]byte, error) {
 	return json.Marshal(*newJSONAdmContainerInfo(&info))
@@ -385,6 +386,12 @@ func getAdmK8sDenyRuleOptions() map[string]*api.RESTAdmissionRuleOption {
 				Name:     share.CriteriaKeyModules,
 				Ops:      allSetOps,
 				MatchSrc: api.MatchSrcImage,
+			},
+			share.CriteriaKeyPsaCompliance: &api.RESTAdmissionRuleOption{
+				Name:     share.CriteriaKeyPsaCompliance,
+				Ops:      []string{share.CriteriaOpEqual},
+				Values:   psaPolicies,
+				MatchSrc: api.MatchSrcBoth,
 			},
 		}
 	}

--- a/share/criteria.go
+++ b/share/criteria.go
@@ -45,7 +45,8 @@ const (
 	CriteriaKeyAllowPrivEscalation string = "allowPrivEscalation"
 	CriteriaKeyPspCompliance       string = "pspCompliance" // psp compliance violation
 	CriteriaKeyRequestLimit        string = "resourceLimit"
-	CriteriaKeyModules			   string = "modules"
+	CriteriaKeyModules             string = "modules"
+	CriteriaKeyPsaCompliance       string = "psaCompliance" // psa compliance violation
 )
 
 const (
@@ -79,6 +80,11 @@ const (
 )
 
 const CriteriaValueAny string = "any"
+
+const (
+	PsaPolicyRestricted string = "restricted"
+	PsaPolicyBaseline   string = "baseline"
+)
 
 func IsSvcIpGroupMember(usergroup *CLUSGroup, svcipgroup *CLUSGroup) bool {
 	if usergroup == nil || svcipgroup == nil {


### PR DESCRIPTION
This is a simple initial implementation of an admission control rule that checks whether a deployment is in compliance of one of two custom NeuVector PSA policies: `baseline` and `restricted`. This mirrors the native K8s implementation, however the rules that govern the policies are different (mostly stripped down). This rule can be combined with a namespace targeting rule in admission control to mirror the native K8s behavior of setting a policy to a particular namespace.

Currently, the policies are a broken up version of the old PSP rule:

Baseline
> No host namespace sharing (network, PID, IPC)
> No privileged containers

Restricted
> All baseline rules
> No privilege escalation
> Containers must run as non-root users

No additional conditions have been added on top of what existed in the previous PSP rule. This is mainly because K8s PSA only slightly expands the scope of its policies compared to PSPs previous capabilities. Regardless, more discussion should be had regarding whether the scope of our PSA implementation is substantial.