### PR TITLE
NVSHAS-6695: Expose namespace label in REST API

### DIFF
--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -788,6 +788,7 @@ type RESTDomain struct {
 	RunningPods      int      `json:"running_pods"`
 	Services         int      `json:"services"`
 	Tags             []string `json:"tags"`
+	Labels           map[string]string `json:"labels"`
 }
 
 type RESTDomainsData struct {

--- a/controller/api/apis.yaml
+++ b/controller/api/apis.yaml
@@ -6251,6 +6251,7 @@ definitions:
       - running_pods
       - services
       - tags
+      - labels
     properties:
       name:
         type: string
@@ -6272,6 +6273,15 @@ definitions:
         items:
           type: string
           example: [""]
+      labels:
+        type: object
+        properties:
+          key:
+            type: string
+            example: "ns.env-1"
+          value:
+            type: string
+            example: "production"
   RESTDomainConfig:
     type: object
     properties:

--- a/controller/cache/domain.go
+++ b/controller/cache/domain.go
@@ -155,7 +155,7 @@ func (m CacheMethod) GetAllDomains(acc *access.AccessControl) ([]*api.RESTDomain
 		if !acc.Authorize(cache.domain, nil) {
 			continue
 		}
-		dmap[name] = &api.RESTDomain{Name: name, Tags: cache.domain.Tags}
+		dmap[name] = &api.RESTDomain{Name: name, Tags: cache.domain.Tags, Labels: cache.domain.Labels}
 	}
 
 	domainMutex.RUnlock()


### PR DESCRIPTION
Append Nameapce's labels via a REST API call: GET "/v1/domain"

(1) Add REST entry:
type RESTDomain struct {
         .........
	Labels           map[string]string `json:"labels"`
}

(2) Update CLI response: "show domain".

(3) Update swagger data.