### PR TITLE
NVSHAS-7700: Add a flag to enable the pruning groups/policy/response rules when its namesapce was deleted

### DIFF
--- a/controller/cache/domain.go
+++ b/controller/cache/domain.go
@@ -4,14 +4,17 @@ import (
 	"encoding/json"
 	"reflect"
 	"sync"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
 	"github.com/neuvector/neuvector/controller/access"
 	"github.com/neuvector/neuvector/controller/api"
 	"github.com/neuvector/neuvector/controller/common"
+	"github.com/neuvector/neuvector/controller/kv"
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/cluster"
+	"github.com/neuvector/neuvector/share/utils"
 )
 
 type domainCache struct {
@@ -20,6 +23,7 @@ type domainCache struct {
 
 var domainCacheMap map[string]*domainCache = make(map[string]*domainCache)
 var domainMutex sync.RWMutex
+var domainRemoveMap map[string]time.Time = make(map[string]time.Time)
 
 func initDomain(name string, nsLabels map[string]string) *share.CLUSDomain {
 	return &share.CLUSDomain{Name: name, Labels: nsLabels}
@@ -72,6 +76,12 @@ func domainConfigUpdate(nType cluster.ClusterNotifyType, key string, value []byt
 		domainMutex.Lock()
 		oDomain, _ := domainCacheMap[name]
 		domainCacheMap[name] = &domainCache{domain: &domain}
+		if cacher.rmNsGrps {
+			if _, ok := domainRemoveMap[name]; ok {
+				log.WithFields(log.Fields{"domain": name}).Debug()
+				delete(domainRemoveMap, name)
+			}
+		}
 		domainMutex.Unlock()
 
 		if oDomain == nil || !reflect.DeepEqual(oDomain.domain.Labels, domain.Labels){
@@ -88,6 +98,13 @@ func domainConfigUpdate(nType cluster.ClusterNotifyType, key string, value []byt
 			return
 		}
 
+		// Put pruned namespaces
+		if cacher.rmNsGrps {
+			if _, ok := domainRemoveMap[name]; !ok {
+				log.WithFields(log.Fields{"domain": name}).Debug()
+				domainRemoveMap[name] = time.Now()
+			}
+		}
 		// Shouldn't happen, but have the logic anyway. Not delete kv, only initial the cache
 		domainCacheMap[name] = &domainCache{domain: initDomain(name, nil)}
 	}
@@ -212,4 +229,56 @@ func (m CacheMethod) GetAllDomains(acc *access.AccessControl) ([]*api.RESTDomain
 		i++
 	}
 	return domains, tagPerDomain
+}
+
+const PruneGroupDelay time.Duration = time.Minute*time.Duration(1)
+func pruneGroupsByNamespace() {
+	domains := utils.NewSet()
+	now := time.Now()
+
+	domainMutex.Lock()
+	for name, t := range domainRemoveMap {
+		if now.Sub(t) >= PruneGroupDelay {
+			delete(domainRemoveMap, name)
+			domains.Add(name)
+		}
+	}
+	domainMutex.Unlock()
+
+	if domains.Cardinality() == 0 {
+		return
+	}
+
+	// only leader has the action items.
+	if isLeader() {
+		var groups []string
+		log.WithFields(log.Fields{"domains": domains}).Debug()
+
+	/*
+		lock, err := clusHelper.AcquireLock(share.CLUSLockPolicyKey, policyClusterLockWait)
+		if err != nil {
+			// wait for next turn
+			log.WithFields(log.Fields{"error": err}).Error("Acquire lock error")
+			return
+		}
+		defer clusHelper.ReleaseLock(lock)
+	*/
+
+		cacheMutexRLock()
+		for name, groupCache := range groupCacheMap {
+			if domains.Contains(groupCache.group.Domain) {
+				groups = append(groups, name)
+			}
+		}
+		cacheMutexRUnlock()
+
+		if len(groups) > 0 {
+			log.WithFields(log.Fields{"groups": groups}).Debug()
+			for _, name := range groups {
+				kv.DeletePolicyByGroup(name)
+				kv.DeleteResponseRuleByGroup(name)
+				clusHelper.DeleteGroup(name)
+			}
+		}
+	}
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -238,6 +238,7 @@ func main() {
 	teleCurrentVer := flag.String("telemetry_current_ver", "", "")                     // in the format {major}.{minor}.{patch}[-s{#}], for testing only
 	telemetryFreq := flag.Uint("telemetry_freq", 60, "")                               // in minutes, for testing only
 	noDefAdmin := flag.Bool("no_def_admin", false, "Do not create default admin user") // for new install only
+	rmNsGrps := flag.Bool("rm_nsgroups", false, "Remove groups when namespace was deleted")
 	flag.Parse()
 
 	if *debug {
@@ -283,6 +284,7 @@ func main() {
 	}
 
 	ocImageRegistered := false
+	enableRmNsGrps := false
 	log.WithFields(log.Fields{"endpoint": *rtSock, "runtime": global.RT.String()}).Info("Container socket connected")
 	if platform == share.PlatformKubernetes {
 		k8sVer, ocVer := global.ORCH.GetVersion(false, false)
@@ -298,6 +300,11 @@ func main() {
 			}
 		}
 		log.WithFields(log.Fields{"k8s": k8sVer, "oc": ocVer, "flavor": flavor}).Info()
+
+		if *rmNsGrps {
+			log.Info("Remove groups when namespace was deleted")
+			enableRmNsGrps = true
+		}
 	}
 
 	if _, err = global.ORCH.GetOEMVersion(); err != nil {
@@ -571,6 +578,7 @@ func main() {
 		OrchChan:                 orchObjChan,
 		TimerWheel:               timerWheel,
 		DebugCPath:               ctrlEnv.debugCPath,
+		EnableRmNsGroups:         enableRmNsGrps,
 		ConnLog:                  connLog,
 		MutexLog:                 mutexLog,
 		ScanLog:                  scanLog,

--- a/monitor/monitor.c
+++ b/monitor/monitor.c
@@ -30,6 +30,7 @@
 #define ENV_CTRL_SERVER_PORT   "CTRL_SERVER_PORT"
 #define ENV_FED_SERVER_PORT    "FED_SERVER_PORT"
 #define ENV_CTRL_PATH_DEBUG    "CTRL_PATH_DEBUG"
+#define ENV_CTRL_PRUNE_NSGRPS  "CTRL_PRUNE_NSGROUPS"
 #define ENV_DEBUG_LEVEL        "DEBUG_LEVEL"
 #define ENV_TAP_INTERFACE      "TAP_INTERFACE"
 #define ENV_TAP_ALL_CONTAINERS "TAP_ALL_CONTAINERS"
@@ -395,6 +396,11 @@ static pid_t fork_exec(int i)
         if ((enable = getenv(ENV_NO_DEFAULT_ADMIN)) != NULL) {
             if (checkImplicitEnableFlag(enable) == 1) {
                 args[a ++] = "-no_def_admin";
+            }
+        }
+        if ((enable = getenv(ENV_CTRL_PRUNE_NSGRPS)) != NULL) {
+            if (checkImplicitEnableFlag(enable) == 1) {
+                args[a ++] = "-rm_nsgroups";
             }
         }
         args[a] = NULL;


### PR DESCRIPTION
With the k8s environment variable flag,

            - name: CTRL_PRUNE_NSGROUPS
               value: "1"

We will prune the groups, network policy, and response rules d in 2-3 minutes after the associated namespace was deleted.