### PR TITLE
NVSHAS-7482 disallow non-local metadata names in admission control import

### DIFF
--- a/controller/rest/crdsecurityrule.go
+++ b/controller/rest/crdsecurityrule.go
@@ -2065,6 +2065,13 @@ func (h *nvCrdHandler) parseCurCrdAdmCtrlContent(admCtrlSecRule *resource.NvAdmC
 		}
 	}
 
+	if reviewType == share.ReviewTypeImportAdmCtrl {
+		if name != share.ScopeLocal {
+			errMsg := fmt.Sprintf("%s file format error: invalid metadata name \"%s\"", reviewTypeDisplay, name)
+			return nil, 1, errMsg, ""
+		}
+	}
+
 	var buffer bytes.Buffer
 
 	errCount := 0


### PR DESCRIPTION
Previously the metadata name was only checked when the `reviewType` was `share.ReviewTypeCRD`. The handler for admission control rule/config imports sends a `reviewType` of `share.ReviewTypeImportAdmCtrl`.

Perhaps this validation could be abstracted upwards.