### PR TITLE
Nvshas 6477 bugfixes

### DIFF
--- a/controller/cache/admission.go
+++ b/controller/cache/admission.go
@@ -1217,14 +1217,14 @@ func mergeStringMaps(propFromYaml map[string]string, propFromImage map[string]st
 	return union
 }
 
-func hasPssViolation(crt *share.CLUSAdmRuleCriterion, c *nvsysadmission.AdmContainerInfo) bool {
+func hasPssViolation(crt *share.CLUSAdmRuleCriterion, c *nvsysadmission.AdmContainerInfo, imageRunsAsRoot bool) bool {
 	selectedPolicy := strings.TrimSpace(strings.ToLower(crt.Value))
 
 	switch selectedPolicy {
 	case share.PssPolicyBaseline:
 		return violatesBaseLinePolicy(c)
 	case share.PssPolicyRestricted:
-		return violatesRestrictedPolicy(c)
+		return violatesRestrictedPolicy(c, imageRunsAsRoot)
 	}
 
 	return false // invalid policy
@@ -1363,7 +1363,7 @@ func isAdmissionRuleMet(admResObject *nvsysadmission.AdmResObject, c *nvsysadmis
 		case share.CriteriaKeyModules:
 			met, positive = isModulesCriterionMet(crt, scannedImage.Modules)
 		case share.CriteriaKeyHasPssViolation:
-			met = hasPssViolation(crt, c)
+			met = hasPssViolation(crt, c, scannedImage.RunAsRoot)
 			positive = true
 		default:
 			met, positive = false, true

--- a/controller/cache/pss.go
+++ b/controller/cache/pss.go
@@ -257,7 +257,7 @@ func violatesBaseLinePolicy(c *nvsysadmission.AdmContainerInfo) bool {
 	return triggersPolicyViolation(c, baselineViolations)
 }
 
-func violatesRestrictedPolicy(c *nvsysadmission.AdmContainerInfo) bool {
+func violatesRestrictedPolicy(c *nvsysadmission.AdmContainerInfo, imageRunsAsRoot bool) bool {
 	if violatesBaseLinePolicy(c) {
 		return true
 	}
@@ -270,5 +270,5 @@ func violatesRestrictedPolicy(c *nvsysadmission.AdmContainerInfo) bool {
 		exceedsRestrictedCapabilities,
 	}
 
-	return triggersPolicyViolation(c, restrictedViolations)
+	return triggersPolicyViolation(c, restrictedViolations) || imageRunsAsRoot
 }

--- a/controller/cache/pss.go
+++ b/controller/cache/pss.go
@@ -266,6 +266,7 @@ func violatesRestrictedPolicy(c *nvsysadmission.AdmContainerInfo) bool {
 		allowsPrivelegeEscalation,
 		allowsRootUsers,
 		doesNotSetLegalSeccompProfile,
+		exceedsRestrictedCapabilities,
 	}
 
 	return triggersPolicyViolation(c, restrictedViolations)

--- a/controller/cache/pss.go
+++ b/controller/cache/pss.go
@@ -246,6 +246,7 @@ func violatesBaseLinePolicy(c *nvsysadmission.AdmContainerInfo) bool {
 		allowsPrivelegedContainers,
 		exceedsBaselineCapabilites,
 		hasHostPathVolumes,
+		usesHostPorts,
 		usesIllegalAppArmorProfile,
 		usesIllegalSELinuxOptions,
 		usesCustomProcMount,

--- a/controller/cache/pss_test.go
+++ b/controller/cache/pss_test.go
@@ -290,9 +290,19 @@ func TestRestrictedPolicy_ValidContainer(t *testing.T) {
 	preTest()
 
 	testContainer := getValidTestContainer()
-	if violatesRestrictedPolicy(&testContainer) {
+	if violatesRestrictedPolicy(&testContainer, false) {
 		t.Error("valid container should not violate restricted policy")
 	}
 
 	postTest()
+}
+
+func TestRestrictedPolicy_ImageRunsAsRoot(t *testing.T) {
+	preTest()
+
+	testContainer := getValidTestContainer()
+	imageRunsAsRoot := true
+	if !violatesRestrictedPolicy(&testContainer, imageRunsAsRoot) {
+		t.Error("image running as root should violate restricted policy")
+	}
 }


### PR DESCRIPTION
Corrects some simple oversights and includes an additional check for an image running as root.

Deals with the following bugs:
- NVSHAS-6830
- NVSHAS-6832
- NVSHAS-6895