### PR TITLE
NVSHAS-6910: found exited updaters on the oc49's crio cluster

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -246,7 +246,7 @@ func isNeuvectorFunctionRole(role string, rootPid int) bool {
 	// passed the 1st screening
 
 	// 2nd screening: handle the exited child container at the last part
-	if rootPid == 0 {
+	if !osutil.IsPidValid(rootPid) {
 		// log.Debug("invalid root pid")
 		return true // skipped the test
 	}


### PR DESCRIPTION
On the CRI-O runtime, the updater pod was detected after it exited. The nv pod verification needs to be patched to accommodate the condition.