### PR TITLE
Some unnecessary enforcer's log traces are suppressed for reducing i/o accesses

### DIFF
--- a/agent/bench.go
+++ b/agent/bench.go
@@ -888,7 +888,7 @@ func (b *Bench) doContainerCustomCheck(wls []*share.CLUSWorkload) {
 		}
 	}
 
-	log.Info("Running benchmark checks done")
+	log.Debug("Running benchmark checks done")
 }
 
 func (b *Bench) doHostCustomCheck() {

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -2828,7 +2828,8 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 
 	c, ok := p.containerMap[id]
 	if !ok {
-		mLog.WithFields(log.Fields{"proc": proc, "id": id}).Error("SHD: Unknown ID")
+		// the container was exited before we investigate into it
+		mLog.WithFields(log.Fields{"proc": proc, "id": id}).Debug("SHD: Unknown ID")
 		return true
 	}
 

--- a/share/fsmon/fanotify_linux.go
+++ b/share/fsmon/fanotify_linux.go
@@ -358,7 +358,7 @@ func (fn *FaNotify) addSingleFile(r *rootFd, path string, mask uint64) bool {
 	}
 
 	if err := fn.fa.Mark(faMarkAddFlags, mask, unix.AT_FDCWD, path); err != nil {
-		log.WithFields(log.Fields{"path": path, "error": err}).Error("FMON:")
+		log.WithFields(log.Fields{"path": path, "error": err}).Debug("FMON:")
 		return false
 	}
 
@@ -394,7 +394,7 @@ func (fn *FaNotify) StartMonitor(rootPid int) bool {
 
 	r, ok := fn.roots[rootPid]
 	if !ok {
-		log.WithFields(log.Fields{"rootPid": rootPid}).Error("FMON: not found")
+		log.WithFields(log.Fields{"rootPid": rootPid}).Debug("FMON: not found")
 		return false
 	}
 
@@ -410,7 +410,7 @@ func (fn *FaNotify) StartMonitor(rootPid int) bool {
 	for dir, mask := range r.dirMonitorMap {
 		path := ppath + dir
 		if err := fn.fa.Mark(faMarkAddFlags, mask, unix.AT_FDCWD, path); err != nil {
-			log.WithFields(log.Fields{"path": path, "error": err}).Error("FMON:")
+			log.WithFields(log.Fields{"path": path, "error": err}).Debug("FMON:")
 		} else {
 			mLog.WithFields(log.Fields{"path": path, "mask": fmt.Sprintf("0x%08x", mask)}).Debug("FMON:")
 		}

--- a/share/fsmon/monitor.go
+++ b/share/fsmon/monitor.go
@@ -604,7 +604,7 @@ func (w *FileWatch) StartWatch(id string, rootPid int, conf *FsmonConfig, capBlo
 	// log.WithFields(log.Fields{"Access": conf.Rule}).Debug("FMON:")
 	//// no access rules for neuvector and host
 	if !osutil.IsPidValid(rootPid) {
-		log.WithFields(log.Fields{"id": id, "Pid": rootPid}).Error("FMON: invalid Pid")
+		log.WithFields(log.Fields{"id": id, "Pid": rootPid}).Debug("FMON: invalid Pid")
 		return
 	}
 


### PR DESCRIPTION
Move them into debug-level messages since the container was exited before we investigated it.