### PR TITLE
NVSHAS-7321: goroutine crash at container.(*containerdDriver).GetParent

### DIFF
--- a/agent/cluster.go
+++ b/agent/cluster.go
@@ -443,7 +443,8 @@ func createWorkload(info *container.ContainerMetaExtra) *share.CLUSWorkload {
 			}
 		}
 	}
-
+	gInfoRLock()
+	defer gInfoRUnlock()
 	if isChild, parent := getSharedContainer(info); isChild && parent != nil {
 		wl.Service = parent.service
 		wl.Domain = parent.domain


### PR DESCRIPTION
It was a concurrent map access case. Add a reader lock to prevent this condition.