### PR TITLE
NVSHAS-7511: goroutine crash by disabling a feature flag.

### DIFF
--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -2055,11 +2055,16 @@ func (p *Probe) CheckDNSTunneling(ids []string, clientPort share.CLUSProtoPort, 
 }
 
 func (p *Probe) GetProbeSummary() *share.CLUSProbeSummary {
+	var summary *share.CLUSProbeSummary
+	if !p.bProfileEnable {
+		return summary
+	}
+
 	p.lockProcMux()
 	defer p.unlockProcMux()
 
 	// general information
-	summary := &share.CLUSProbeSummary{
+	summary = &share.CLUSProbeSummary{
 		ContainerMap:      uint32(len(p.containerMap)),
 		PidContainerMap:   uint32(len(p.pidContainerMap)),
 		PidProcMap:        uint32(len(p.pidProcMap)),


### PR DESCRIPTION
When collecting the support log, the panic condition occurs with the no runtime protection flag.