### PR TITLE
NVSHAS-7321: goroutine crash at container.(*containerdDriver).GetParent

### DIFF
--- a/agent/bench.go
+++ b/agent/bench.go
@@ -291,7 +291,7 @@ func (b *Bench) BenchLoop() {
 				if c, ok := gInfo.activeContainers[id]; ok {
 					// skip kubernetes pod
 					if Host.Platform != share.PlatformKubernetes || c.parentNS != "" {
-						wls = append(wls, createWorkload(c.info))
+						wls = append(wls, createWorkload(c.info, &c.service, &c.domain))
 						if agentEnv.scanSecrets {
 							group := makeLearnedGroupName(utils.NormalizeForURL(c.service))
 							b.taskScanner.addScanTask(c.pid, name, id, group)
@@ -308,7 +308,7 @@ func (b *Bench) BenchLoop() {
 			for _, c := range gInfo.activeContainers {
 				// skip kubernetes pod
 				if Host.Platform != share.PlatformKubernetes || c.parentNS != "" {
-					wls = append(wls, createWorkload(c.info))
+					wls = append(wls, createWorkload(c.info, &c.service, &c.domain))
 				}
 			}
 			gInfoRUnlock()

--- a/agent/cluster.go
+++ b/agent/cluster.go
@@ -396,7 +396,7 @@ func putContainerForStop(info *container.ContainerMetaExtra, wl *share.CLUSWorkl
 	putWorkload(wl)
 }
 
-func createWorkload(info *container.ContainerMetaExtra) *share.CLUSWorkload {
+func createWorkload(info *container.ContainerMetaExtra, svc, domain *string) *share.CLUSWorkload {
 	wl := share.CLUSWorkload{
 		ID:           info.ID,
 		Name:         info.Name,
@@ -444,20 +444,9 @@ func createWorkload(info *container.ContainerMetaExtra) *share.CLUSWorkload {
 		}
 	}
 
-	// TODO: a temp fix to protect the READ of activeContainers map
-	gInfoRLock()
-	defer gInfoRUnlock()
-
-	if isChild, parent := getSharedContainer(info); isChild && parent != nil {
-		wl.Service = parent.service
-		wl.Domain = parent.domain
-	} else {
-		// k8s: container is not running. Then, the POD is not running, either.
-		//      In this isChild (true) but wl.Running (false) case,
-		//      the reported service name is not correct but acceptable.
-		svc := global.ORCH.GetService(&info.ContainerMeta, Host.Name)
-		wl.Service = utils.MakeServiceName(svc.Domain, svc.Name)
-		wl.Domain = svc.Domain
+	if svc != nil && domain != nil {
+		wl.Service = utils.MakeServiceName(*domain, *svc)
+		wl.Domain = *domain
 	}
 	return &wl
 }
@@ -547,7 +536,7 @@ func clusterAddContainer(ev *ClusterEvent) {
 	log.WithFields(log.Fields{"container": ev.id}).Debug("")
 
 	if cache, ok := wlCacheMap[ev.id]; !ok || cache.wl.Running != ev.info.Running {
-		wl := createWorkload(ev.info)
+		wl := createWorkload(ev.info, ev.service, ev.domain)
 		if ev.role != nil {
 			wl.PlatformRole = *ev.role
 		}
@@ -583,7 +572,7 @@ func clusterStopContainer(ev *ClusterEvent) {
 		// This should not happen with the new code change - 03/02/2017
 		log.WithFields(log.Fields{"id": ev.id}).Error("Miss add event!")
 		// Container might not be intercepted and reported yet.
-		wl := createWorkload(ev.info)
+		wl := createWorkload(ev.info, ev.service, ev.domain)
 		putWorkload(wl)
 		wlCacheMap[ev.id] = &workloadInfo{wl: wl}
 

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1898,7 +1898,7 @@ func taskAddContainer(id string, info *container.ContainerMetaExtra) {
 		// service is not reported until container is running; domain should be filled.
 		// it reports the exited container as well
 		svc := global.ORCH.GetService(&info.ContainerMeta, Host.Name)
-		ev := ClusterEvent{event: EV_ADD_CONTAINER, id: id, info: info, domain: &svc.Domain}
+		ev := ClusterEvent{event: EV_ADD_CONTAINER, id: id, info: info, service: &svc.Name, domain: &svc.Domain}
 		ClusterEventChan <- &ev
 
 		log.Debug("Container not running")

--- a/agent/group_profile.go
+++ b/agent/group_profile.go
@@ -322,7 +322,7 @@ func deleteGroupProfileCache(name string) bool {
 //////////////////////////////////////////////////////
 func isContainerSelected(c *containerData, group *share.CLUSGroup) bool {
 	// TODO: remove "CriteriaKeyAddress" from entry ??
-	wl := createWorkload(c.info)
+	wl := createWorkload(c.info, &c.service, &c.domain)
 	wl.Running = true // from activeContainer
 	wl.Name = c.name
 	wl.Service = c.service


### PR DESCRIPTION
Refer to the service and domain names from the engine and remove the unnecessary getParent function at the cluster operations.