### PR TITLE
NVSHAS-7716: Compliance.Host.Violation audit event is missing in k8s if the container runtime is not docker

### DIFF
--- a/agent/bench.go
+++ b/agent/bench.go
@@ -344,7 +344,7 @@ func (b *Bench) doKubeBench(masterScript, workerScript, remediation string) (err
 		} else {
 			list := b.getBenchMsg(out)
 			b.assignKubeBenchMeta(list)
-
+			b.kubeHostDone = true
 			b.logHostResult(list)
 			b.putBenchReport(Host.ID, share.BenchKubeMaster, list, share.BenchStatusFinished)
 		}
@@ -365,13 +365,13 @@ func (b *Bench) doKubeBench(masterScript, workerScript, remediation string) (err
 		} else {
 			list := b.getBenchMsg(out)
 			b.assignKubeBenchMeta(list)
-
+			b.kubeHostDone = true
 			b.logHostResult(list)
 			b.putBenchReport(Host.ID, share.BenchKubeWorker, list, share.BenchStatusFinished)
 		}
 	}
 
-	b.kubeHostDone = true
+
 
 	return errMaster, errWorker
 }


### PR DESCRIPTION
Move the k8s-check done flags before the log events.