### PR TITLE
NVSHAS-7487 fixed an issue with var/lib/dpkg/status.d/ packages

### DIFF
--- a/share/scan/scan_utils.go
+++ b/share/scan/scan_utils.go
@@ -58,6 +58,7 @@ const (
 var libsList utils.Set = utils.NewSet(
 	// rpm files are added as union
 	dpkgStatus,
+	dpkgStatusDir,
 	apkPackages,
 	"etc/lsb-release",
 	"etc/os-release",
@@ -143,6 +144,22 @@ func (s *ScanUtil) readRunningPackages(id string, pid int, prefix, kernel string
 				continue
 			}
 			hasPackage = true
+		} else if lib == dpkgStatusDir {
+			dpkgfiles, err := ioutil.ReadDir(path)
+			if err != nil {
+				continue
+			}
+			for _, file := range dpkgfiles {
+				filepath := fmt.Sprintf("%s%s", path, file.Name())
+				filedata, err := getDpkgStatus(filepath, kernel)
+				if err != nil {
+					continue
+				}
+				name := fmt.Sprintf("%s%s", dpkgStatusDir, file.Name())
+				files = append(files, utils.TarFileInfo{name, filedata})
+			}
+			hasPackage = true
+			continue
 		} else if lib == dpkgStatus {
 			//get the dpkg status file
 			data, err = getDpkgStatus(path, kernel)


### PR DESCRIPTION
Fixed an issue where var/lib/dpkg/status.d/ packages weren't handled properly on running containers causing modules to be unreported.