### PR TITLE
Network policy pull regulator

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -272,6 +272,7 @@ func main() {
 	disable_scan_secrets := flag.Bool("no_scrt", false, "disable secret scans")
 	disable_auto_benchmark := flag.Bool("no_auto_benchmark", false, "disable auto benchmark")
 	disable_system_protection := flag.Bool("no_sys_protect", false, "disable system protections")
+	policy_puller := flag.Int("policy_puller", 0, "set policy pulling period")
 	flag.Parse()
 
 	if *debug {
@@ -309,6 +310,11 @@ func main() {
 	if *disable_system_protection {
 		log.Info("System protection is disabled (process/file profiles)")
 		agentEnv.systemProfiles = false
+	}
+
+	agentEnv.netPolicyPuller = *policy_puller
+	if *policy_puller != 0 {
+		log.WithFields(log.Fields{"period": *policy_puller}).Info("policy pull regulator")
 	}
 
 	if *join != "" {

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -2155,10 +2155,25 @@ func taskDPConnect() {
 	dp.DPCtrlSetSysConf(&xffenabled)
 }
 
+var nextNetworkPolicyVer *share.CLUSGroupIPPolicyVer  // incoming network ploicy version
 // gInfo write should only be done in this thread; and gInfo read doesn't need to be locked
 // in this thread.
 func containerTaskWorker(probeChan chan *probe.ProbeMessage, fsmonChan chan *fsmon.MonitorMessage, dpStatusChan chan bool) {
 	log.Debug()
+	var pnpTargetTick, ticks int
+	nPolicyPullPeriod := agentEnv.netPolicyPuller
+	calculationTicker := time.NewTicker(time.Second * 2)
+	if nPolicyPullPeriod > 0 {
+		log.WithFields(log.Fields{"netPolicyPuller": nPolicyPullPeriod}).Info()
+		pnpTargetTick = 1			// minimum break
+		if nPolicyPullPeriod > 0 {	// valid period
+			if nPolicyPullPeriod > 1 {
+				pnpTargetTick = nPolicyPullPeriod/2	// maximum, per 2 seconds
+			}
+		}
+	} else {
+		calculationTicker.Stop()	// no timer
+	}
 
 	for {
 		if shouldExit() {
@@ -2167,6 +2182,17 @@ func containerTaskWorker(probeChan chan *probe.ProbeMessage, fsmonChan chan *fsm
 		}
 
 		select {
+		case <-calculationTicker.C:
+			ticks++
+			if ticks > pnpTargetTick {
+				ticks = 0
+				if nextNetworkPolicyVer != nil {
+					if !systemUpdatePolicy(*nextNetworkPolicyVer) {
+						ticks = pnpTargetTick  // version changed? trigger a quick cycle
+					}
+				}
+				nextNetworkPolicyVer = nil
+			}
 		case task := <-ContainerTaskChan:
 			taskName := ContainerTaskName[task.task]
 			log.WithFields(log.Fields{"task": taskName, "id": task.id}).Debug("Task received")

--- a/agent/system.go
+++ b/agent/system.go
@@ -218,51 +218,65 @@ func mergeWlPolicyConfig(rules []share.CLUSGroupIPPolicy, ruleslen, wlslots, wle
 	return newGroupIPPolicy
 }
 
-func systemConfigPolicyVersion(nType cluster.ClusterNotifyType, key string, value []byte) []share.CLUSGroupIPPolicy {
-	var s share.CLUSGroupIPPolicyVer
+func systemConfigPolicyVersion(s share.CLUSGroupIPPolicyVer) []share.CLUSGroupIPPolicy {
 	groupIPPolicy := make([]share.CLUSGroupIPPolicy, 0)
 
-	if err := json.Unmarshal(value, &s); err == nil {
-		//check whether key "recalculate/groupIPRules" exist, if not
-		//use old key "network/groupIPRules" for rolling upgrade case
-		var rule_key, newRuleKey string
-		rule_key = fmt.Sprintf("%s/", share.CLUSRecalPolicyIPRulesKey(share.PolicyIPRulesDefaultName))
-		if cluster.Exist(rule_key) {
-			// indicate network policy version change.
-			newRuleKey = fmt.Sprintf("%s%s/", rule_key, s.PolicyIPRulesVersion)
-		} else {
-			rule_key = fmt.Sprintf("%s/", share.CLUSPolicyIPRulesKey(share.PolicyIPRulesDefaultName))
-			if !cluster.Exist(rule_key) {
-				return groupIPPolicy
-			}
-			// indicate network policy version change.
-			newRuleKey = fmt.Sprintf("%s%s/", rule_key, s.PolicyIPRulesVersion)
+	//check whether key "recalculate/groupIPRules" exist, if not
+	//use old key "network/groupIPRules" for rolling upgrade case
+	var rule_key, newRuleKey string
+	rule_key = fmt.Sprintf("%s/", share.CLUSRecalPolicyIPRulesKey(share.PolicyIPRulesDefaultName))
+	if cluster.Exist(rule_key) {
+		// indicate network policy version change.
+		newRuleKey = fmt.Sprintf("%s%s/", rule_key, s.PolicyIPRulesVersion)
+	} else {
+		rule_key = fmt.Sprintf("%s/", share.CLUSPolicyIPRulesKey(share.PolicyIPRulesDefaultName))
+		if !cluster.Exist(rule_key) {
+			return groupIPPolicy
 		}
-
-		//combine group ip rules from separate slots
-		groupIPPolicy = getPolicyConfig(newRuleKey, s.SlotNo, s.RulesLen)
-
-		if groupIPPolicy != nil && len(groupIPPolicy) > 0 && s.WorkloadSlot > 0 && s.WorkloadLen > 0 {
-			groupIPPolicy = mergeWlPolicyConfig(groupIPPolicy, s.RulesLen, s.WorkloadSlot, s.WorkloadLen)
-		}
-		//log.WithFields(log.Fields{"mergelen":len(groupIPPolicy)}).Debug("after merge")
+		// indicate network policy version change.
+		newRuleKey = fmt.Sprintf("%s%s/", rule_key, s.PolicyIPRulesVersion)
 	}
+
+	//combine group ip rules from separate slots
+	groupIPPolicy = getPolicyConfig(newRuleKey, s.SlotNo, s.RulesLen)
+
+	if groupIPPolicy != nil && len(groupIPPolicy) > 0 && s.WorkloadSlot > 0 && s.WorkloadLen > 0 {
+		groupIPPolicy = mergeWlPolicyConfig(groupIPPolicy, s.RulesLen, s.WorkloadSlot, s.WorkloadLen)
+	}
+	//log.WithFields(log.Fields{"mergelen":len(groupIPPolicy)}).Debug("after merge")
 	return groupIPPolicy
 }
 
+// parent goroutine: containerTaskWorker()
 func systemConfigPolicy(nType cluster.ClusterNotifyType, key string, value []byte) {
-	//get group ip rules from cluster
-	groupIPPolicy := systemConfigPolicyVersion(nType, key, value)
-
-	if len(groupIPPolicy) == 0 && pe.NetworkPolicy == nil {
-		log.Error("Empty policy")
-		return
-	}
-
 	if nType == cluster.ClusterNotifyDelete {
 		// This should not happen
 		log.Error("Policy key delete not supported!")
 		return
+	}
+
+	//get group ip rules from cluster
+	var s share.CLUSGroupIPPolicyVer
+	if err := json.Unmarshal(value, &s); err != nil {
+		log.WithFields(log.Fields{"error": err}).Error()
+		return
+	}
+
+	if agentEnv.netPolicyPuller == 0 {
+		systemUpdatePolicy(s) // inline
+	} else {
+		nextNetworkPolicyVer = &s // regulator
+	}
+}
+
+func systemUpdatePolicy(s share.CLUSGroupIPPolicyVer) bool {
+	// log.WithFields(log.Fields{"ver": s.PolicyIPRulesVersion}).Debug()
+	groupIPPolicy := systemConfigPolicyVersion(s)
+	if len(groupIPPolicy) == 0 {
+		if pe.NetworkPolicy == nil {
+			log.Error("Empty policy")
+		}
+		return false
 	}
 
 	wm := initWorkloadPolicyMap()
@@ -309,6 +323,7 @@ func systemConfigPolicy(nType cluster.ClusterNotifyType, key string, value []byt
 			prober.StartMonitorConnection()
 		}
 	}
+	return true
 }
 
 func hostPolicyLookup(conn *dp.Connection) (uint32, uint8, bool) {
@@ -977,7 +992,7 @@ func (p *systemConfigTask) handler() {
 }
 
 func systemUpdateHandler(nType cluster.ClusterNotifyType, key string, value []byte, modifyIdx uint64) {
-	// log.WithFields(log.Fields{"nType": nType, "key": key}).Debug("")
+	// log.WithFields(log.Fields{"nType": nType, "key": key}).Debug()
 	configTask := &systemConfigTask{
 		nType: nType,
 		key:   key,

--- a/agent/types.go
+++ b/agent/types.go
@@ -21,6 +21,7 @@ type AgentEnvInfo struct {
 	scanSecrets          bool
 	autoBenchmark        bool
 	systemProfiles       bool
+	netPolicyPuller      int
 }
 
 const (

--- a/monitor/monitor.c
+++ b/monitor/monitor.c
@@ -44,6 +44,7 @@
 #define ENV_NO_SCAN_SECRETS    "ENF_NO_SECRET_SCANS"
 #define ENV_NO_AUTO_BENCHMARK  "ENF_NO_AUTO_BENCHMARK"
 #define ENV_NO_SYSTEM_PROTECT  "ENF_NO_SYSTEM_PROFILES"
+#define ENV_POLICY_PULLER      "ENF_NETPOLICY_PULL_INTERVAL"
 #define ENV_PWD_VALID_UNIT     "PWD_VALID_UNIT"
 #define ENV_RANCHER_EP         "RANCHER_EP"
 #define ENV_RANCHER_SSO        "RANCHER_SSO"
@@ -204,7 +205,7 @@ static pid_t fork_exec(int i)
     char *args[PROC_ARGS_MAX], *join, *adv, *bind, *url, *iface, *subnets, *cnet_type;
     char *lan_port, *rpc_port, *grpc_port, *fed_port, *server_port, *join_port, *adv_port, *adm_port;
     char *license, *registry, *repository, *tag, *user, *pass, *base, *api_user, *api_pass, *enable;
-    char *on_demand, *pwd_valid_unit, *rancher_ep, *debug_level;
+    char *on_demand, *pwd_valid_unit, *rancher_ep, *debug_level, *policy_pull_period;
     char *telemetry_neuvector_ep, *telemetry_current_ver, *telemetry_freq;
     int a;
 
@@ -471,10 +472,14 @@ static pid_t fork_exec(int i)
         if (getenv(ENV_NO_SYSTEM_PROTECT)) {
             args[a ++] = "-no_sys_protect";
         }
+        if ((policy_pull_period = getenv(ENV_POLICY_PULLER)) != NULL) {
+            args[a ++] = "-policy_puller";
+            args[a ++] = policy_pull_period;
+        }
 
         args[a] = NULL;
         break;
-    
+
     case PROC_CTRL_OPA:
         args[0] = g_procs[i].path;
         a = 1;


### PR DESCRIPTION
Add network policy pulling regulator at enforcers by adding an environmental variable on enforcers:

- name: ENF_NETPOLICY_PULL_INTERVAL
              value: "60"        

The parameter to adjust the pull timer. default: 0 (or without this variable), it keeps the original inline behaviors, 

Other values ("N") in seconds will have the assisted regulator:  
(1) positive value: It is regulated for at least N seconds pulling breaks. (No pull within N seconds).
(2) negative value: no network policy pull.