### PR TITLE
NVSHAS-7445: show empty object in workload if app container is stopped

### DIFF
--- a/share/container/docker.go
+++ b/share/container/docker.go
@@ -156,7 +156,6 @@ func (d *dockerDriver) GetContainer(id string) (*ContainerMetaExtra, error) {
 			Envs:     info.Config.Env,
 			PidMode:  info.HostConfig.PidMode,
 			NetMode:  info.HostConfig.NetworkMode,
-			Sandbox:  info.NetworkSettings.SandboxID,
 		},
 		ImageID:     TrimImageID(info.Image),
 		Privileged:  info.HostConfig.Privileged,
@@ -171,12 +170,12 @@ func (d *dockerDriver) GetContainer(id string) (*ContainerMetaExtra, error) {
 		LogPath:     info.LogPath,
 	}
 
-	if meta.Sandbox == "" && meta.Labels != nil {
+	if meta.Labels != nil {
+		// for k8s only
 		if sandbox, ok := meta.Labels["io.kubernetes.sandbox.id"]; ok {
 			meta.Sandbox = sandbox
 		}
 	}
-
 
 	if info, err := d.client.InspectImage(meta.ImageID); err == nil {
 		meta.Author = info.Author


### PR DESCRIPTION
Docker runtime driver: avoid using docker's native sandbox identifier.