### PR TITLE
The Host.FileAccess.Violation incidents are missing after an linux user is added and modified

### DIFF
--- a/share/fsmon/monitor.go
+++ b/share/fsmon/monitor.go
@@ -815,7 +815,7 @@ func (w *FileWatch) handleFileEvents(fmod *fileMod, info os.FileInfo, fullPath s
 			//attribute is changed
 			event = fileEventAttr
 			fmod.finfo.FileMode = info.Mode()
-		} else if (fmod.mask & syscall.IN_ACCESS) > 0 {
+		} else if (fmod.mask & (syscall.IN_ACCESS|syscall.IN_CLOSE_WRITE)) > 0 {
 			// check the hash existing and match
 			event = fileEventAccessed
 			if hash, err := osutil.GetFileHash(fullPath); err == nil {


### PR DESCRIPTION
The file-changed handler fails to process the wr_closed events.