### PR TITLE
NVSHAS-6693: A flag to turn off runtime protection

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -259,6 +259,7 @@ func main() {
 	disable_kv_congest_ctl := flag.Bool("no_kvc", false, "disable kv congestion control")
 	disable_scan_secrets := flag.Bool("no_scrt", false, "disable secret scans")
 	disable_auto_benchmark := flag.Bool("no_auto_benchmark", false, "disable auto benchmark")
+	disable_system_protection := flag.Bool("no_sys_protect", false, "disable system protections")
 	flag.Parse()
 
 	if *debug {
@@ -290,6 +291,12 @@ func main() {
 	if *disable_auto_benchmark {
 		log.Info("Auto benchmark is disabled")
 		agentEnv.autoBenchmark = false
+	}
+
+	agentEnv.systemProfiles = true
+	if *disable_system_protection {
+		log.Info("System protection is disabled (process/file profiles)")
+		agentEnv.systemProfiles = false
 	}
 
 	if *join != "" {
@@ -541,6 +548,7 @@ func main() {
 	faEndChan := make(chan bool, 1)
 	fsmonEndChan := make(chan bool, 1)
 	probeConfig := probe.ProbeConfig{
+		ProfileEnable:        agentEnv.systemProfiles,
 		Pid:                  Agent.Pid,
 		PidMode:              Agent.PidMode,
 		DpTaskCallback:       dpTaskCallback,
@@ -570,6 +578,7 @@ func main() {
 	}
 
 	fmonConfig := fsmon.FileMonitorConfig{
+		ProfileEnable:  agentEnv.systemProfiles,
 		IsAufs:         global.RT.GetStorageDriver() == "aufs",
 		EnableTrace:    *show_monitor_trace,
 		EndChan:        fsmonEndChan,
@@ -610,7 +619,10 @@ func main() {
 
 	go statsLoop(bPassiveContainerDetect)
 	go timerLoop()
-	go group_profile_loop()
+
+	if agentEnv.systemProfiles {
+		go group_profile_loop()
+	}
 
 	// Wait for SIGTREM
 	go func() {

--- a/agent/group_profile.go
+++ b/agent/group_profile.go
@@ -208,8 +208,11 @@ func addGroupCache(name string, grp share.CLUSGroup) bool {
 
 ///////
 func updateGroupProfileCache(nType cluster.ClusterNotifyType, name string, obj interface{}) bool {
-	log.WithFields(log.Fields{"group": name}).Debug("GRP:")
+	if !agentEnv.systemProfiles {
+		return false
+	}
 
+	log.WithFields(log.Fields{"group": name}).Debug("GRP:")
 	procUpdated := false
 	fileUpdated := false
 	grpCacheLock.Lock()
@@ -858,6 +861,10 @@ func uppdateFileGroupAccess(c *containerData) bool {
 
 /////// "host" is not an actual workload, will NOT enter this function
 func workloadJoinGroup(c *containerData) {
+	if !agentEnv.systemProfiles {
+		return
+	}
+
 	log.WithFields(log.Fields{"id": c.id}).Debug("GRP: ")
 
 	wlCacheLock.Lock()
@@ -906,6 +913,10 @@ func workloadJoinGroup(c *containerData) {
 
 ///////
 func workloadLeaveGroup(c *containerData) {
+	if !agentEnv.systemProfiles {
+		return
+	}
+
 	// log.WithFields(log.Fields{"cid": id}).Debug("GRP: ")
 	// remove monitors
 	prober.RemoveProcessControl(c.id)
@@ -1106,6 +1117,10 @@ func updateContainerFamilyTrees(name string) {
 }
 
 func domainChange(domain share.CLUSDomain) {
+	if !agentEnv.systemProfiles {
+		return
+	}
+
 	log.WithFields(log.Fields{"domain": domain}).Debug()
 
 	var groups []*groupProfileData

--- a/agent/probe/probe.go
+++ b/agent/probe/probe.go
@@ -33,6 +33,7 @@ type procDelayExit struct {
 }
 
 type Probe struct {
+	bProfileEnable       bool	// default: true
 	agentPid             int
 	agentMntNsId         uint64
 	dpTaskCallback       dp.DPTaskCallback
@@ -457,6 +458,7 @@ func (p *Probe) delayProcReportService() {
 func New(pc *ProbeConfig) (*Probe, error) {
 	log.Info()
 	p := &Probe{
+		bProfileEnable:       pc.ProfileEnable,
 		agentPid:             pc.Pid,
 		dpTaskCallback:       pc.DpTaskCallback,
 		notifyTaskChan:       pc.NotifyTaskChan,
@@ -503,6 +505,10 @@ func New(pc *ProbeConfig) (*Probe, error) {
 		mLog.SetLevel(log.DebugLevel)
 	}
 
+	if !p.bProfileEnable {
+		log.Info("Process profiler is disabled")
+	}
+
 	// p.pidNetlink = false // for test scan mode
 	if err := global.SYS.CallNetNamespaceFunc(1, p.cbOpenNetlinkSockets, nil); err != nil {
 		return nil, err
@@ -512,7 +518,7 @@ func New(pc *ProbeConfig) (*Probe, error) {
 	bAufsDriver := global.RT.GetStorageDriver() == "aufs"
 	if bAufsDriver {
 		log.WithFields(log.Fields{"runtime": global.RT.String(), "storage driver": global.RT.GetStorageDriver()}).Info("PROC: ")
-	} else {
+	} else if p.bProfileEnable {
 		var ok bool
 		if p.fAccessCtl, ok = NewFileAccessCtrl(p); !ok {
 			log.Info("PROC: Process control is not supported")
@@ -524,9 +530,11 @@ func New(pc *ProbeConfig) (*Probe, error) {
 		p.FaEndChan <- true
 	}
 
-	var ok bool
-	if p.fsnCtr, ok = NewFsnCenter(p, global.RT.GetStorageDriver()); !ok {
-		log.Error("FSN: failed")
+	if p.bProfileEnable {
+		var ok bool
+		if p.fsnCtr, ok = NewFsnCenter(p, global.RT.GetStorageDriver()); !ok {
+			log.Error("FSN: failed")
+		}
 	}
 
 	p.selfID, _, _ = global.SYS.GetSelfContainerID()
@@ -554,11 +562,13 @@ func New(pc *ProbeConfig) (*Probe, error) {
 func (p *Probe) Close() {
 	log.Info()
 
-	if p.fAccessCtl != nil {
-		p.fAccessCtl.Close()
+	if p.bProfileEnable {
+		if p.fAccessCtl != nil {
+			p.fAccessCtl.Close()
+		}
+		p.fsnCtr.Close()
 	}
 
-	p.fsnCtr.Close()
 	p.nsInet.Close()
 
 	if p.pidNetlink {

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -1677,6 +1677,10 @@ func (p *Probe) isAgentChildren(proc *procInternal, id string) bool {
 
 // Application event handler: locked by calling functions
 func (p *Probe) evaluateApplication(proc *procInternal, id string, bKeepAlive bool) {
+	if !p.bProfileEnable {
+		return
+	}
+
 	if proc.path == "" || proc.path == "/" {
 		// path is required, it can not be either "" or "/".
 		// log.WithFields(log.Fields{"proc": proc}).Debug("PROC: ignored, no path")
@@ -2647,8 +2651,10 @@ func (p *Probe) applyProcessBlockingPolicy(id string, pid int, pg *share.CLUSPro
 
 //////
 func (p *Probe) HandleProcessPolicyChange(id string, pid int, pg *share.CLUSProcessProfile, bAddContainer, bBlocking bool) {
-	p.processProfileReeval(id, pg, bAddContainer)
-	p.applyProcessBlockingPolicy(id, pid, pg, bBlocking)
+	if p.bProfileEnable {
+		p.processProfileReeval(id, pg, bAddContainer)
+		p.applyProcessBlockingPolicy(id, pid, pg, bBlocking)
+	}
 }
 
 func (p *Probe) SetMonitorTrace(bEnable bool) {
@@ -2773,6 +2779,9 @@ func negativeResByMode(mode string) string {
 
 func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInternal, ppe *share.CLUSProcessProfileEntry, bFromPmon bool) bool {
 	var bPass, bImageFile, bModified bool
+	if !p.bProfileEnable {
+		return true
+	}
 
 	if id == "" { // nodes
 		return true
@@ -2970,6 +2979,9 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 
 func (p *Probe) BuildProcessFamilyGroups(id string, rootPid int, bSandboxPod, bPrivileged bool) {
 	//log.WithFields(log.Fields{"id": id, "pid": rootPid}).Debug("SHD:")
+	if !p.bProfileEnable {
+		return
+	}
 
 	p.lockProcMux()
 	defer p.unlockProcMux()
@@ -3043,6 +3055,9 @@ func (p *Probe) BuildProcessFamilyGroups(id string, rootPid int, bSandboxPod, bP
 }
 
 func (p *Probe) HandleAnchorModeChange(bAdd bool, id, cPath string, rootPid int) {
+	if !p.bProfileEnable {
+		return
+	}
 	if bAdd {
 		if rootPid != 0 {
 			if ok, files := p.fsnCtr.AddContainer(id, cPath, rootPid); !ok {
@@ -3076,6 +3091,10 @@ func (p *Probe) HandleAnchorModeChange(bAdd bool, id, cPath string, rootPid int)
 }
 
 func (p *Probe) UpdateFromAllowRule(id, path string) {
+	if !p.bProfileEnable {
+		return
+	}
+
 	p.lockProcMux()
 	if c, ok := p.containerMap[id]; ok {
 		if _, ok = c.fInfo[path]; ok {

--- a/agent/probe/types.go
+++ b/agent/probe/types.go
@@ -11,6 +11,7 @@ import (
 )
 
 type ProbeConfig struct {
+	ProfileEnable        bool
 	Pid                  int
 	PidMode              string
 	DpTaskCallback       dp.DPTaskCallback

--- a/agent/types.go
+++ b/agent/types.go
@@ -20,6 +20,7 @@ type AgentEnvInfo struct {
 	kvCongestCtrl        bool
 	scanSecrets          bool
 	autoBenchmark        bool
+	systemProfiles       bool
 }
 
 const (

--- a/monitor/monitor.c
+++ b/monitor/monitor.c
@@ -43,6 +43,7 @@
 #define ENV_NO_KV_CONGEST_CTL  "ENF_NO_KV_CONGESTCTL"
 #define ENV_NO_SCAN_SECRETS    "ENF_NO_SECRET_SCANS"
 #define ENV_NO_AUTO_BENCHMARK  "ENF_NO_AUTO_BENCHMARK"
+#define ENV_NO_SYSTEM_PROTECT  "ENF_NO_SYSTEM_PROFILES"
 #define ENV_PWD_VALID_UNIT     "PWD_VALID_UNIT"
 #define ENV_RANCHER_EP         "RANCHER_EP"
 #define ENV_RANCHER_SSO        "RANCHER_SSO"
@@ -463,6 +464,10 @@ static pid_t fork_exec(int i)
         if (getenv(ENV_NO_AUTO_BENCHMARK)) {
             args[a ++] = "-no_auto_benchmark";
         }
+        if (getenv(ENV_NO_SYSTEM_PROTECT)) {
+            args[a ++] = "-no_sys_protect";
+        }
+
         args[a] = NULL;
         break;
     default:

--- a/share/fsmon/monitor.go
+++ b/share/fsmon/monitor.go
@@ -114,6 +114,7 @@ type groupInfo struct {
 
 type FileWatch struct {
 	mux        sync.Mutex
+	bEnable    bool		// profile function is enabled, default: true
 	aufs       bool
 	fanotifier *FaNotify
 	inotifier  *Inotify
@@ -188,6 +189,7 @@ type FsmonConfig struct {
 }
 
 type FileMonitorConfig struct {
+	ProfileEnable  bool
 	IsAufs         bool
 	EnableTrace    bool
 	EndChan        chan bool
@@ -207,11 +209,29 @@ func NewFileWatcher(config *FileMonitorConfig) (*FileWatch, error) {
 		mLog.SetLevel(log.DebugLevel)
 	}
 
+	fw := &FileWatch{
+		bEnable:    config.ProfileEnable,
+		aufs:       config.IsAufs,
+		fileEvents: make(map[string]*fileMod),
+		groups:     make(map[int]*groupInfo),
+		sendrpt:    config.SendReport,
+		sendRule:   config.SendAccessRule,
+		estRuleSrc: config.EstRule,
+		walkerTask: config.WalkerTask,
+	}
+
+	if !fw.bEnable {
+		log.Info("File monitor is disabled")
+		config.EndChan <- true
+		return fw, nil
+	}
+
 	n, err := NewFaNotify(config.EndChan, config.PidLookup, global.SYS)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Open fanotify fail")
 		return nil, err
 	}
+
 	ni, err := NewInotify()
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Open inotify fail")
@@ -221,17 +241,9 @@ func NewFileWatcher(config *FileMonitorConfig) (*FileWatch, error) {
 	go n.MonitorFileEvents()
 	go ni.MonitorFileEvents()
 
-	fw := &FileWatch{
-		aufs:       config.IsAufs,
-		fanotifier: n,
-		inotifier:  ni,
-		fileEvents: make(map[string]*fileMod),
-		groups:     make(map[int]*groupInfo),
-		sendrpt:    config.SendReport,
-		sendRule:   config.SendAccessRule,
-		estRuleSrc: config.EstRule,
-		walkerTask: config.WalkerTask,
-	}
+	fw.fanotifier = n
+	fw.inotifier= ni
+
 	go fw.loop()
 	return fw, nil
 }
@@ -399,6 +411,10 @@ func (w *FileWatch) learnFromEvents(rootPid int, fmod *fileMod, path string, eve
 }
 
 func (w *FileWatch) UpdateAccessRules(name string, rootPid int, conf *share.CLUSFileAccessRule) {
+	if !w.bEnable {
+		return
+	}
+
 	// log.WithFields(log.Fields{"name": name}).Debug("FMON:")
 	w.mux.Lock()
 
@@ -425,6 +441,9 @@ func (w *FileWatch) UpdateAccessRules(name string, rootPid int, conf *share.CLUS
 
 func (w *FileWatch) Close() {
 	log.Info()
+	if !w.bEnable {
+		return
+	}
 
 	if w.fanotifier != nil {
 		w.fanotifier.Close()
@@ -576,6 +595,10 @@ func (w *FileWatch) addCoreFile(cid string, dirList map[string]*osutil.FileInfoE
 }
 
 func (w *FileWatch) StartWatch(id string, rootPid int, conf *FsmonConfig, capBlock, bNeuvectorSvc bool) {
+	if !w.bEnable {
+		return
+	}
+
 	log.WithFields(log.Fields{"id": id, "group": conf.Profile.Group, "Pid": rootPid, "mode": conf.Profile.Mode}).Debug("FMON:")
 	// log.WithFields(log.Fields{"File": conf.Profile}).Debug("FMON:")
 	// log.WithFields(log.Fields{"Access": conf.Rule}).Debug("FMON:")
@@ -629,15 +652,6 @@ func (w *FileWatch) StartWatch(id string, rootPid int, conf *FsmonConfig, capBlo
 
 	if conf.Rule != nil {
 		w.UpdateAccessRules(conf.Profile.Group, rootPid, conf.Rule)
-	}
-}
-
-func (w *FileWatch) AddProcessFile(id string, rootPid int, pid int) {
-	if files := osutil.GetFileInfoExtFromPid(rootPid, pid); files != nil {
-		for _, finfo := range files {
-			finfo.ContainerId = id
-			w.addFile(finfo)
-		}
 	}
 }
 
@@ -749,6 +763,9 @@ func (w *FileWatch) handleFileEvents(fmod *fileMod, info os.FileInfo, fullPath s
 }
 
 func (w *FileWatch) ContainerCleanup(rootPid int) {
+	if !w.bEnable {
+		return
+	}
 	w.fanotifier.ContainerCleanup(rootPid)
 	w.inotifier.ContainerCleanup(rootPid)
 	w.mux.Lock()
@@ -757,16 +774,25 @@ func (w *FileWatch) ContainerCleanup(rootPid int) {
 }
 
 func (w *FileWatch) GetWatchFileList(rootPid int) []*share.CLUSFileMonitorFile {
+	if !w.bEnable {
+		return nil
+	}
 	return w.fanotifier.GetWatchFileList(rootPid)
 }
 
 func (w *FileWatch) GetAllFileMonitorFile() []*share.CLUSFileMonitorFile {
+	if !w.bEnable {
+		return nil
+	}
 	return w.fanotifier.GetWatches()
 }
 
 ////////
 func (w *FileWatch) GetProbeData() *FmonProbeData {
 	var probeData FmonProbeData
+	if !w.bEnable {
+		return nil
+	}
 
 	w.mux.Lock()
 	probeData.NFileEvents = len(w.fileEvents)


### PR DESCRIPTION
To minimize the enforcer's resource usage:

Add an environment variable:

          env:
            - name: ENF_NO_SYSTEM_PROFILES
              value: "1"


Which will disable the system profiles (process and file monitors). No learning processes, no profile modes, no process/file (package) incidents, and no file activity monitor. 
