### PR TITLE
NVSHAS-7680: Zero-drift: Unabled to block external process because an allowed learned rule

### DIFF
--- a/agent/policy/process.go
+++ b/agent/policy/process.go
@@ -190,6 +190,7 @@ func (e *Engine) ProcessPolicyLookup(name, id string, proc *share.CLUSProcessPro
 				proc.Action = p.Action
 				proc.AllowFileUpdate = p.AllowFileUpdate
 				proc.ProbeCmds = p.ProbeCmds
+				proc.CfgType = p.CfgType
 				break
 			}
 		}

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -3081,7 +3081,12 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 			ppe.Uuid = share.CLUSReservedUuidShieldMode
 		case share.PolicyActionAllow:
 			bPass = true
-			if !ppe.AllowFileUpdate && !bNotImageButNewlyAdded {
+			if ppe.CfgType == share.Learned { // user needs to allow the process manually
+				// TODO: how about the learned rule's translation from GroundCfg-CRD?
+				bPass = false
+				ppe.Action = negativeResByMode(mode)
+				ppe.Uuid = share.CLUSReservedUuidShieldMode
+			} else if !ppe.AllowFileUpdate && !bNotImageButNewlyAdded {
 				if bModified {
 					bPass = false
 					ppe.Action = negativeResByMode(mode)


### PR DESCRIPTION
During the “Protect” mode, an external process will be rejected if the process rule is not allowed explicitly by users.

Before:
       Whenever it matches an allow process rule, we also allow it. (a white-list concept)

After:
       * Even if it matched a “learned” type process rule, it will be rejected.
       * Users need to add/apply the (learned) process rule manually to let it become a “user-created” rule type in order to allow the matched external processes. (UI needs to show the difference).