### PR TITLE
NVSHAS-7182: Nessus agent create processes at randomized path, which makes very big process profile

### DIFF
--- a/agent/policy/process.go
+++ b/agent/policy/process.go
@@ -5,6 +5,7 @@ import "C"
 
 import (
 	"errors"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
@@ -143,10 +144,12 @@ func MatchProfileProcess(entry *share.CLUSProcessProfileEntry, proc *share.CLUSP
 		} else { // on a spefific file
 			return proc.Path == entry.Path
 		}
-	} else { // recursive directory ( * and /bin/*)
+	} else { // recursive directory ( *, /bin/*, and /usr/*/nginx)
 		if strings.HasSuffix(entry.Path, "/*") {
 			path := entry.Path[:len(entry.Path)-2]
 			return strings.HasPrefix(dir, path) && (entry.Name == proc.Name)
+		} else if index := strings.Index(entry.Path, "/*/"); index > -1 {
+			return strings.HasPrefix(dir, entry.Path[:index]) && (entry.Name == proc.Name) && (bin == filepath.Base(entry.Path))
 		}
 	}
 


### PR DESCRIPTION


Merging "learned" processes rules for the same name but from the same root path (at least one matched parent path token):

a process pair ( name,    path )
(1)   "sleep", "/tmp/my/1/sleep")
(2)   "sleep", "/tmp/my/2/sleep"
merged ==> ( "sleep", "/tmp/my/*/sleep" ), replace rule (1) by the new rule
(3)  ("sleep", "/tmp/my/3/sleep")
consider as rule (2) ===>  ( "sleep", "/tmp/my/*/sleep" ), no new rule


Note: we will not learn "not-image" binaries with the "zero-drift" baseline process profile during Discover mode. You can use the "basic" baseline profile to test them in your containers.

 