### PR TITLE
 NVSHAS-5830 fix for struct2Text

### DIFF
--- a/controller/common/output.go
+++ b/controller/common/output.go
@@ -136,12 +136,12 @@ func struct2Text(elog interface{}) string {
 				emt := f.Type().Field(j)
 				emf := f.Field(j)
 
-				if tag := emt.Tag.Get("json"); tag != "" {
+				if tag := emt.Tag.Get("json"); tag != "" && tag != "-" {
 					logText = appendLogField(logText, tag, emf)
 				}
 			}
 		} else {
-			if tag := t.Tag.Get("json"); tag != "" {
+			if tag := t.Tag.Get("json"); tag != "" && tag != "-" {
 				logText = appendLogField(logText, tag, f)
 			}
 		}


### PR DESCRIPTION
Fixed an issue where non json format syslog messages would include json "-" tag. This would cause excluded json fields to be included in non json output for syslogger.