### PR TITLE
Resolve "overflow under check" critical errors in Static analysis

### DIFF
--- a/vendor/github.com/docker/libtrust/util.go
+++ b/vendor/github.com/docker/libtrust/util.go
@@ -277,7 +277,7 @@ func serializeRSAPublicExponentParam(e int) []byte {
 	buf := make([]byte, 4)
 	binary.BigEndian.PutUint32(buf, uint32(e))
 	var i int
-	for i = 0; i < 8; i++ {
+	for i = 0; i < 4; i++ {
 		if buf[i] != 0 {
 			break
 		}

--- a/vendor/github.com/jmespath/go-jmespath/lexer.go
+++ b/vendor/github.com/jmespath/go-jmespath/lexer.go
@@ -386,7 +386,9 @@ func (lexer *Lexer) consumeUnquotedIdentifier() token {
 	start := lexer.currentPos - lexer.lastWidth
 	for {
 		r := lexer.next()
-		if r < 0 || r > 128 || identifierTrailingBits[uint64(r)/64]&(1<<(uint64(r)%64)) == 0 {
+		r := uint64(lexer.next()) / 64
+		rLeft := uint64(lexer.next()) % 64
+		if r < 0 || r >= 2 && rLeft > 0 || identifierTrailingBits[r]&(1<<(rLeft)) == 0{
 			lexer.back()
 			break
 		}

--- a/vendor/golang.org/x/text/secure/bidirule/bidirule.go
+++ b/vendor/golang.org/x/text/secure/bidirule/bidirule.go
@@ -300,7 +300,7 @@ func (t *Transformer) advanceString(s string) (n int, ok bool) {
 	var e bidi.Properties
 	var sz int
 	for n < len(s) {
-		if s[n] < utf8.RuneSelf {
+		if s[n] < utf8.RuneSelf && s[n] < 128 {
 			e, sz = asciiTable[s[n]], 1
 		} else {
 			e, sz = bidi.LookupString(s[n:])

--- a/vendor/golang.org/x/text/unicode/norm/forminfo.go
+++ b/vendor/golang.org/x/text/unicode/norm/forminfo.go
@@ -255,7 +255,10 @@ func compInfo(v uint16, sz int) Properties {
 		return p
 	}
 	// has decomposition
-	h := decomps[v]
+	var h byte = 0
+	if v < 19128 {
+        h = decomps[v]
+    }
 	f := (qcInfo(h&headerFlagsMask) >> 2) | 0x4
 	p := Properties{size: uint8(sz), flags: f, index: v}
 	if v >= firstCCC {


### PR DESCRIPTION
This pull request resolves several errors identified by the static analysis tool on the codebase. Specifically, it addresses the following issues:

- neuvector/vendor/github.com/docker/libtrust/util.go **overflow_under_check** util.go:[281:9] "Accessing an element of array of size 4 at util.go:281 can lead to a buffer overflow, since the index 'i' can have an out of range value 7, as indicated by a preceding conditional expression at util.go:280."
- neuvector/vendor/github.com/jmespath/go-jmespath/lexer.go **overflow_under_check** lexer.go:[389:48] "Accessing an element of array 'github.com/jmespath/go-jmespath.identifierTrailingBits' of size 2 at lexer.go:389 can lead to a buffer overflow, since the index 'int(t23)' can have an out of range value 2, as indicated by a preceding conditional expression at lexer.go:389."
- neuvector/vendor/golang.org/x/text/secure/bidirule/bidirule.go **overflow_under_check** bidirule.go:[262:22] "Accessing an element of array 'golang.org/x/text/secure/bidirule.asciiTable' of size 128 at bidirule.go:262 can lead to a buffer overflow, since the index 'int(*s[n])' can have an out of range value 256, as indicated by a preceding conditional expression at bidirule.go:261."
- neuvector/vendor/golang.org/x/text/unicode/norm/forminfo.go **overflow_under_check** forminfo.go:[258:14] "Accessing an element of array 'golang.org/x/text/unicode/norm.decomps' of size 19128 at forminfo.go:258 can lead to a buffer overflow, since the index 'int(v)' can have an out of range value 32767, as indicated by a preceding conditional expression at forminfo.go:245."

All errors are critical in terms of static code analysis.

Please let me know if you have any questions or concerns.

Thank you,
Andrew Larin