### PR TITLE
NVSHAS-7439: High Disk IO is observed when nodes are rebooted

### DIFF
--- a/agent/timer.go
+++ b/agent/timer.go
@@ -54,8 +54,8 @@ var nextConnectReportTick uint32 = reportInterval
 
 ///
 const memoryRecyclePeriod uint32 = 10                       // minutes
-const memEnforcerMediumPeak uint64 = 256 * 1024 * 1024      // 256 MB
-const memEnforcerTopPeak uint64 = 8 * memEnforcerMediumPeak // 2 GB
+const memEnforcerMediumPeak uint64 = 3 * 512 * 1024 * 1024  // 1.5 GB
+const memEnforcerTopPeak uint64 = 2 * memEnforcerMediumPeak // 3.0 GB
 const memSafeGap uint64 = 64 * 1024 * 1024                  // 64 MB
 var memStatsEnforcerResetMark uint64 = memEnforcerTopPeak - memSafeGap
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -61,9 +61,9 @@ var timerWheel *utils.TimerWheel
 
 const statsInterval uint32 = 5
 const controllerStartGapThreshold = time.Duration(time.Minute * 2)
-const memoryRecyclePeriod uint32 = 10                     // minutes
-const memControllerTopPeak uint64 = 4 * 512 * 1024 * 1024 // 2 GB (inc. allinone case)
-const memSafeGap uint64 = 64 * 1024 * 1024                // 64 MB
+const memoryRecyclePeriod uint32 = 10                     	// minutes
+const memControllerTopPeak uint64 = 4 * 1024 * 1024 * 1024 	// 4 GB (inc. allinone case)
+const memSafeGap uint64 = 64 * 1024 * 1024                	// 64 MB
 
 // Unlike in enforcer, only read host IPs in host mode, so no need to enter host network namespace
 func getHostModeHostIPs() {

--- a/share/cluster/consul.go
+++ b/share/cluster/consul.go
@@ -171,6 +171,9 @@ func createConfigFile(cc *ClusterConfig) error {
 	sa = append(sa, fmt.Sprintf("        \"server\": %d,\n", rpcPort))
 	sa = append(sa, fmt.Sprintf("        \"serf_lan\": %d,\n", lanPort))
 	sa = append(sa, fmt.Sprintf("        \"serf_wan\": %d\n", -1))
+	sa = append(sa, fmt.Sprintf("    },\n"))
+	sa = append(sa, fmt.Sprintf("    \"performance\": {\n"))
+	sa = append(sa, fmt.Sprintf("        \"rpc_hold_timeout\": \"%ds\"\n", 300))
 	sa = append(sa, fmt.Sprintf("    }\n"))
 	sa = append(sa, fmt.Sprintf("}\n"))
 

--- a/share/system/cgroup_linux.go
+++ b/share/system/cgroup_linux.go
@@ -719,7 +719,7 @@ func (s *SystemTools) CGroupMemoryStatReset(threshold uint64) bool {
 			log.WithFields(log.Fields{"usage": usage, "threshold": threshold}).Info()
 			go func() {
 				if err := s.setMemoryForceEmpty(); err != nil && err != errUnsupported {
-					log.WithFields(log.Fields{"err": err}).Error()
+					log.WithFields(log.Fields{"err": err}).Debug()
 				}
 			}()
 			return true


### PR DESCRIPTION
Enforcer has a cgroup memory reset 10-minute routine which will trigger container processes to reclaim unused memory and ask the kernel to recalculate the container memory usage. When this event begins, the Kernel will make the running container processes a new memory allocation. Thus, it could create an unexpected IO READ.

Currently, this PR increases the ceiling of container memory. Thus, regular enforcers (below 1.5 GB) and controllers (below 4GB) will NOT kick these triggers. The k8s resource limits will overwrite the settings and trigger this OOM protection situation as necessary.

Also, including some minor bug fixes of the consul watch utility functions and a performance configuration.