### PR TITLE
NVSHAS-6477 implement k8s pss admission rule

### DIFF
--- a/controller/cache/pss.go
+++ b/controller/cache/pss.go
@@ -1,0 +1,264 @@
+package cache
+
+import (
+	"strings"
+
+	nvsysadmission "github.com/neuvector/neuvector/controller/nvk8sapi/nvvalidatewebhookcfg/admission"
+)
+
+// The following functions are meant to represent the policy controls as listed
+// in the Kubernetes Policy Security Standards
+// https://kubernetes.io/docs/concepts/security/pod-security-standards/
+//
+// There are two exceptions:
+// (1) The "HostProcess" check is not implemented since we do not support Windows
+// (2) In the "Host Ports" check, there is no behavior related to allowing a
+//     "known" list. This is also the case in the Kubernetes source code as of
+//     September 27th, 2022.
+
+// Baseline Policy - Host Namespaces
+func sharesHostNamespace(c *nvsysadmission.AdmContainerInfo) bool {
+	return c.HostNetwork || c.HostPID || c.HostIPC
+}
+
+// Baseline Policy - Privileged Containers
+func allowsPrivelegedContainers(c *nvsysadmission.AdmContainerInfo) bool {
+	return c.Privileged
+}
+
+// Baseline Policy - Capabilities
+func exceedsBaselineCapabilites(c *nvsysadmission.AdmContainerInfo) bool {
+	baselineCapabilities := map[string]bool{
+		"AUDIT_WRITE":      true,
+		"CHOWN":            true,
+		"DAC_OVERRIDE":     true,
+		"FOWNER":           true,
+		"FSETID":           true,
+		"KILL":             true,
+		"MKNOD":            true,
+		"NET_BIND_SERVICE": true,
+		"SETFCAP":          true,
+		"SETGID":           true,
+		"SETPCAP":          true,
+		"SETUID":           true,
+		"SYS_CHROOT":       true,
+	}
+
+	for _, capability := range c.Capabilities.Add {
+		if _, found := baselineCapabilities[strings.ToUpper(capability)]; !found {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Baseline Policy - HostPath Volumes
+func hasHostPathVolumes(c *nvsysadmission.AdmContainerInfo) bool {
+	for _, volume := range c.Volumes {
+		if volume.HostPath != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Baseline Policy - Host Ports
+func usesHostPorts(c *nvsysadmission.AdmContainerInfo) bool {
+	for _, hostPort := range c.HostPorts {
+		if hostPort != 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+const (
+	AppArmorDefault   = "runtime/default"
+	AppArmorLocalhost = "localhost/"
+)
+
+// Baseline Policy - AppArmor
+func usesIllegalAppArmorProfile(c *nvsysadmission.AdmContainerInfo) bool {
+	if c.AppArmorProfile == nil {
+		return false
+	}
+
+	if *c.AppArmorProfile == AppArmorDefault {
+		return false
+	}
+
+	if (*c.AppArmorProfile)[:len(AppArmorLocalhost)] == AppArmorLocalhost {
+		return false
+	}
+
+	return true
+}
+
+// Baseline Policy - SELinux
+func usesIllegalSELinuxOptions(c *nvsysadmission.AdmContainerInfo) bool {
+	legalTypes := map[string]bool{
+		"":                 true,
+		"container_t":      true,
+		"container_init_t": true,
+		"container_kvm_t":  true,
+	}
+
+	if _, isLegalType := legalTypes[c.SELinuxOptions.Type]; !isLegalType {
+		return true
+	}
+
+	if c.SELinuxOptions.User != "" || c.SELinuxOptions.Role != "" {
+		return true
+	}
+
+	return false
+}
+
+// Baseline Policy - /proc Mount Type
+func usesCustomProcMount(c *nvsysadmission.AdmContainerInfo) bool {
+	return c.ProcMount != "" || !strings.EqualFold(c.ProcMount, "default")
+}
+
+// Baseline Policy - Seccomp
+func usesIllegalSeccompProfile(c *nvsysadmission.AdmContainerInfo) bool {
+	profile := strings.ToLower(c.SeccompProfile)
+	return profile != "" && profile != "runtimedefault" && profile != "localhost"
+}
+
+// Baseline Policy - Sysctls
+func usesIllegalSysctls(c *nvsysadmission.AdmContainerInfo) bool {
+	legalSysctls := map[string]bool{
+		"kernel.shm_rmid_forced":              true,
+		"net.ipv4.ip_local_port_range":        true,
+		"net.ipv4.ip_unprivileged_port_start": true,
+		"net.ipv4.tcp_syncookies":             true,
+		"net.ipv4.ping_group_range":           true,
+	}
+
+	for _, sysctl := range c.Sysctls {
+		if _, found := legalSysctls[strings.ToLower(sysctl)]; !found {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Restricted Policy - Volume Types
+func usesIllegalVolumeTypes(c *nvsysadmission.AdmContainerInfo) bool {
+	if len(c.Volumes) == 0 {
+		return false
+	}
+
+	for _, volume := range c.Volumes {
+		legalVolumesSet := []bool{
+			volume.ConfigMap != nil,
+			volume.CSI != nil,
+			volume.DownwardAPI != nil,
+			volume.EmptyDir != nil,
+			// volume.VolumeSource.Ephemeral != nil, // TODO: update k8s.io package
+			volume.PersistentVolumeClaim != nil,
+			volume.Projected != nil,
+			volume.Secret != nil,
+		}
+
+		setsLegalVolume := false
+		for _, legalVolumeSet := range legalVolumesSet {
+			if legalVolumeSet {
+				setsLegalVolume = true
+				break
+			}
+		}
+		if !setsLegalVolume {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Restricted Policy - Privilege Escalation
+func allowsPrivelegeEscalation(c *nvsysadmission.AdmContainerInfo) bool {
+	return c.AllowPrivilegeEscalation
+}
+
+// Restricted Policy - Running as Non-root & Running as Non-root user (v1.23+)
+func allowsRootUsers(c *nvsysadmission.AdmContainerInfo) bool {
+	return c.RunAsUser != 0
+}
+
+// Restricted Policy - Seccomp (v1.19+)
+func doesNotSetLegalSeccompProfile(c *nvsysadmission.AdmContainerInfo) bool {
+	profile := strings.ToLower(c.SeccompProfile)
+	return profile != "runtimedefault" && profile != "localhost"
+}
+
+// Restricted Policy - Capabilities (v1.22+)
+func exceedsRestrictedCapabilities(c *nvsysadmission.AdmContainerInfo) bool {
+	dropsAll := false
+	for _, capability := range c.Capabilities.Drop {
+		if strings.EqualFold(capability, "ALL") {
+			dropsAll = true
+			break
+		}
+	}
+	if !dropsAll {
+		return true
+	}
+
+	if len(c.Capabilities.Add) > 1 {
+		return true
+	}
+
+	if len(c.Capabilities.Add) == 0 {
+		return false
+	}
+
+	return !strings.EqualFold(c.Capabilities.Add[0], "NET_BIND_SERVICE")
+}
+
+type policyViolationCheck func(*nvsysadmission.AdmContainerInfo) bool
+
+func triggersPolicyViolation(c *nvsysadmission.AdmContainerInfo, checks []policyViolationCheck) bool {
+	for _, inViolation := range checks {
+		if inViolation(c) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func violatesBaseLinePolicy(c *nvsysadmission.AdmContainerInfo) bool {
+	baselineViolations := []policyViolationCheck{
+		sharesHostNamespace,
+		allowsPrivelegedContainers,
+		exceedsBaselineCapabilites,
+		hasHostPathVolumes,
+		usesIllegalAppArmorProfile,
+		usesIllegalSELinuxOptions,
+		usesCustomProcMount,
+		usesIllegalSeccompProfile,
+		usesIllegalSysctls,
+	}
+
+	return triggersPolicyViolation(c, baselineViolations)
+}
+
+func violatesRestrictedPolicy(c *nvsysadmission.AdmContainerInfo) bool {
+	if violatesBaseLinePolicy(c) {
+		return true
+	}
+
+	restrictedViolations := []policyViolationCheck{
+		usesIllegalVolumeTypes,
+		allowsPrivelegeEscalation,
+		allowsRootUsers,
+		doesNotSetLegalSeccompProfile,
+	}
+
+	return triggersPolicyViolation(c, restrictedViolations)
+}

--- a/controller/cache/pss.go
+++ b/controller/cache/pss.go
@@ -119,7 +119,7 @@ func usesIllegalSELinuxOptions(c *nvsysadmission.AdmContainerInfo) bool {
 
 // Baseline Policy - /proc Mount Type
 func usesCustomProcMount(c *nvsysadmission.AdmContainerInfo) bool {
-	return c.ProcMount != "" || !strings.EqualFold(c.ProcMount, "default")
+	return c.ProcMount != "" && !strings.EqualFold(c.ProcMount, "default")
 }
 
 // Baseline Policy - Seccomp

--- a/controller/cache/pss.go
+++ b/controller/cache/pss.go
@@ -187,7 +187,7 @@ func allowsPrivelegeEscalation(c *nvsysadmission.AdmContainerInfo) bool {
 
 // Restricted Policy - Running as Non-root & Running as Non-root user (v1.23+)
 func allowsRootUsers(c *nvsysadmission.AdmContainerInfo) bool {
-	return c.RunAsUser != 0
+	return c.RunAsUser == 0 || !c.RunAsNonRoot
 }
 
 // Restricted Policy - Seccomp (v1.19+)

--- a/controller/cache/pss_test.go
+++ b/controller/cache/pss_test.go
@@ -1,0 +1,283 @@
+package cache
+
+import (
+	"testing"
+
+	nvsysadmission "github.com/neuvector/neuvector/controller/nvk8sapi/nvvalidatewebhookcfg/admission"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func getValidTestContainer() nvsysadmission.AdmContainerInfo {
+	return nvsysadmission.AdmContainerInfo{
+		HostNetwork: false,
+		HostPID:     false,
+		HostIPC:     false,
+		Privileged:  false,
+		Capabilities: nvsysadmission.LinuxCapabilities{
+			Add:  []string{"NET_BIND_SERVICE"},
+			Drop: []string{"ALL"},
+		},
+		Volumes:         []corev1.Volume{},
+		HostPorts:       []int32{},
+		AppArmorProfile: nil,
+		SELinuxOptions: nvsysadmission.SELinuxOptions{
+			Type: "",
+			User: "",
+			Role: "",
+		},
+		Sysctls:                  []string{},
+		AllowPrivilegeEscalation: false,
+		RunAsUser:                1,
+		RunAsNonRoot:             true,
+		SeccompProfile:           "runtimedefault",
+	}
+}
+
+func TestSharesHostNamespace_HostNetwork(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	testContainer.HostNetwork = true
+	if !sharesHostNamespace(&testContainer) {
+		t.Error("container with HostNetwork set to true should violate baseline policy")
+	}
+
+	postTest()
+}
+
+func TestSharesHostNamespace_HostPID(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	testContainer.HostPID = true
+	if !sharesHostNamespace(&testContainer) {
+		t.Error("container with HostPID set to true should violate baseline policy")
+	}
+
+	postTest()
+}
+
+func TestSharesHostNamespace_IPC(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	testContainer.HostIPC = true
+	if !sharesHostNamespace(&testContainer) {
+		t.Error("container with HostIPC set to true should violate baseline policy")
+	}
+
+	postTest()
+}
+
+func TestAllowsPrivilegedContainers(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	testContainer.Privileged = true
+	if !allowsPrivelegedContainers(&testContainer) {
+		t.Error("container with Privileged set to true should violate baseline policy")
+	}
+
+	postTest()
+}
+
+func TestExceedsBaselineCapabilities(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	testContainer.Capabilities.Add = append(testContainer.Capabilities.Add, "SOME_ILLEGAL_CAPABILITY")
+	if !exceedsBaselineCapabilites(&testContainer) {
+		t.Error("container with invalid added capability should violate baseline policy")
+	}
+
+	postTest()
+}
+
+func TestHasHostPathVolumes(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	testContainer.Volumes = append(testContainer.Volumes, corev1.Volume{
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{},
+		},
+	})
+	if !hasHostPathVolumes(&testContainer) {
+		t.Error("container with HostPath volume should violate baseline policy")
+	}
+
+	postTest()
+}
+
+func TestUsesHostPorts(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	testContainer.HostPorts = append(testContainer.HostPorts, 12345)
+	if !usesHostPorts(&testContainer) {
+		t.Error("container with HostPorts should violate baseline policy")
+	}
+
+	postTest()
+}
+
+func TestUsesIllegalAppArmorProfile(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	illegalAppArmorProfile := "illegal_apparmor_profile"
+	testContainer.AppArmorProfile = &illegalAppArmorProfile
+	if !usesIllegalAppArmorProfile(&testContainer) {
+		t.Error("container with illegal AppArmor profile should violate baseline policy")
+	}
+
+	postTest()
+}
+
+func TestUsesIllegalSeLinuxOptions_Type(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	testContainer.SELinuxOptions.Type = "illegal_type"
+	if !usesIllegalSELinuxOptions(&testContainer) {
+		t.Error("container with illegal SeLinux options type should violate baseline policy")
+	}
+
+	postTest()
+}
+
+func TestUsesIllegalSeLinuxOptions_User(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	testContainer.SELinuxOptions.User = "any set user is illegal"
+	if !usesIllegalSELinuxOptions(&testContainer) {
+		t.Error("container with any SeLinux options user set should violate baseline policy")
+	}
+
+	postTest()
+}
+
+func TestUsesIllegalSeLinuxOptions_Role(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	testContainer.SELinuxOptions.Role = "any set role is illegal"
+	if !usesIllegalSELinuxOptions(&testContainer) {
+		t.Error("container with any SeLinux options role set should violate baseline policy")
+	}
+
+	postTest()
+}
+
+func TestUsesCustomProcMount(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	testContainer.ProcMount = "some non default procmount string"
+	if !usesCustomProcMount(&testContainer) {
+		t.Error("container with custom ProcMount should violate baseline policy")
+	}
+
+	postTest()
+}
+
+func TestUsesIllegalSysctls(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	testContainer.Sysctls = append(testContainer.Sysctls, "some_illegal_sysctl")
+	if !usesIllegalSysctls(&testContainer) {
+		t.Error("container with illegal sysctl should violate baseline policy")
+	}
+
+	postTest()
+}
+
+func TestUsesIllegalVolumeTypes_IllegalSet(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	testContainer.Volumes = []corev1.Volume{
+		corev1.Volume{
+			VolumeSource: corev1.VolumeSource{
+				Cinder: &corev1.CinderVolumeSource{},
+			},
+		},
+	}
+	if !usesIllegalVolumeTypes(&testContainer) {
+		t.Error("container with illegal volume type set should violate restricted policy")
+	}
+
+	postTest()
+}
+
+func TestAllowsPrivelegeEscalation(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	testContainer.AllowPrivilegeEscalation = true
+	if !allowsPrivelegeEscalation(&testContainer) {
+		t.Error("container that allows privilege escalation should violate restricted policy")
+	}
+
+	postTest()
+}
+
+func TestDoesNotSetLegalSeccompProfile(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	testContainer.SeccompProfile = "illegal_seccomp_profile"
+	if !usesIllegalSeccompProfile(&testContainer) {
+		t.Error("container that does not explicitly set legal seccomp profile should violate restricted policy")
+	}
+
+	postTest()
+}
+
+func TestExceedsRestrictedCapabilities_NoDropAll(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	testContainer.Capabilities.Drop = []string{}
+	if !exceedsRestrictedCapabilities(&testContainer) {
+		t.Error("container that does not drop all capabilities should violate restricted policy")
+	}
+
+	postTest()
+}
+
+func TestExceedsRestrictedCapabilities_AddsIllegal(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	testContainer.Capabilities.Add = append(testContainer.Capabilities.Add, "illegal_capability")
+	if !exceedsRestrictedCapabilities(&testContainer) {
+		t.Error("container that adds more capabilities than NET_BIND_SERVICE should violate restricted policy")
+	}
+
+	postTest()
+}
+
+func TestBaselinePolicy_ValidContainer(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	if violatesBaseLinePolicy(&testContainer) {
+		t.Error("valid container should not violate baseline policy")
+	}
+
+	postTest()
+}
+
+func TestRestrictedPolicy_ValidContainer(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	if violatesRestrictedPolicy(&testContainer) {
+		t.Error("valid container should not violate restricted policy")
+	}
+
+	postTest()
+}

--- a/controller/nvk8sapi/nvvalidatewebhookcfg/admission/admission.go
+++ b/controller/nvk8sapi/nvvalidatewebhookcfg/admission/admission.go
@@ -107,6 +107,7 @@ type AdmContainerInfo struct {
 	ProcMount                string                `json:"proc_mount"`
 	SeccompProfile           string                `json:"seccomp_profile"`
 	Sysctls                  []string              `json:"sysctls"`
+	RunAsNonRoot             bool                  `json:"run_as_non_root"`
 }
 
 type JSONAdmContainerInfo struct { // for debugging purpose only

--- a/controller/rest/admwebhook.go
+++ b/controller/rest/admwebhook.go
@@ -480,6 +480,13 @@ func parsePodSpec(objectMeta *metav1.ObjectMeta, spec *corev1.PodSpec) ([]*nvsys
 			// if spec.SecurityContext.SeccompProfile != nil {
 			// 	admContainerInfo.SeccompProfile = spec.SecurityContext.SeccompProfile.Type
 			// }
+
+			// run as non root
+			if spec.SecurityContext.RunAsNonRoot != nil {
+				admContainerInfo.RunAsNonRoot = *spec.SecurityContext.RunAsNonRoot
+			} else {
+				admContainerInfo.RunAsNonRoot = false
+			}
 		}
 
 		if spec.SecurityContext != nil && spec.SecurityContext.RunAsUser != nil {
@@ -539,6 +546,13 @@ func parsePodSpec(objectMeta *metav1.ObjectMeta, spec *corev1.PodSpec) ([]*nvsys
 			// if c.SecurityContext.SeccompProfile != nil {
 			// 	admContainerInfo.SeccompProfile = c.SecurityContext.SeccompProfile.Type
 			// }
+
+			// container run as non root
+			if c.SecurityContext.RunAsNonRoot != nil {
+				admContainerInfo.RunAsNonRoot = *c.SecurityContext.RunAsNonRoot
+			} else {
+				admContainerInfo.RunAsNonRoot = false
+			}
 		}
 		admContainerInfo.Name = c.Name
 		admContainerInfo.Image = c.Image

--- a/share/criteria.go
+++ b/share/criteria.go
@@ -45,7 +45,8 @@ const (
 	CriteriaKeyAllowPrivEscalation string = "allowPrivEscalation"
 	CriteriaKeyPspCompliance       string = "pspCompliance" // psp compliance violation
 	CriteriaKeyRequestLimit        string = "resourceLimit"
-	CriteriaKeyModules			   string = "modules"
+	CriteriaKeyModules             string = "modules"
+	CriteriaKeyHasPssViolation     string = "hasPssViolation"
 )
 
 const (
@@ -79,6 +80,11 @@ const (
 )
 
 const CriteriaValueAny string = "any"
+
+const (
+	PssPolicyBaseline   string = "baseline"
+	PssPolicyRestricted string = "restricted"
+)
 
 func IsSvcIpGroupMember(usergroup *CLUSGroup, svcipgroup *CLUSGroup) bool {
 	if usergroup == nil || svcipgroup == nil {
@@ -183,13 +189,13 @@ func IsWorkloadSelected(workload *CLUSWorkload, selector []CLUSCriteriaEntry, do
 			positive = true
 			if strings.HasPrefix(crt.Key, "ns:") {
 				if domain != nil {
-					key = "ns-label"	// create "or" combination
+					key = "ns-label" // create "or" combination
 					if v, ok := domain.Labels[crt.Key[3:]]; ok {
 						ret, positive = isCriterionMet(&crt, v)
 					}
 				}
 			} else {
-				key = "pod-label"		// create "or" combination
+				key = "pod-label" // create "or" combination
 				if v, ok := workload.Labels[crt.Key]; ok {
 					ret, positive = isCriterionMet(&crt, v)
 				}


### PR DESCRIPTION
## Outline

This implements an admission control rule that follows Kubernetes Policy Security Standards (https://kubernetes.io/docs/concepts/security/pod-security-standards/) with two exceptions:

1. The "HostProcess" check is not implemented since we do not support Windows
2. In the "Host Ports" check, there is no behavior related to allowing a "known" list. This is also the case in the Kubernetes source code, and every other vendor implementation I could find.

An additional change of note: ephemeral and init containers are being incorporated into admission control validation, however they are currently only checked by the PSS admission rule.

## In-Progress Changes

- [x] Update K8s vendor package in order to correctly capture seccomp profiles and ephemeral volumes

The updates to seccomp profile types will be included in another PR, as it requires changes to `go.mod` and `vendor`.