### PR TITLE
NVSHAS-7300: enforcer panic when a k8s container inherited the service name from its exited parent pod

### DIFF
--- a/agent/cluster.go
+++ b/agent/cluster.go
@@ -444,10 +444,13 @@ func createWorkload(info *container.ContainerMetaExtra) *share.CLUSWorkload {
 		}
 	}
 
-	if isChild, parent := getSharedContainer(info); isChild {
+	if isChild, parent := getSharedContainer(info); isChild && parent != nil {
 		wl.Service = parent.service
 		wl.Domain = parent.domain
 	} else {
+		// k8s: container is not running. Then, the POD is not running, either.
+		//      In this isChild (true) but wl.Running (false) case,
+		//      the reported service name is not correct but acceptable.
 		svc := global.ORCH.GetService(&info.ContainerMeta, Host.Name)
 		wl.Service = utils.MakeServiceName(svc.Domain, svc.Name)
 		wl.Domain = svc.Domain


### PR DESCRIPTION
k8s environment:
It occurs when the enforcer tried to add an exited child container and its parent pod was already gone. The inherited service name assignment hits empty parent data.