### PR TITLE
NVSHAS-6689: Adapting dns123 naming rule to correct improper pod names.

### DIFF
--- a/controller/rest/crdsecurityrule.go
+++ b/controller/rest/crdsecurityrule.go
@@ -2664,7 +2664,7 @@ func handlerGroupCfgExport(w http.ResponseWriter, r *http.Request, ps httprouter
 		}
 
 		tgroup := group2RESTConfig(group)
-		kindName := dns1123NameChg(gname)
+		kindName := utils.Dns1123NameChg(gname)
 		targetNs := ""
 		targetKind := resource.NvClusterSecurityRuleKind
 		apiversion := fmt.Sprintf("%s/%s", common.OEMClusterSecurityRuleGroup, resource.NvClusterSecurityRuleVersion)

--- a/controller/rest/group.go
+++ b/controller/rest/group.go
@@ -288,34 +288,6 @@ var regIPLoose *regexp.Regexp = regexp.MustCompile("^[0-9.]+$")
 var regIPRangeLoose *regexp.Regexp = regexp.MustCompile("^[0-9-./]+$")
 var regDomain *regexp.Regexp = regexp.MustCompile(`^([0-9a-zA-Z])+([0-9a-zA-Z-_])*(\.[0-9a-zA-Z]+([0-9a-zA-Z-_])*)*$`)
 var regSubDomain *regexp.Regexp = regexp.MustCompile(`^(\*)(\.[0-9a-zA-Z]+([0-9a-zA-Z-_])*){2,}$`)
-var regCrdName *regexp.Regexp = regexp.MustCompile(`^([0-9a-z])([0-9a-z-.])*([0-9a-z])$`)
-var regDns1122 *regexp.Regexp = regexp.MustCompile(`^[a-z0-9.-]{1}$`)
-var regDns1122start *regexp.Regexp = regexp.MustCompile(`^[a-z0-9]{1}$`)
-
-func replaceAtIndex(in string, r rune, i int) string {
-	out := []rune(in)
-	out[i] = r
-	return string(out)
-}
-
-func dns1123NameChg(name string) string {
-
-	if !regCrdName.MatchString(name) {
-		length := len(name)
-		fmt.Println("string:", name, "failed regex with len ", length)
-		for i, char := range name {
-			if (i == 0 || i == length-1) && !regDns1122start.MatchString(string(char)) {
-				name = replaceAtIndex(name, '0', i)
-			} else if !regDns1122.MatchString(string(char)) {
-				fmt.Println("char:", string(char), "failed regex")
-				name = strings.Replace(name, string(char), "-", -1)
-			}
-		}
-	}
-
-	return name
-}
-
 func validateDomainName(name string) bool {
 	if regIPRangeLoose.MatchString(name) {
 		return false

--- a/share/orchestration/kubernetes.go
+++ b/share/orchestration/kubernetes.go
@@ -324,7 +324,7 @@ func (d *kubernetes) GetServiceFromPodLabels(namespace, pod string, labels map[s
 	}
 
 	if seviceName, ok := labels[container.NeuvectorSetServiceName]; ok {
-		return &Service{Domain: namespace, Name: strings.ToLower(seviceName)}
+		return &Service{Domain: namespace, Name: utils.Dns1123NameChg(strings.ToLower(seviceName))}
 	}
 
 	// pod.name can take format such as, frontend-3823415956-853n5, calico-node-m308t, kube-proxy-8vbrs.
@@ -368,7 +368,7 @@ func (d *kubernetes) GetServiceFromPodLabels(namespace, pod string, labels map[s
 	// rke2: kube-system / kube-proxy-ubuntu2110-k8123master-auto
 	if namespace == container.KubeNamespaceSystem {
 		if component, ok := labels[container.KubeKeyComponent]; ok {
-			return &Service{Domain: namespace, Name: strings.ToLower(component)}
+			return &Service{Domain: namespace, Name: utils.Dns1123NameChg(strings.ToLower(component))}
 		}
 	}
 

--- a/share/utils/utils.go
+++ b/share/utils/utils.go
@@ -1191,3 +1191,30 @@ func DisplayBytes(num int64) string {
 	}
 	return fmt.Sprintf("%d Bytes", num)
 }
+
+////
+var regCrdName *regexp.Regexp = regexp.MustCompile(`^([0-9a-z])([0-9a-z-.])*([0-9a-z])$`)
+var regDns1122 *regexp.Regexp = regexp.MustCompile(`^[a-z0-9.-]{1}$`)
+var regDns1122start *regexp.Regexp = regexp.MustCompile(`^[a-z0-9]{1}$`)
+
+func replaceAtIndex(in string, r rune, i int) string {
+	out := []rune(in)
+	out[i] = r
+	return string(out)
+}
+
+func Dns1123NameChg(name string) string {
+	if !regCrdName.MatchString(name) {
+		length := len(name)
+		fmt.Println("string:", name, "failed regex with len ", length)
+		for i, char := range name {
+			if (i == 0 || i == length-1) && !regDns1122start.MatchString(string(char)) {
+				name = replaceAtIndex(name, '0', i)
+			} else if !regDns1122.MatchString(string(char)) {
+				fmt.Println("char:", string(char), "failed regex")
+				name = strings.Replace(name, string(char), "-", -1)
+			}
+		}
+	}
+	return name
+}


### PR DESCRIPTION
The pod name should be a validated entry to fulfill dns123 rules. 