### PR TITLE
NVSHAS-6683: Node's State field value as empty string should be avoided

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -352,6 +352,7 @@ func initHostCache(id string) *hostCache {
 		ipWLMap:      make(map[string]*workloadDigest), // ip of host-scope to workload ID
 		runningPods:  utils.NewSet(),
 		runningCntrs: utils.NewSet(),
+		state:        api.StateOnline,
 	}
 }
 

--- a/controller/cache/node.go
+++ b/controller/cache/node.go
@@ -141,7 +141,6 @@ func scheduleHostRemoval(cache *hostCache) {
 
 // Protected by cacheMutexLock
 func cancelHostRemoval(cache *hostCache) {
-	cache.state = ""
 	markWorkloadState(cache.workloads, "")
 	if cache.timerTask != "" {
 		log.WithFields(log.Fields{


### PR DESCRIPTION
To fill "connected" (online) for the host's state, It also corrects that the cancelHostRemoval() accidentally clears this data.

Next on the UI change: if UI receives this state, it should follow up by showing a "green" dot.