### PR TITLE
NVSHAS-7048: no need to send ConfigMap.Failed event if the expected y…

### DIFF
--- a/controller/rest/configmap.go
+++ b/controller/rest/configmap.go
@@ -963,8 +963,6 @@ func LoadInitCfg(load bool) {
 			} else {
 				errMsg = fmt.Sprintf("    %s init configmap read error: %s ", configMap.Type, err.Error())
 			}
-		} else {
-			errMsg = fmt.Sprintf("    %s init configmap file error: %s ", configMap.Type, err.Error())
 		}
 		if errMsg != "" {
 			log.Error(errMsg)


### PR DESCRIPTION
…aml file doesn't exist in configmap