### PR TITLE
NVSHAS-7335 Allow several ADFS certificates in x.509 certificate field.

### DIFF
--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -327,11 +327,19 @@ type RESTServerLDAP struct {
 	GroupMappedRoles []*share.GroupRoleMapping `json:"group_mapped_roles,omitempty"` // group -> (role -> domains)
 }
 
+type RESTX509CertInfo struct {
+	X509Cert          string `json:"x509_cert"`
+	IssuerCommonName  string `json:"issuer_cn"`
+	SubjectCommonName string `json:"subject_cn"`
+	ValidityNotAfter  uint64 `json:"subject_notafter"`
+}
+
 type RESTServerSAML struct {
 	SSOURL     string `json:"sso_url"`
 	Issuer     string `json:"issuer"`
 	X509Cert   string `json:"x509_cert,cloak"`
 	GroupClaim string `json:"group_claim"`
+	X509Certs  []RESTX509CertInfo `json:"x509_certs"`
 
 	Enable           bool                      `json:"enable"`
 	DefaultRole      string                    `json:"default_role"`
@@ -410,6 +418,7 @@ type RESTServerSAMLConfig struct {
 	DefaultRole      *string                    `json:"default_role,omitempty"`
 	RoleGroups       *map[string][]string       `json:"role_groups,omitempty"`        // role -> groups. deprecated since 4.2
 	GroupMappedRoles *[]*share.GroupRoleMapping `json:"group_mapped_roles,omitempty"` // group -> (role -> domains)
+	X509CertExtra    *[]string                  `json:"x509_cert_extra,omitempty"`
 }
 
 type RESTServerSAMLConfigCfgMap struct {

--- a/controller/api/apis.yaml
+++ b/controller/api/apis.yaml
@@ -9431,6 +9431,10 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/GroupRoleMapping'
+      x509_certs:
+        type: array
+        items:
+          $ref: '#/definitions/RESTX509CertInfo'
   RESTServer:
     type: object
     required:
@@ -9559,6 +9563,11 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/GroupRoleMapping'
+      x509_cert_extra:
+        type: array
+        items:
+          type: string
+          example: ["E7B0OS/N3KMVCL6KNMZ2+LOV90S7854NSD84P0BF", "E7B0OS/N3KMVCL6KNMZ2+LOV90S7854NSD84P0BF"]
   RESTServerConfig:
     type: object
     required:
@@ -12752,3 +12761,19 @@ definitions:
       rawjson:
         type: string
         example: "{\"key\": \"value\"}"
+  RESTX509CertInfo:
+    type: object
+    properties:
+      x509_cert:
+        type: string
+        example: "E7B0OS/N3KMVCL6KNMZ2+LOV90S7854NSD84P0BF"
+      issuer_cn:
+        type: string
+        example: "dev-11563853"
+      subject_cn:
+        type: string
+        example: "dev-11563853"
+      subject_notafter:
+        type: integer
+        format: uint64
+        example: 1988147822

--- a/share/auth/auth.go
+++ b/share/auth/auth.go
@@ -131,19 +131,32 @@ func (a *remoteAuth) SAMLSPGetRedirectURL(csaml *share.CLUSServerSAML, redir *ap
 }
 
 func (a *remoteAuth) SAMLSPAuth(csaml *share.CLUSServerSAML, tokenData *api.RESTAuthToken) (map[string][]string, error) {
-	sp := saml.ServiceProvider{
-		IDPSSOURL:           csaml.SSOURL,
-		IDPSSODescriptorURL: csaml.Issuer,
-		IDPPublicCert:       csaml.X509Cert,
+	var certs []string
+	certs = append(certs, csaml.X509Cert)
+	certs = append(certs, csaml.X509CertExtra...)
+
+	r, err := saml.ParseSAMLResponse(tokenData.Token)
+	if err != nil {
+		return nil, err
 	}
 
-	if r, err := saml.ParseSAMLResponse(tokenData.Token); err != nil {
-		return nil, err
-	} else if err = r.Validate(&sp, true); err != nil {
-		return nil, err
-	} else {
-		return r.GetAttributes(), nil
+	for i, c := range certs {
+		sp := saml.ServiceProvider{
+			IDPSSOURL:           csaml.SSOURL,
+			IDPSSODescriptorURL: csaml.Issuer,
+			IDPPublicCert:       c,
+		}
+
+		err = r.Validate(&sp, true)
+		if err != nil{
+			log.WithFields(log.Fields{"samlCertIndex": i, "error": err}).Debug("saml cert failed")
+		} else {
+			log.WithFields(log.Fields{"samlCertIndex": i}).Debug("saml cert succeed")
+			return r.GetAttributes(), nil
+		}
 	}
+
+	return nil, err		// err will be the last r.Validate() result
 }
 
 func (a *remoteAuth) OIDCDiscover(issuer string) (string, string, string, string, error) {

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -813,10 +813,11 @@ type CLUSServerLDAP struct {
 
 type CLUSServerSAML struct {
 	CLUSServerAuth
-	SSOURL     string `json:"sso_url"`
-	Issuer     string `json:"issuer"`
-	X509Cert   string `json:"x509_cert,cloak"`
-	GroupClaim string `json:"group_claim"`
+	SSOURL        string   `json:"sso_url"`
+	Issuer        string   `json:"issuer"`
+	X509Cert      string   `json:"x509_cert,cloak"`
+	GroupClaim    string   `json:"group_claim"`
+	X509CertExtra []string `json:"x509_cert_extra"`
 }
 
 type CLUSServerOIDC struct {


### PR DESCRIPTION
In SAML setting, user can input several certificates.