### PR TITLE
NVSHAS-6689: Ability to change how native service group is created a specific label

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1726,7 +1726,6 @@ func taskInterceptContainer(id string, info *container.ContainerMetaExtra) {
 	c.info = info      // update
 	c.pid = c.info.Pid // update
 	log.WithFields(log.Fields{"container": id, "rootPid": c.info.Pid}).Debug("")
-
 	// The order to call this function for parent and child container is not guaranteed, wait for the parent
 	// if the child comes first
 	// TODO: Why check parent.service? The order is not guaranteed even when parent exists, because it is added

--- a/share/container/common.go
+++ b/share/container/common.go
@@ -92,6 +92,10 @@ const (
 )
 
 const (
+    NeuvectorSetServiceName              = "io.neuvector.service.name"
+)
+
+const (
 	PlatformContainerNone                = ""
 	PlatformContainerNeuVector           = "NeuVector"
 	PlatformContainerDockerUCPCtrl       = "Docker-UCP-Controller"

--- a/share/orchestration/docker.go
+++ b/share/orchestration/docker.go
@@ -75,6 +75,10 @@ func (d *base) GetServiceFromPodLabels(namespace, pod string, labels map[string]
 }
 
 func (d *base) GetService(meta *container.ContainerMeta) *Service {
+	if seviceName, ok := meta.Labels[container.NeuvectorSetServiceName]; ok {
+		return &Service{Name: seviceName}
+	}
+
 	project, _ := meta.Labels[container.DockerComposeProjectKey]
 	service, _ := meta.Labels[container.DockerComposeServiceKey]
 	if project != "" && service != "" {

--- a/share/orchestration/ecs.go
+++ b/share/orchestration/ecs.go
@@ -27,6 +27,10 @@ func (d *ecs) GetServiceFromPodLabels(namespace, pod string, labels map[string]s
 }
 
 func (d *ecs) GetService(meta *container.ContainerMeta) *Service {
+	if seviceName, ok := meta.Labels[container.NeuvectorSetServiceName]; ok {
+		return &Service{Name: seviceName}
+	}
+
 	cluster, _ := meta.Labels[container.ECSCluster]
 	task, _ := meta.Labels[container.ECSTaskDefinition]
 	container, _ := meta.Labels[container.ECSContainerName]

--- a/share/orchestration/kubernetes.go
+++ b/share/orchestration/kubernetes.go
@@ -323,6 +323,10 @@ func (d *kubernetes) GetServiceFromPodLabels(namespace, pod string, labels map[s
 		return nil
 	}
 
+	if seviceName, ok := labels[container.NeuvectorSetServiceName]; ok {
+		return &Service{Domain: namespace, Name: seviceName}
+	}
+
 	// pod.name can take format such as, frontend-3823415956-853n5, calico-node-m308t, kube-proxy-8vbrs.
 	// For the first case, the pod-template-hash is 3823415956, if the hash label exists, we remove it.
 	if d.flavor == share.FlavorRancher && namespace == container.KubeRancherPodNamespace {


### PR DESCRIPTION
For example, the pod with the "io.neuvector.service.name=nginxABC" will belong to "nv.nginxABC"
------------------------
YAML: pod definitions:
-------------------------
metadata:
   labels:
     app: nginx
     io.neuvector.service.name: nginxABC

--------------------
Group definitions:
--------------------
Group Name: 
    nv.nginxABC.neuvector-1
Criteria:
     service=nv.nginxABC.neuvector-1
     domain=neuvector-1