### PR TITLE
NVSHAS-6172: a new group is unable to create after rolling update on oc4.9 or rke2 or native k8s setup

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -276,6 +276,9 @@ func LeadChangeNotify(isLeader bool, leadAddr string) {
 		return
 	}
 
+	//
+	refreshGroupMembers()
+
 	// When lead change, synchonize states in case operation was missed
 	syncLeftNVObjectsToCluster()
 	//NVSHAS-5914, During rolling upgrade remove the unmanaged workload


### PR DESCRIPTION
The rolling update procedure will have a KV data fetching from the old setup, which had a bug about the group name generations. Thus, the workloads with the wrong group names will be accepted by the new controllers using the new group naming method.

To prevent miss-handling cases, the profile data of the obsolete groups will be moved into the new group. Then, the outdated (profile) groups will be deleted.