### PR TITLE
NVSHAS-6910: Manual trigger of Updater job cases NV to create a group for the container.

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -282,7 +282,13 @@ func isNeuVectorContainer(info *container.ContainerMetaExtra) (string, bool) {
 	if podname, ok := labels[container.KubeKeyPodName]; ok {
 		role := nvPod2Role(podname)
 		if role == "" {
-			return "", false
+			// 2nd try
+			if app, ok := labels[container.KubeKeyAppName]; ok {
+				role = nvPod2Role(app)
+			}
+			if role == "" {
+				return "", false
+			}
 		}
 
 		if isNeuvectorFunctionRole(role, info.Pid) {

--- a/share/container/common.go
+++ b/share/container/common.go
@@ -54,6 +54,7 @@ const (
 	KubeContainerNamePod   string = "POD"
 	KubeContainerNameProxy string = "kube-proxy"
 	KubePodNamePrefixProxy string = "kube-proxy"
+	KubeKeyAppName         string = "app"
 )
 
 const (

--- a/share/container/crio.go
+++ b/share/container/crio.go
@@ -476,12 +476,24 @@ func (d *crioDriver) GetContainer(id string) (*ContainerMetaExtra, error) {
 		if image, _ := d.GetImage(meta.Image); image != nil {
 			meta.ImageID = image.ID
 			meta.Author = image.Author
+			for k, v := range image.Labels {
+				// Not to overwrite container labels when merging
+				if _, ok := meta.Labels[k]; !ok {
+					meta.Labels[k] = v
+				}
+			}
 		} else {
 			// 2nd chance
 			if meta.ImageID == "" && meta.ImageDigest != "" {
 				if image, _ := d.GetImage(cs.Status.ImageRef); image != nil {
 					meta.ImageID = image.ID
 					meta.Author = image.Author
+					for k, v := range image.Labels {
+						// Not to overwrite container labels when merging
+						if _, ok := meta.Labels[k]; !ok {
+							meta.Labels[k] = v
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The case is duplicated by following similar command:

"kubectl create job --from cronjob/neuvector-updater-pod manual-run-jay.says.do.5 -n neuvector"

The syntax will create a user-defined POD name: "manual-run-jay.says.do.5"
Our current method can not identify that they were one of our pod names.

(1) enhance the identification method to cover this case.
(2) "cri-o driver": add image labels into container labels.