### PR TITLE
Nvshas 7649 - Applying checks on process "ps" to determine exception

### DIFF
--- a/agent/probe/faccess_linux.go
+++ b/agent/probe/faccess_linux.go
@@ -858,12 +858,17 @@ func (fa *FileAccessCtrl) GetProbeData() *FileAccessProbeData {
 //     crio uses "docker-runc-current", but docker-native uses "docker"
 func (fa *FileAccessCtrl) isParentProcessException(ppath, path, name string) bool {
 	// mlog.WithFields(log.Fields{"ppath": ppath, "path": path}).Debug("FA:")
-	if name == "ps" {
-		return true // common service call
-	}
+
 
 	// parent: matching only from binary
 	pname := filepath.Base(ppath)
+	if name == "ps" {
+		if global.RT.IsRuntimeProcess(pname, nil) && global.RT.IsRuntimeProcess(name, nil) {
+			return true
+		}
+		return false // common service call
+	}
+
 	if fa.bKubePlatform {
 		switch pname {
 		case "pod", "kubelet":

--- a/agent/probe/faccess_linux.go
+++ b/agent/probe/faccess_linux.go
@@ -863,7 +863,7 @@ func (fa *FileAccessCtrl) isParentProcessException(ppath, path, name string) boo
 	// parent: matching only from binary
 	pname := filepath.Base(ppath)
 	if name == "ps" {
-		if global.RT.IsRuntimeProcess(pname, nil) && global.RT.IsRuntimeProcess(name, nil) {
+		if global.RT.IsRuntimeProcess(pname, nil) {
 			return true
 		}
 		return false // common service call

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -2278,13 +2278,6 @@ func (p *Probe) isProcessException(proc *procInternal, group, id string, bParent
 	bRtProc := global.RT.IsRuntimeProcess(proc.name, nil)
 	bRtProcP := global.RT.IsRuntimeProcess(proc.pname, nil)
 
-	if proc.name == "ps" {
-		mLog.WithFields(log.Fields{"name": proc.name,
-			"group": group,
-			"bRtProc":bRtProc,
-			"bParentHostProc": bParentHostProc,
-			"bRtProcP": bRtProcP}).Error("JAYU!! LOOK HERE @@@@@@@@ ")
-	}
 	// parent: matching only from binary
 	pname := filepath.Base(proc.ppath)
 	if p.bKubePlatform {
@@ -2323,20 +2316,8 @@ func (p *Probe) isProcessException(proc *procInternal, group, id string, bParent
 		case "portmap", "containerd", "sleep", "uptime", "nice":
 			return true
 		case "ps":
-
-			daemon := global.RT.IsDaemonProcess(proc.name, nil)
-			daemonP := global.RT.IsDaemonProcess(proc.pname, nil)
-			mLog.WithFields(log.Fields{"name": proc.name,
-				"parent runtime process":bRtProcP,
-				"runtime process":bRtProc,
-				"bParentHostProc": bParentHostProc,
-				" daemon": daemon,
-				"Parent daemon": daemonP,
-				"proc.ppath": proc.ppath}).Error("JAYU: PS excepted!")
-
-			if parentProc, ok := p.pidProcMap[proc.ppid]; ok {
-			mLog.WithFields(log.Fields{"name": *parentProc }).Debug("JAYU Dumping parent")
-			}
+			// Exception for process where the parent is a runtime process.
+			// Some CNI daemons will call `ps` and we will get false positives without the exception.
 			if bRtProcP {
 				return true
 			}

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -1839,7 +1839,6 @@ func (p *Probe) evaluateApplication(proc *procInternal, id string, bKeepAlive bo
 	}
 
 	risky := proc.action == share.PolicyActionCheckApp
-	//if proc.name != "ps" {
 	if action, ok = p.procProfileEval(id, proc, bKeepAlive); !ok {
 		return // policy is not ready
 	}

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -2374,7 +2374,7 @@ func (p *Probe) isProcessException(proc *procInternal, group, id string, bParent
 
 		// hidden: relaxing the restrictions for future implementation
 		if p.isParentAllowed(id, proc) {
-			log.WithFields(log.Fields{"group": group, "name": proc.name, "pname": proc.pname, "cmds" : proc.cmds}).Debug("PROC: Parent is allowed, relaxing")
+			//log.WithFields(log.Fields{"group": group, "name": proc.name, "pname": proc.pname, "cmds" : proc.cmds}).Debug("PROC: Parent is allowed, relaxing")
 			return true
 		}
 	}

--- a/share/container/docker.go
+++ b/share/container/docker.go
@@ -411,6 +411,7 @@ func (d *dockerDriver) IsDaemonProcess(proc string, cmds []string) bool {
 }
 
 func (d *dockerDriver) IsRuntimeProcess(proc string, cmds []string) bool {
+	//log.WithField("rtProcMap", d.rtProcMap).Debug("JAYU DUMPING PROCMAP")
 	return d.rtProcMap.Contains(proc)
 }
 

--- a/share/container/docker.go
+++ b/share/container/docker.go
@@ -411,7 +411,6 @@ func (d *dockerDriver) IsDaemonProcess(proc string, cmds []string) bool {
 }
 
 func (d *dockerDriver) IsRuntimeProcess(proc string, cmds []string) bool {
-	//log.WithField("rtProcMap", d.rtProcMap).Debug("JAYU DUMPING PROCMAP")
 	return d.rtProcMap.Contains(proc)
 }
 


### PR DESCRIPTION
Note, Replacing https://github.com/neuvector/neuvector/pull/645

The original code gave "ps" a blanket exception which could allow things to fall thru. So in this PR, I closed the hole with checks to make sure the parent is runtime process for exceptions. Docker/kube will sometimes check on a container using `ps` in the background and this would throw false positives incidents. 