### PR TITLE
NVSHAS-7054 [agent] Added a line of code to update proc user(name) when it is getting evaluated.

### DIFF
--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -1764,6 +1764,10 @@ func (p *Probe) evaluateApplication(proc *procInternal, id string, bKeepAlive bo
 		}
 	}
 
+	// NVSHAS-7054
+	// The effective user was incorrect as it was grabbing the parent's euid instead of the pid's actual euid
+	proc.user =  p.getUserName(proc.pid, proc.euid)
+
 	var action string
 	var bSkipReport, ok, bSkipEval bool
 	if !riskyReported {

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -782,6 +782,11 @@ func (p *Probe) evalNewRunningApp(pid int) {
 
 	// last chance to update fields
 	if c.id != "" { // container processes only, skip host processes
+
+		// NVSHAS-7054
+		// The effective user was incorrect as it was grabbing the parent's euid instead of the pid's actual euid
+		proc.user =  p.getUserName(proc.pid, proc.euid)
+
 		if proc.cmds != nil && proc.cmds[0] != "sshd:" {
 			cmds, _ := global.SYS.ReadCmdLine(proc.pid)
 			if cmds != nil && cmds[0] != "" {


### PR DESCRIPTION
The issue was that when you do a `docker exec --user <user> ...` the nv agent would pick up the host' username instead of the container's username (they share the same uid). I figured out that when we're doing the evaluation, that the process' filepaths look correct but getting the wrong user from `/etc/passwd`. But that wasn't true since the path was correct - it was because the username was inherited by the parent by default and never updated again.  