### PR TITLE
NVSHAS-6700 - Adding debugging logs to help debug miss classified

### DIFF
--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -510,6 +510,8 @@ func (p *Probe) addContainerProcess(c *procContainer, pid int) {
 	} else {
 		c.children.Add(pid) // nodes only has a pool
 	}
+	log.WithFields(log.Fields{"pid": pid, "container": c.id}).Debug("PROC: New container Process")
+
 }
 
 func (p *Probe) cleanupProcessInContainer(id string) {

--- a/controller/cache/log.go
+++ b/controller/cache/log.go
@@ -326,7 +326,9 @@ func recordEvent(rlog *api.Event) {
 }
 
 func recordIncident(rlog *api.Incident) {
-	log.WithFields(log.Fields{"name": rlog.Name}).Debug("")
+	log.WithFields(log.Fields{
+		"incident": rlog,
+	}).Debug("Incident Information")
 
 	if curIncidentIndex == logCacheSize {
 		_, incidentCache = incidentCache[0], incidentCache[1:]


### PR DESCRIPTION
incidents.
In this ticket, we saw that an incident was correctly reported but it was reported as a `Host.Suspicious.Process` instead of a `Container.Suspicious.Process`. Unfortunately, it is difficult to reproduce and the logs currently don't tell us why it was misreported as a host process.
My change is to add logging to `recordIncident()` because I noticed that the log is generated but it doesn't add any value to debugging. So now it will still log but give us more details. It will also correspond with the controller's API when we get the incidents list. The other change is to `addContainerProcess()` so it will record the pid to container relationship. We were already doing this for `addContainer()`. I believe by adding this log, we can create timeline of when the container was added to our cache and if it happened after we reported the incident (note that the next incidents after some delays in the test will properly indicate that it is a container issue). MY suspicion is that the container was added AFTER the first reported incident and we may need to explore a mechanism to update incidents or buffer the incident so we can get the container information.