### PR TITLE
fixed dereference after comparison to nil

### DIFF
--- a/controller/rest/registry.go
+++ b/controller/rest/registry.go
@@ -1137,7 +1137,7 @@ func replaceFedRegistryConfig(newRegs []*share.CLUSRegistryConfig) bool {
 		foundSameReg := false
 		if o, ok := oldRegs[n.Name]; ok {
 			// found same-name fed registry in existing kv keys
-			if ((o.AwsKey == nil && n.AwsKey == nil) || (*o.AwsKey == *n.AwsKey)) && len(o.Filters) == len(n.Filters) {
+			if ((o.AwsKey == nil && n.AwsKey == nil) || (o.AwsKey != nil && n.AwsKey != nil && *o.AwsKey == *n.AwsKey)) && len(o.Filters) == len(n.Filters) {
 				oldFilters := utils.NewSetFromSliceKind(o.Filters)
 				newFilters := utils.NewSetFromSliceKind(n.Filters)
 				if diff := oldFilters.SymmetricDifference(newFilters); diff.Cardinality() == 0 {


### PR DESCRIPTION
The critical issue identified by the static analysis tool on the Neuvector codebase. Specifically:

- controller/rest/registry.go, registry.go:[1140:49]. After having been compared to a nil value at registry.go:1140 (first half of "if" statement), pointer 'o.AwsKey' (as well as 'n.AwsKey') is dereferenced at registry.go:1140.

Сreated a pull request in which a change was added to the code to eliminate this error.