### PR TITLE
Service names updates: reducing the similiar randomized hash in the group names.

### DIFF
--- a/agent/cluster.go
+++ b/agent/cluster.go
@@ -444,9 +444,14 @@ func createWorkload(info *container.ContainerMetaExtra) *share.CLUSWorkload {
 		}
 	}
 
-	svc := global.ORCH.GetService(&info.ContainerMeta)
-	wl.Service = utils.MakeServiceName(svc.Domain, svc.Name)
-	wl.Domain = svc.Domain
+	if isChild, parent := getSharedContainer(info); isChild {
+		wl.Service = parent.service
+		wl.Domain = parent.domain
+	} else {
+		svc := global.ORCH.GetService(&info.ContainerMeta, Host.Name)
+		wl.Service = utils.MakeServiceName(svc.Domain, svc.Name)
+		wl.Domain = svc.Domain
+	}
 	return &wl
 }
 

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1123,7 +1123,7 @@ func fillContainerProperties(c *containerData, parent *containerData,
 	// Not using write lock because all fields filled here are simple
 	c.svcSubnet = global.ORCH.GetServiceSubnet(info.Envs)
 	if parent == nil {
-		svc := global.ORCH.GetService(&info.ContainerMeta)
+		svc := global.ORCH.GetService(&info.ContainerMeta, Host.Name)
 		c.service = utils.MakeServiceName(svc.Domain, svc.Name)
 		c.domain = svc.Domain
 		c.hostMode = hostMode
@@ -1589,7 +1589,7 @@ func startNeuVectorMonitors(id, role string, info *container.ContainerMetaExtra)
 	// (1) native runtime env.: name of the image
 	// (2) k8s: namespace + name in the metadata section of its YAML
 	//          like controller =>  "neuvector (Domain/Namespace) + neuvector-controller-pod (Name)""
-	svc := global.ORCH.GetService(&info.ContainerMeta)
+	svc := global.ORCH.GetService(&info.ContainerMeta, Host.Name)
 	c.service = utils.MakeServiceName(svc.Domain, svc.Name)
 	c.domain = svc.Domain
 	group := makeLearnedGroupName(utils.NormalizeForURL(c.service))
@@ -1897,7 +1897,7 @@ func taskAddContainer(id string, info *container.ContainerMetaExtra) {
 	if !info.Running {
 		// service is not reported until container is running; domain should be filled.
 		// it reports the exited container as well
-		svc := global.ORCH.GetService(&info.ContainerMeta)
+		svc := global.ORCH.GetService(&info.ContainerMeta, Host.Name)
 		ev := ClusterEvent{event: EV_ADD_CONTAINER, id: id, info: info, domain: &svc.Domain}
 		ClusterEventChan <- &ev
 

--- a/controller/cache/object.go
+++ b/controller/cache/object.go
@@ -1230,7 +1230,7 @@ func mergeProbeCommands(cmds [][]string) []k8sProbeCmd {
 func addK8sPodEvent(pod resource.Pod) {
 	probes := mergeProbeCommands(append(pod.LivenessCmds, pod.ReadinessCmds...))
 	groupName := fmt.Sprintf("nv.%s.%s", pod.Name, pod.Domain)
-	if svc := global.ORCH.GetServiceFromPodLabels(pod.Domain, pod.Name, pod.Labels); svc != nil {
+	if svc := global.ORCH.GetServiceFromPodLabels(pod.Domain, pod.Name, pod.Node, pod.Labels); svc != nil {
 		groupName = api.LearnedGroupPrefix + utils.NormalizeForURL(utils.MakeServiceName(svc.Domain, svc.Name))
 	}
 

--- a/share/container/common.go
+++ b/share/container/common.go
@@ -97,6 +97,11 @@ const (
 )
 
 const (
+	IbmCloudProviderIP                   = "ibm-cloud-provider-ip"
+	IbmCloudClusterID                    = "clusterID"
+)
+
+const (
 	PlatformContainerNone                = ""
 	PlatformContainerNeuVector           = "NeuVector"
 	PlatformContainerDockerUCPCtrl       = "Docker-UCP-Controller"

--- a/share/orchestration/aliyun.go
+++ b/share/orchestration/aliyun.go
@@ -9,8 +9,8 @@ type aliyun struct {
 	noop
 }
 
-func (d *aliyun) GetService(meta *container.ContainerMeta) *Service {
-	return baseDriver.GetService(meta)
+func (d *aliyun) GetService(meta *container.ContainerMeta, node string) *Service {
+	return baseDriver.GetService(meta, node)
 }
 
 func (d *aliyun) GetPlatformRole(m *container.ContainerMeta) (string, bool) {

--- a/share/orchestration/docker.go
+++ b/share/orchestration/docker.go
@@ -28,15 +28,15 @@ type docker struct {
 	envParser *utils.EnvironParser
 }
 
-func (d *docker) GetService(meta *container.ContainerMeta) *Service {
-	return baseDriver.GetService(meta)
+func (d *docker) GetService(meta *container.ContainerMeta, node string) *Service {
+	return baseDriver.GetService(meta, node)
 }
 
 func (d *docker) GetPlatformRole(meta *container.ContainerMeta) (string, bool) {
 	role, secure := baseDriver.GetPlatformRole(meta)
 
 	if role == "" {
-		svc := d.GetService(meta)
+		svc := d.GetService(meta, "")
 		for _, r := range d.envParser.GetSystemGroups() {
 			if r.MatchString(svc.Name) {
 				return container.PlatformContainerDockerSystem, false
@@ -70,11 +70,11 @@ type base struct {
 	noop
 }
 
-func (d *base) GetServiceFromPodLabels(namespace, pod string, labels map[string]string) *Service {
+func (d *base) GetServiceFromPodLabels(namespace, pod, node string, labels map[string]string) *Service {
 	return nil
 }
 
-func (d *base) GetService(meta *container.ContainerMeta) *Service {
+func (d *base) GetService(meta *container.ContainerMeta, node string) *Service {
 	if seviceName, ok := meta.Labels[container.NeuvectorSetServiceName]; ok {
 		return &Service{Name: seviceName}
 	}

--- a/share/orchestration/docker_test.go
+++ b/share/orchestration/docker_test.go
@@ -16,7 +16,7 @@ func TestServiceName(t *testing.T) {
 	meta.Labels[container.DockerComposeProjectKey] = "Docker Trusted Registry 2.2.5 - (Replica 112dbe66163e)"
 	meta.Labels[container.DockerComposeServiceKey] = "notary-server"
 
-	svc := driver.GetService(&meta)
+	svc := driver.GetService(&meta, "")
 	expect := "Docker.Trusted.Registry.notary-server"
 	if svc.Name != expect {
 		t.Errorf("Error: expect=%v actual=%v\n", expect, svc)
@@ -25,7 +25,7 @@ func TestServiceName(t *testing.T) {
 	meta.Labels[container.DockerComposeProjectKey] = "Docker Universal Control Plane RN3B:GP34:KHVM:LLB6:5CRA:HRTW:SCPJ:3OHZ:3DXG:W2Z2:6S76:YBTI"
 	meta.Labels[container.DockerComposeServiceKey] = "ucp-auth-api"
 
-	svc = driver.GetService(&meta)
+	svc = driver.GetService(&meta, "")
 	expect = "Docker.UCP.ucp-auth-api"
 	if svc.Name != expect {
 		t.Errorf("Error: expect=%v actual=%v\n", expect, svc)

--- a/share/orchestration/ecs.go
+++ b/share/orchestration/ecs.go
@@ -22,11 +22,11 @@ func (d *ecs) isDeployedBy(meta *container.ContainerMeta) bool {
 	return false
 }
 
-func (d *ecs) GetServiceFromPodLabels(namespace, pod string, labels map[string]string) *Service {
+func (d *ecs) GetServiceFromPodLabels(namespace, pod, node string, labels map[string]string) *Service {
 	return nil
 }
 
-func (d *ecs) GetService(meta *container.ContainerMeta) *Service {
+func (d *ecs) GetService(meta *container.ContainerMeta, node string) *Service {
 	if seviceName, ok := meta.Labels[container.NeuvectorSetServiceName]; ok {
 		return &Service{Name: seviceName}
 	}
@@ -40,7 +40,7 @@ func (d *ecs) GetService(meta *container.ContainerMeta) *Service {
 		return &Service{Name: task + "." + container}
 	}
 
-	return baseDriver.GetService(meta)
+	return baseDriver.GetService(meta, node)
 }
 
 func (d *ecs) GetPlatformRole(m *container.ContainerMeta) (string, bool) {

--- a/share/orchestration/noop.go
+++ b/share/orchestration/noop.go
@@ -37,11 +37,11 @@ func (d *noop) GetServiceSubnet(envs []string) *net.IPNet {
 	return nil
 }
 
-func (d *noop) GetServiceFromPodLabels(namespace, pod string, labels map[string]string) *Service {
+func (d *noop) GetServiceFromPodLabels(namespace, pod, node string, labels map[string]string) *Service {
 	return nil
 }
 
-func (d *noop) GetService(meta *container.ContainerMeta) *Service {
+func (d *noop) GetService(meta *container.ContainerMeta, node string) *Service {
 	return nil
 }
 

--- a/share/orchestration/rancher.go
+++ b/share/orchestration/rancher.go
@@ -41,16 +41,16 @@ func (d *rancher) isDeployedBy(meta *container.ContainerMeta) bool {
 	return false
 }
 
-func (d *rancher) GetServiceFromPodLabels(namespace, pod string, labels map[string]string) *Service {
+func (d *rancher) GetServiceFromPodLabels(namespace, pod, node string, labels map[string]string) *Service {
 	return nil
 }
 
-func (d *rancher) GetService(meta *container.ContainerMeta) *Service {
+func (d *rancher) GetService(meta *container.ContainerMeta, node string) *Service {
 	if service, _ := meta.Labels[container.RancherKeyStackServiceName]; service != "" {
 		return &Service{Name: service}
 	}
 
-	return baseDriver.GetService(meta)
+	return baseDriver.GetService(meta, node)
 }
 
 func (d *rancher) GetPlatformRole(m *container.ContainerMeta) (string, bool) {

--- a/share/orchestration/types.go
+++ b/share/orchestration/types.go
@@ -24,8 +24,8 @@ type Service struct {
 type Driver interface {
 	GetVersion(reGetK8sVersion, reGetOcVersion bool) (string, string)
 	SetIPAddrScope(ports map[string][]share.CLUSIPAddr, meta *container.ContainerMeta, nets map[string]*container.Network)
-	GetServiceFromPodLabels(namespace, pod string, labels map[string]string) *Service
-	GetService(meta *container.ContainerMeta) *Service
+	GetServiceFromPodLabels(namespace, pod, node string, labels map[string]string) *Service
+	GetService(meta *container.ContainerMeta, node string) *Service
 	GetPlatformRole(meta *container.ContainerMeta) (string, bool) // return platform type and if container should be secured
 	GetDomain(labels map[string]string) string
 	GetServiceSubnet(envs []string) *net.IPNet

--- a/share/orchestration/unknown.go
+++ b/share/orchestration/unknown.go
@@ -12,12 +12,12 @@ type unknown struct {
 	envParser *utils.EnvironParser
 }
 
-func (d *unknown) GetServiceFromPodLabels(namespace, pod string, labels map[string]string) *Service {
+func (d *unknown) GetServiceFromPodLabels(namespace, pod, node string, labels map[string]string) *Service {
 	return nil
 }
 
-func (d *unknown) GetService(meta *container.ContainerMeta) *Service {
-	return baseDriver.GetService(meta)
+func (d *unknown) GetService(meta *container.ContainerMeta, node string) *Service {
+	return baseDriver.GetService(meta, node)
 }
 
 func (d *unknown) GetDomain(labels map[string]string) string {


### PR DESCRIPTION
Eliminate the hash-like identifiers :
(1) label "ClusterID"
(2) label "ibm-cloud-provider-ip"
(3) UUID strings
(4) Node name.

Plus test cases.