### PR TITLE
NVSHAS-6790: no new benchmark info in kv if ENF_NO_AUTO_BENCHMARK is enabled

### DIFF
--- a/agent/bench.go
+++ b/agent/bench.go
@@ -198,9 +198,13 @@ func (b *Bench) BenchLoop() {
 	for {
 		select {
 		case <-b.hostTimer.C:
-			b.doDockerHostBench()
-
+			if agentEnv.autoBenchmark {
+				b.doDockerHostBench()
+			}
 		case <-b.kubeTimer.C:
+			if !agentEnv.autoBenchmark {
+				continue
+			}
 			// Check version whenever the benchmark is rerun
 			k8sVer, ocVer := global.ORCH.GetVersion(false, false)
 			if masterScript == "" {
@@ -272,10 +276,12 @@ func (b *Bench) BenchLoop() {
 			b.doKubeBench(masterScript, workerScript, remediation)
 		case <-b.conTimer.C:
 			containers := b.cloneAllNewContainers()
-			if Host.CapDockerBench {
-				b.doDockerContainerBench(containers)
-			} else {
-				b.putBenchReport(Host.ID, share.BenchDockerContainer, nil, share.BenchStatusFinished)
+			if agentEnv.autoBenchmark {
+				if Host.CapDockerBench {
+					b.doDockerContainerBench(containers)
+				} else {
+					b.putBenchReport(Host.ID, share.BenchDockerContainer, nil, share.BenchStatusFinished)
+				}
 			}
 
 			// Run custom checks
@@ -464,12 +470,16 @@ func (b *Bench) RerunKube(cmd, cmdRemap string, forced bool) {
 }
 
 func (b *Bench) ResetDockerStatus() {
-	b.putBenchReport(Host.ID, share.BenchDockerHost, nil, share.BenchStatusIdle)
+	if agentEnv.autoBenchmark {
+		b.putBenchReport(Host.ID, share.BenchDockerHost, nil, share.BenchStatusIdle)
+	}
 }
 
 func (b *Bench) ResetKubeStatus() {
-	b.putBenchReport(Host.ID, share.BenchKubeMaster, nil, share.BenchStatusIdle)
-	b.putBenchReport(Host.ID, share.BenchKubeWorker, nil, share.BenchStatusIdle)
+	if agentEnv.autoBenchmark {
+		b.putBenchReport(Host.ID, share.BenchKubeMaster, nil, share.BenchStatusIdle)
+		b.putBenchReport(Host.ID, share.BenchKubeWorker, nil, share.BenchStatusIdle)
+	}
 }
 
 func (b *Bench) cloneAllNewContainers() map[string]string {
@@ -767,10 +777,6 @@ func (b *Bench) runDockerHostBench() ([]byte, error) {
 }
 
 func (b *Bench) doDockerHostBench() error {
-	if !agentEnv.autoBenchmark {
-		return nil
-	}
-
 	log.Debug()
 
 	b.putBenchReport(Host.ID, share.BenchDockerHost, nil, share.BenchStatusRunning)
@@ -795,10 +801,6 @@ func (b *Bench) doDockerHostBench() error {
 }
 
 func (b *Bench) doDockerContainerBench(containers map[string]string) error {
-	if !agentEnv.autoBenchmark {
-		return nil
-	}
-
 	b.putBenchReport(Host.ID, share.BenchDockerContainer, nil, share.BenchStatusRunning)
 	if out, err := b.runDockerContainerBench(containers); err != nil {
 		b.logBenchFailure(benchPlatDocker, share.BenchStatusDockerContainerFail)


### PR DESCRIPTION
Modify logic to have no new (added) benchmark KV entries if the flag is enabled.

For example,

bench/<host id>/report/docker_container
bench/<host id>/report/docker_host
bench/<host id>/report/kube_master
bench/<host id>/report/kube_worker

and 

scan/state/bench/host/<host id>
scan/state/bench/workload/<container id>
