### PR TITLE
[Update] update CPU stat calculation by CPU kernal count

### DIFF
--- a/share/system/stats.go
+++ b/share/system/stats.go
@@ -1,12 +1,13 @@
 package system
 
 import (
-	"time"
-
 	"github.com/neuvector/neuvector/share"
+	"runtime"
+	"time"
 )
 
 func calculateCPU(prevCPU, prevCPUSystem uint64, cpu, cpuSystem uint64) float64 {
+	cpuNum := runtime.NumCPU()
 	var cDelta float64 = float64(cpu - prevCPU)
 	var sDelta float64 = float64(cpuSystem - prevCPUSystem)
 
@@ -14,7 +15,7 @@ func calculateCPU(prevCPU, prevCPUSystem uint64, cpu, cpuSystem uint64) float64 
 		if cDelta > sDelta {
 			return 1
 		} else {
-			return cDelta / sDelta
+			return cDelta / sDelta * float64(cpuNum)
 		}
 	}
 


### PR DESCRIPTION
cDelta / sDelta is range between 0 and 100%.
But on a 4-core system, cpu usage can be anywhere between 0 and 400%, so it has to be multiplied by the number of cores.

refer 'docekr stats' :https://github.com/moby/moby/blob/eb131c5383db8cac633919f82abad86c99bffbe5/cli/command/container/stats_helpers.go#L175-L188 
https://github.com/moby/moby/issues/13626