### PR TITLE
NVSHAS-6990 & NVSHAS-6991

### DIFF
--- a/controller/rest/auth.go
+++ b/controller/rest/auth.go
@@ -233,7 +233,7 @@ func _registerLoginSession(login *loginSession) int {
 		var msg string
 		domainRoles := login.domainRoles
 		if login.mainSessionUser != "" {
-			userName = fmt.Sprintf("%s (master cluster)", login.mainSessionUser)
+			userName = fmt.Sprintf("%s (primary cluster)", login.mainSessionUser)
 		} else {
 			userName = login.fullname
 		}
@@ -334,7 +334,7 @@ func (s *loginSession) _logout() {
 	var userName string
 	domainRoles := s.domainRoles
 	if s.mainSessionUser != "" {
-		userName = fmt.Sprintf("%s (master cluster)", s.mainSessionUser)
+		userName = fmt.Sprintf("%s (primary cluster)", s.mainSessionUser)
 	} else {
 		userName = s.fullname
 	}
@@ -360,7 +360,7 @@ func (s *loginSession) _expire() {
 	} else {
 		var userName string
 		if s.mainSessionUser != "" {
-			userName = fmt.Sprintf("%s (master cluster)", s.mainSessionUser)
+			userName = fmt.Sprintf("%s (primary cluster)", s.mainSessionUser)
 		} else {
 			userName = s.fullname
 		}

--- a/controller/rest/federation.go
+++ b/controller/rest/federation.go
@@ -2213,7 +2213,8 @@ func handlerJointKickedInternal(w http.ResponseWriter, r *http.Request, ps httpr
 		restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFedOperationFailed, err.Error())
 		return
 	}
-	cacheFedEvent(share.CLUSEvFedKick, "Dimissed from federation", login.fullname, login.remote, login.id, login.domainRoles)
+	userName := fmt.Sprintf("%s (primary cluster)", login.mainSessionUser)
+	cacheFedEvent(share.CLUSEvFedKick, "Dimissed from federation", userName, login.remote, login.id, login.domainRoles)
 	go leaveFedCleanup(masterCluster.ID, jointCluster.ID)
 	restRespSuccess(w, r, nil, acc, login, nil, "Leave federation by primary cluster's request")
 }


### PR DESCRIPTION
NVSHAS-6990: suggest to change wording from master cluster to primary cluster in the event
NVSHAS-6991: show internal hidden user ~fedOperator in the event when a worker cluster is kicked by master cluster