### PR TITLE
NVSHAS-6689 #2: Ability to change how native service group is created with specific labels.

### DIFF
--- a/share/orchestration/kubernetes.go
+++ b/share/orchestration/kubernetes.go
@@ -324,7 +324,7 @@ func (d *kubernetes) GetServiceFromPodLabels(namespace, pod string, labels map[s
 	}
 
 	if seviceName, ok := labels[container.NeuvectorSetServiceName]; ok {
-		return &Service{Domain: namespace, Name: seviceName}
+		return &Service{Domain: namespace, Name: strings.ToLower(seviceName)}
 	}
 
 	// pod.name can take format such as, frontend-3823415956-853n5, calico-node-m308t, kube-proxy-8vbrs.
@@ -368,7 +368,7 @@ func (d *kubernetes) GetServiceFromPodLabels(namespace, pod string, labels map[s
 	// rke2: kube-system / kube-proxy-ubuntu2110-k8123master-auto
 	if namespace == container.KubeNamespaceSystem {
 		if component, ok := labels[container.KubeKeyComponent]; ok {
-			return &Service{Domain: namespace, Name: component}
+			return &Service{Domain: namespace, Name: strings.ToLower(component)}
 		}
 	}
 


### PR DESCRIPTION
According to k8s spec, the allowed k8s pod's meta name is:

metadata.name: Invalid value, a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9][a-z0-9])?(\.[a-z0-9]([-a-z0-9][a-z0-9])?)*')