### PR TITLE
NVSHAS-6992: Pod is at running state but its exited containers were not under the pod.

### DIFF
--- a/agent/cluster.go
+++ b/agent/cluster.go
@@ -399,6 +399,7 @@ func putContainerForStop(info *container.ContainerMetaExtra, wl *share.CLUSWorkl
 func createWorkload(info *container.ContainerMetaExtra, svc, domain *string) *share.CLUSWorkload {
 	wl := share.CLUSWorkload{
 		ID:           info.ID,
+		ShareNetNS:   info.Sandbox,
 		Name:         info.Name,
 		SelfHostname: info.Hostname,
 		AgentID:      Agent.ID,


### PR DESCRIPTION
"containerd": the short-lived containers fail to under their running parent pods because the containerd driver does not provide the sandbox identifiers and we can not relate their pod relationship.

Add a sandbox identifier for a child pod which we already have for the cri-o runtime driver.