### PR TITLE
NVSHAS-6992: docker, Pod is at running state but its exited containers were not under the pod

### DIFF
--- a/share/container/docker.go
+++ b/share/container/docker.go
@@ -156,6 +156,7 @@ func (d *dockerDriver) GetContainer(id string) (*ContainerMetaExtra, error) {
 			Envs:     info.Config.Env,
 			PidMode:  info.HostConfig.PidMode,
 			NetMode:  info.HostConfig.NetworkMode,
+			Sandbox:  info.NetworkSettings.SandboxID,
 		},
 		ImageID:     TrimImageID(info.Image),
 		Privileged:  info.HostConfig.Privileged,
@@ -169,6 +170,13 @@ func (d *dockerDriver) GetContainer(id string) (*ContainerMetaExtra, error) {
 		Networks:    utils.NewSet(),
 		LogPath:     info.LogPath,
 	}
+
+	if meta.Sandbox == "" && meta.Labels != nil {
+		if sandbox, ok := meta.Labels["io.kubernetes.sandbox.id"]; ok {
+			meta.Sandbox = sandbox
+		}
+	}
+
 
 	if info, err := d.client.InspectImage(meta.ImageID); err == nil {
 		meta.Author = info.Author

--- a/share/container/dockerclient/types.go
+++ b/share/container/dockerclient/types.go
@@ -296,6 +296,7 @@ type ContainerInfo struct {
 		NetworkID   string `json:"NetworkID,omitempty" yaml:"NetworkID,omitempty"`
 		EndpointID  string `json:"EndpointID,omitempty" yaml:"EndpointID,omitempty"`
 		SandboxKey  string `json:"SandboxKey,omitempty" yaml:"SandboxKey,omitempty"`
+		SandboxID   string `json:"SandboxID"`
 	}
 	SysInitPath    string
 	ResolvConfPath string


### PR DESCRIPTION
Add the container's sandbox identifier for docker runtime. 