### PR TITLE
NVSHAS-6707: goroutine crash at cache.startWorkerThread.func1(0xc0000…

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -1928,7 +1928,7 @@ func startWorkerThread(ctx *Context) {
 					if ev.ResourceNew != nil {
 						n = ev.ResourceNew.(*resource.Deployment)
 					} else if ev.ResourceOld != nil {
-						o = ev.ResourceNew.(*resource.Deployment)
+						o = ev.ResourceOld.(*resource.Deployment)
 					}
 					if n != nil {
 						if n.Domain == resource.NvAdmSvcNamespace && n.Name == "neuvector-scanner-pod" {


### PR DESCRIPTION
…9a320, 0xc00009a640, 0xc00046d901, 0x3c, 0xc0001a29c0, 0xc00009a230, 0xc00009a2d0)