### PR TITLE
NVSHAS-7563: Enforcer traceback when runtime protection is disabled

### DIFF
--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -1353,6 +1353,9 @@ func (p *Probe) handleProcExit(pid int) *procInternal {
 
 // after FORK event but before EXEC
 func (p *Probe) handleProcUIDChange(pid, ruid, euid int) {
+	if !p.bProfileEnable {
+		return
+	}
 	if proc, ok := p.pidProcMap[pid]; ok {
 		if (proc.reported & escalatReported) > 0 {
 			return


### PR DESCRIPTION
When the runtime protection is disabled, we also disable UID escalation evaluation.