### PR TITLE
NVSHAS-7532: Can not re-create deleted learned group

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -2125,3 +2125,9 @@ func (m CacheMethod) GetConfigKvData(key string) ([]byte, bool) {
 	}
 	return nil, false
 }
+
+func learnedGroupDelete(group string, param interface{}) {
+	if utils.DoesGroupHavePolicyMode(group) && group != api.AllHostGroup {
+		dispatchHelper.LearnGroupDelete(group, isLeader())
+	}
+}

--- a/controller/cache/group.go
+++ b/controller/cache/group.go
@@ -1666,6 +1666,10 @@ func (m CacheMethod) DeleteGroupCache(name string, acc *access.AccessControl) er
 		}
 	}
 	clusHelper.DeleteCustomCheckConfig(name)
+
+	// remove dispatcher entry
+	customGroupDelete(name, nil)
+	learnedGroupDelete(name, nil)
 	return nil
 }
 

--- a/controller/cache/object.go
+++ b/controller/cache/object.go
@@ -1461,7 +1461,7 @@ func workloadUpdate(nType cluster.ClusterNotifyType, key string, value []byte) {
 			addrWorkloadAdd(wl.ID, wlCache)
 		}
 		//NVSHAS-7433, it is possible newly added short-lived workload is not running
-		//so we need to delete Workload:IP and its related policy 
+		//so we need to delete Workload:IP and its related policy
 		if wl.Running || newWorkload {
 			connectWorkloadAdd(wl.ID, wlCache)
 		}
@@ -1725,6 +1725,7 @@ func registerEventHandlers() {
 	evhdls.Register(EV_GROUP_DELETE, []eventHandlerFunc{
 		connectGroupDelete,
 		customGroupDelete,
+		learnedGroupDelete,
 		automodeGroupDelete,
 	})
 	evhdls.Register(EV_WORKLOAD_AGENT_CHANGE, []eventHandlerFunc{


### PR DESCRIPTION
The deleted learned service groups fail to delete the dispatcher entry. Thus, the re-created group can not be formed. 