### PR TITLE
NVSHAS-7465, improve network/dlp/waf rule parsing logic on controller and agent, treat 'container' group as special group and only expand it on agent to save kv and internal traffic

### DIFF
--- a/agent/policy/network.go
+++ b/agent/policy/network.go
@@ -547,20 +547,135 @@ func fillWorkloadAddress(addr *share.CLUSWorkloadAddr, addrMap map[string]*share
 	}
 }
 
+func getPortsForApplicationAg(appMap map[share.CLUSProtoPort]*share.CLUSApp, application uint32) string {
+	var ports string = ""
+	for protoPort, app := range appMap {
+		if app.Application == application || app.Proto == application {
+			if ports == "" {
+				ports = fmt.Sprintf("%d", protoPort.Port)
+			} else {
+				ports = fmt.Sprintf("%s,%d", ports, protoPort.Port)
+			}
+		}
+	}
+	return ports
+}
+
+func getMappedPortAg(portMap map[share.CLUSProtoPort]*share.CLUSMappedPort, ports string) string {
+	var pp string = ""
+	portList := strings.Split(ports, ",")
+	for _, ap := range portList {
+		proto, pl, ph, err := utils.ParsePortRangeLink(ap)
+		if err != nil {
+			// log.WithFields(log.Fields{"port": ap}).Error("Fail to parse")
+			continue
+		}
+		for _, mp := range portMap {
+			// seems the mapping is not ip specific, so ip is ignored in mapping search
+			if (mp.IPProto == proto || proto == 0) && (mp.Port >= pl && mp.Port <= ph) {
+				if pp == "" {
+					pp = utils.GetPortLink(mp.IPProto, mp.HostPort)
+				} else {
+					pp = fmt.Sprintf("%s,%s", pp, utils.GetPortLink(mp.IPProto, mp.HostPort))
+				}
+			}
+		}
+	}
+	return pp
+}
+
+func fillPortsForWorkloadAddressAg(wlAddr *share.CLUSWorkloadAddr, apps []share.CLUSPortApp, pInfo *WorkloadIPPolicyInfo) {
+	var pp string
+
+	//log.WithFields(log.Fields{"pInfo": pInfo, "apps": apps}).Debug("")
+	if apps != nil && len(apps) != 0 {
+		wlAddr.LocalPortApp = make([]share.CLUSPortApp, 0)
+		wlAddr.NatPortApp = make([]share.CLUSPortApp, 0)
+		for _, app := range apps {
+			if app.Ports == "" {
+				pp = "any"
+			} else {
+				pp = app.Ports
+			}
+			wlAddr.LocalPortApp = append(wlAddr.LocalPortApp,
+				share.CLUSPortApp{
+					Ports:       pp,
+					Application: app.Application,
+					CheckApp:    app.CheckApp,
+				})
+			mapp := getMappedPortAg(pInfo.PortMap, pp)
+			if mapp != "" {
+				wlAddr.NatPortApp = append(wlAddr.NatPortApp,
+					share.CLUSPortApp{
+						Ports:       mapp,
+						Application: app.Application,
+						CheckApp:    app.CheckApp,
+					})
+			}
+
+			// For some app, we may not always reliablely identify them.
+			// So we utilize the recognized ports. If the app
+			// is not identified on these ports, we handle them the same as
+			// the specified app
+			if app.CheckApp && app.Application >= C.DPI_APP_PROTO_MARK {
+				appPorts := getPortsForApplicationAg(pInfo.AppMap, app.Application)
+				if app.Ports == "" {
+					pp = appPorts
+				} else {
+					pp = utils.GetCommonPorts(appPorts, app.Ports)
+				}
+				if pp != "" {
+					wlAddr.LocalPortApp = append(wlAddr.LocalPortApp,
+						share.CLUSPortApp{
+							Ports:       pp,
+							Application: C.DP_POLICY_APP_UNKNOWN,
+							CheckApp:    true,
+						})
+
+					mapp := getMappedPortAg(pInfo.PortMap, pp)
+					if mapp != "" {
+						wlAddr.NatPortApp = append(wlAddr.NatPortApp,
+							share.CLUSPortApp{
+								Ports:       mapp,
+								Application: C.DP_POLICY_APP_UNKNOWN,
+								CheckApp:    true,
+							})
+					}
+				}
+			}
+		}
+	}
+}
+
 func getRelevantWorkload(addrs []*share.CLUSWorkloadAddr,
-	pMap map[string]*WorkloadIPPolicyInfo) ([]*share.CLUSWorkloadAddr, []*WorkloadIPPolicyInfo) {
+	pMap map[string]*WorkloadIPPolicyInfo, isto bool) ([]*share.CLUSWorkloadAddr, []*WorkloadIPPolicyInfo) {
 
 	wlList := make([]*share.CLUSWorkloadAddr, 0)
 	pInfoList := make([]*WorkloadIPPolicyInfo, 0)
 	for _, addr := range addrs {
 		if addr.WlID == share.CLUSWLModeGroup {
-			for id, pInfo := range pMap {
-				mode := pInfo.Policy.Mode
-				if strings.Contains(addr.PolicyMode, mode) {
-					wlList = append(wlList, &share.CLUSWorkloadAddr{WlID: id,
-						LocalPortApp: addr.LocalPortApp, NatPortApp: addr.NatPortApp})
-					pInfoList = append(pInfoList, pInfo)
+			if (polAppDir&C.DP_POLICY_APPLY_EGRESS > 0 && !isto) ||
+				(polAppDir&C.DP_POLICY_APPLY_INGRESS > 0 && isto) {
+				for id, pInfo := range pMap {
+					mode := pInfo.Policy.Mode
+					if strings.Contains(addr.PolicyMode, mode) {
+						wlList = append(wlList, &share.CLUSWorkloadAddr{WlID: id,
+							LocalPortApp: addr.LocalPortApp, NatPortApp: addr.NatPortApp})
+						pInfoList = append(pInfoList, pInfo)
+					}
 				}
+			}
+		} else if addr.WlID == share.CLUSWLAllContainer {
+			for id, pInfo := range pMap {
+				wlAddr := share.CLUSWorkloadAddr{
+					WlID: id,
+					PolicyMode: pInfo.Policy.Mode,
+				}
+				if isto {
+					fillPortsForWorkloadAddressAg(&wlAddr, addr.LocalPortApp, pInfo)
+				}
+				wlList = append(wlList, &wlAddr)
+				pInfoList = append(pInfoList, pInfo)
 			}
 		} else {
 			if pInfo, ok := pMap[addr.WlID]; ok {
@@ -573,20 +688,34 @@ func getRelevantWorkload(addrs []*share.CLUSWorkloadAddr,
 }
 
 func getWorkload(addrs []*share.CLUSWorkloadAddr,
-	wlMap map[string]*share.CLUSWorkloadAddr) []*share.CLUSWorkloadAddr {
+	wlMap map[string]*share.CLUSWorkloadAddr, isto bool) []*share.CLUSWorkloadAddr {
 
 	wlList := make([]*share.CLUSWorkloadAddr, 0)
 	for _, addr := range addrs {
 		if addr.WlID == share.CLUSWLModeGroup {
-			for id, wl := range wlMap {
-				if strings.Contains(addr.PolicyMode, wl.PolicyMode) {
-					if addr.NatPortApp == nil  || len(addr.NatPortApp) <= 0 {//PAI
-						wlList = append(wlList, &share.CLUSWorkloadAddr{WlID: id,
-								LocalPortApp: addr.LocalPortApp, NatPortApp: addr.NatPortApp})
-					} else {
-						wlList = append(wlList, &share.CLUSWorkloadAddr{WlID: id,
-								LocalPortApp: addr.LocalPortApp, NatPortApp: wl.NatPortApp})
+			if (polAppDir&C.DP_POLICY_APPLY_EGRESS > 0 && isto) ||
+				(polAppDir&C.DP_POLICY_APPLY_INGRESS > 0 && !isto) {
+				for id, wl := range wlMap {
+					if strings.Contains(addr.PolicyMode, wl.PolicyMode) {
+						if addr.NatPortApp == nil  || len(addr.NatPortApp) <= 0 {//PAI
+							wlList = append(wlList, &share.CLUSWorkloadAddr{WlID: id,
+									LocalPortApp: addr.LocalPortApp, NatPortApp: addr.NatPortApp})
+						} else {
+							wlList = append(wlList, &share.CLUSWorkloadAddr{WlID: id,
+									LocalPortApp: addr.LocalPortApp, NatPortApp: wl.NatPortApp})
+						}
 					}
+				}
+			}
+		} else if addr.WlID == share.CLUSWLAllContainer {
+			if (polAppDir&C.DP_POLICY_APPLY_EGRESS > 0 && isto) ||
+				(polAppDir&C.DP_POLICY_APPLY_INGRESS > 0 && !isto) {
+				for id, wl := range wlMap {
+					wlAddr := share.CLUSWorkloadAddr{
+						WlID: id,
+						PolicyMode: wl.PolicyMode,
+					}
+					wlList = append(wlList, &wlAddr)
 				}
 			}
 		} else {
@@ -660,8 +789,8 @@ func (e *Engine) parseGroupIPPolicy(p []share.CLUSGroupIPPolicy, workloadPolicyM
 		}
 
 		/* create egress rules */
-		wlList, pInfoList := getRelevantWorkload(pp.From, workloadPolicyMap)
-		wlToList := getWorkload(pp.To, addrMap)
+		wlList, pInfoList := getRelevantWorkload(pp.From, workloadPolicyMap, false)
+		wlToList := getWorkload(pp.To, addrMap, true)
 		for i, from := range wlList {
 			pInfo := pInfoList[i]
 			for _, to := range wlToList {
@@ -702,8 +831,8 @@ func (e *Engine) parseGroupIPPolicy(p []share.CLUSGroupIPPolicy, workloadPolicyM
 		}
 
 		/* create ingress rules */
-		wlList, pInfoList = getRelevantWorkload(pp.To, workloadPolicyMap)
-		wlFromList := getWorkload(pp.From, addrMap)
+		wlList, pInfoList = getRelevantWorkload(pp.To, workloadPolicyMap, true)
+		wlFromList := getWorkload(pp.From, addrMap, false)
 		for i, to := range wlList {
 			pInfo := pInfoList[i]
 			for _, from := range wlFromList {

--- a/agent/policy/type.go
+++ b/agent/policy/type.go
@@ -9,10 +9,14 @@ import (
 	"github.com/neuvector/neuvector/share/utils"
 )
 
+var polAppDir int
+
 type GroupProcPolicyCallback func(id string) (*share.CLUSProcessProfile, bool)
 
 type WorkloadIPPolicyInfo struct {
 	RuleMap    map[string]*dp.DPPolicyIPRule
+	AppMap     map[share.CLUSProtoPort]*share.CLUSApp
+	PortMap    map[share.CLUSProtoPort]*share.CLUSMappedPort
 	Policy     dp.DPWorkloadIPPolicy
 	Configured bool
 	SkipPush   bool
@@ -39,7 +43,7 @@ type Engine struct {
 	PolicyAddrMap  map[string]share.CLUSSubnet
 }
 
-func (e *Engine) Init(HostID string, HostIPs utils.Set, TunnelIP []net.IPNet, cb GroupProcPolicyCallback) {
+func (e *Engine) Init(HostID string, HostIPs utils.Set, TunnelIP []net.IPNet, cb GroupProcPolicyCallback, pad int) {
 	e.HostID = HostID
 	e.HostIPs = HostIPs
 	e.TunnelIP = TunnelIP
@@ -51,4 +55,5 @@ func (e *Engine) Init(HostID string, HostIPs utils.Set, TunnelIP []net.IPNet, cb
 	}
 	e.getGroupRule = cb
 	e.PolicyAddrMap = make(map[string]share.CLUSSubnet)
+	polAppDir = pad
 }

--- a/agent/system.go
+++ b/agent/system.go
@@ -48,7 +48,7 @@ func policyInit() {
 	} else {
 		policyApplyDir = C.DP_POLICY_APPLY_EGRESS
 	}
-	pe.Init(Host.ID, gInfo.hostIPs, Host.TunnelIP, ObtainGroupProcessPolicy)
+	pe.Init(Host.ID, gInfo.hostIPs, Host.TunnelIP, ObtainGroupProcessPolicy, policyApplyDir)
 }
 
 func updateContainerPolicyMode(id, policyMode string) {
@@ -145,8 +145,15 @@ func systemConfigProc(nType cluster.ClusterNotifyType, key string, value []byte)
 func initWorkloadPolicyMap() map[string]*policy.WorkloadIPPolicyInfo {
 	workloadPolicyMap := make(map[string]*policy.WorkloadIPPolicyInfo)
 	for wlID, c := range gInfo.activeContainers {
+		//container that has no datapath needs not be
+		//in workloadPolicyMap to save memory and cpu
+		if !c.hasDatapath {
+			continue
+		}
 		pInfo := policy.WorkloadIPPolicyInfo{
 			RuleMap: make(map[string]*dp.DPPolicyIPRule),
+			AppMap: c.appMap,
+			PortMap: c.portMap,
 			Policy: dp.DPWorkloadIPPolicy{
 				WlID:        wlID,
 				WorkloadMac: nil,

--- a/controller/cache/dlp_rule.go
+++ b/controller/cache/dlp_rule.go
@@ -265,7 +265,7 @@ func assocWl2PolicyIds(grp string, senset utils.Set, outside_wl2sensor map[strin
 	if grpcache, ok := groupCacheMap[grp]; ok {
 		for _, m := range grpcache.members.ToSlice() {
 			wlid := m.(string)
-			if wlcache, ok := wlCacheMap[wlid]; ok {
+			if wlcache, ok := wlCacheMap[wlid]; ok && wlcache.workload.HasDatapath {
 				inside_grps = inside_grps.Union(wlcache.groups)
 			}
 		}
@@ -303,6 +303,10 @@ func assocWl2PolicyIds(grp string, senset utils.Set, outside_wl2sensor map[strin
 	if grpcache, ok := groupCacheMap[grp]; ok {
 		for _, m := range grpcache.members.ToSlice() {
 			wlid := m.(string)
+			//only include wl that has datapath to save memory and cpu
+			if wlcache, exist := wlCacheMap[wlid]; exist && !wlcache.workload.HasDatapath {
+				continue
+			}
 			if rids, ok := wl2policies[wlid]; !ok {
 				wl2policies[wlid] = inside_ruleids
 			} else {
@@ -316,6 +320,10 @@ func assocWl2PolicyIds(grp string, senset utils.Set, outside_wl2sensor map[strin
 		if ogrpcache, ok := groupCacheMap[ogrp]; ok {
 			for _, om := range ogrpcache.members.ToSlice() {
 				owlid := om.(string)
+				//only include wl that has datapath to save memory and cpu
+				if wlcache, exist := wlCacheMap[owlid]; exist && !wlcache.workload.HasDatapath {
+					continue
+				}
 				if orids, ok := outside_wl2policies[owlid]; !ok {
 					outside_wl2policies[owlid] = outside_ruleids
 				} else {
@@ -356,6 +364,10 @@ func assocWl2Sensors(grp string, senset utils.Set, wl2sensors map[string]map[str
 		}
 		for _, m := range grpcache.members.ToSlice() {
 			wlid := m.(string)
+			//only include wl that has datapath to save memory and cpu
+			if wlcache, exist := wlCacheMap[wlid]; exist && !wlcache.workload.HasDatapath {
+				continue
+			}
 			if sam, ok := wl2sensors[wlid]; !ok {
 				if wl2sensors[wlid] == nil {
 					wl2sensors[wlid] = make(map[string]string)

--- a/controller/cache/waf_rule.go
+++ b/controller/cache/waf_rule.go
@@ -283,7 +283,7 @@ func assocWafWl2PolicyIds(grp string, senset utils.Set, outside_wl2sensor map[st
 	if grpcache, ok := groupCacheMap[grp]; ok {
 		for _, m := range grpcache.members.ToSlice() {
 			wlid := m.(string)
-			if wlcache, ok := wlCacheMap[wlid]; ok {
+			if wlcache, ok := wlCacheMap[wlid]; ok && wlcache.workload.HasDatapath {
 				inside_grps = inside_grps.Union(wlcache.groups)
 			}
 		}
@@ -321,6 +321,10 @@ func assocWafWl2PolicyIds(grp string, senset utils.Set, outside_wl2sensor map[st
 	if grpcache, ok := groupCacheMap[grp]; ok {
 		for _, m := range grpcache.members.ToSlice() {
 			wlid := m.(string)
+			//only include wl that has datapath to save memory and cpu
+			if wlcache, exist := wlCacheMap[wlid]; exist && !wlcache.workload.HasDatapath {
+				continue
+			}
 			if rids, ok := wl2policies[wlid]; !ok {
 				wl2policies[wlid] = inside_ruleids
 			} else {
@@ -334,6 +338,10 @@ func assocWafWl2PolicyIds(grp string, senset utils.Set, outside_wl2sensor map[st
 		if ogrpcache, ok := groupCacheMap[ogrp]; ok {
 			for _, om := range ogrpcache.members.ToSlice() {
 				owlid := om.(string)
+				//only include wl that has datapath to save memory and cpu
+				if wlcache, exist := wlCacheMap[owlid]; exist && !wlcache.workload.HasDatapath {
+					continue
+				}
 				if orids, ok := outside_wl2policies[owlid]; !ok {
 					outside_wl2policies[owlid] = outside_ruleids
 				} else {
@@ -374,6 +382,10 @@ func assocWafWl2Sensors(grp string, senset utils.Set, wl2sensors map[string]map[
 		}
 		for _, m := range grpcache.members.ToSlice() {
 			wlid := m.(string)
+			//only include wl that has datapath to save memory and cpu
+			if wlcache, exist := wlCacheMap[wlid]; exist && !wlcache.workload.HasDatapath {
+				continue
+			}
 			if sam, ok := wl2sensors[wlid]; !ok {
 				if wl2sensors[wlid] == nil {
 					wl2sensors[wlid] = make(map[string]string)

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -1095,6 +1095,7 @@ var CLUSWLFqdnPrefix string = "fqdn:"
 var CLUSLearnedHostPrefix string = "Host:"
 var CLUSLearnedWorkloadPrefix string = "Workload:"
 var CLUSEndpointIngress string = "ingress"
+var CLUSWLAllContainer string = "nv.allcontainer"
 
 const DefaultGroupRuleID uint32 = 0
 const PolicyLearnedIDBase = 10000

--- a/share/utils/utils.go
+++ b/share/utils/utils.go
@@ -475,6 +475,60 @@ func GetPortRangeLink(ipproto uint8, port uint16, portR uint16) string {
 	}
 }
 
+func GetCommonPorts(ports1 string, ports2 string) string {
+	var p, pp string = "", ""
+	var low, high uint16
+	var proto uint8
+
+	p1 := strings.Split(ports1, ",")
+	p2 := strings.Split(ports2, ",")
+	for _, pp1 := range p1 {
+		proto1, low1, high1, err := ParsePortRangeLink(pp1)
+		if err != nil {
+			// log.WithFields(log.Fields{"port": ports1}).Error("Fail to parse")
+			continue
+		}
+		for _, pp2 := range p2 {
+			proto2, low2, high2, err := ParsePortRangeLink(pp2)
+			if err != nil {
+				// log.WithFields(log.Fields{"port": ports2}).Error("Fail to parse")
+				continue
+			}
+
+			if proto1 == 0 {
+				proto = proto2
+			} else if proto2 == 0 {
+				proto = proto1
+			} else if proto1 == proto2 {
+				proto = proto1
+			} else {
+				continue
+			}
+			if high1 < low2 || high2 < low1 {
+				continue
+			}
+			if low1 > low2 {
+				low = low1
+			} else {
+				low = low2
+			}
+			if high1 > high2 {
+				high = high2
+			} else {
+				high = high1
+			}
+			pp = GetPortRangeLink(proto, low, high)
+			if p == "" {
+				p = pp
+			} else {
+				p = fmt.Sprintf("%s,%s", p, pp)
+			}
+		}
+	}
+	//log.WithFields(log.Fields{"ports1": ports1, "ports2": ports2, "common": p}).Debug()
+	return p
+}
+
 func InterpretIP(ip, ipR net.IP) string {
 	str := ip.String()
 	if ipR != nil {


### PR DESCRIPTION
Also requested by a customer and can be applied in general, if user create a 'container' to 'container' any/any rule, all subsequent wl->wl rule will not be pushed to kv and enforcers, this will greatly reduce network policy volumn, and user can focus on DLP and WAF detection. In this case DLP will only detect on edge traffic, eg.) ingress/egrss from/to external etc.