### PR TITLE
NVSHAS-7735: Restart k3s service, enforcer pod enters error loop

### DIFF
--- a/share/container/crio.go
+++ b/share/container/crio.go
@@ -4,10 +4,12 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -28,6 +30,8 @@ const defaultCriOSock = "/var/run/crio/crio.sock"
 type crioDriver struct {
 	sys          *system.SystemTools
 	sysInfo      *sysinfo.SysInfo
+	endpoint     string
+	endpointHost string
 	nodeHostname string
 	criClient    *grpc.ClientConn
 	version      *criRT.VersionResponse
@@ -38,6 +42,8 @@ type crioDriver struct {
 	podImgDigest     string
 	podImgID         string
 	pidHost          bool
+	failedQueryCnt   int
+	eventCallback    EventCallback
 }
 
 type imageInfo struct {
@@ -97,10 +103,15 @@ func crioConnect(endpoint string, sys *system.SystemTools) (Runtime, error) {
 		return nil, err
 	}
 
-	log.WithFields(log.Fields{"endpoint": endpoint, "version": ver}).Info("crio connected")
+	sockPath := endpoint
+	if id, _, err := sys.GetSelfContainerID(); err == nil {
+		sockPath, err = criGetContainerSocketPath(cri, ctx, id, endpoint)
+	}
+
+	log.WithFields(log.Fields{"endpoint": endpoint, "sockPath": sockPath, "version": ver}).Info("crio connected")
 
 	driver := crioDriver{
-		sys: sys, version: ver, criClient: cri, podImgRepoDigest: "pod",
+		sys: sys, version: ver, criClient: cri, podImgRepoDigest: "pod", endpoint: endpoint, endpointHost: sockPath,
 		// Read /host/proc/sys/kernel/hostname doesn't give the correct node hostname. Change UTS namespace to read it
 		sysInfo: sys.GetSystemInfo(), nodeHostname: sys.GetHostname(1), daemonInfo: daemon,
 	}
@@ -128,6 +139,48 @@ func imageRef2Digest(ref string) string {
 	} else {
 		return ref
 	}
+}
+
+func (d *crioDriver) reConnect() error {
+	if !d.pidHost {
+		return errors.New("Not pidHost")
+	}
+	// the original socket has been recreated and its mounted path was also lost.
+	endpoint := d.endpoint
+	if d.endpointHost != "" {	// use the host
+		endpoint = filepath.Join("/proc/1/root", d.endpointHost)
+	}
+
+	log.WithFields(log.Fields{"endpoint": endpoint}).Info("Reconnecting ...")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	crio, err := crioAPI.New(endpoint)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("Fail to create crio client")
+		return err
+	}
+
+	daemon, err := crio.DaemonInfo()
+	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("Fail to get daemon info")
+		return err
+	}
+
+	cri, ver, err := newCriClient(endpoint, ctx)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("Fail to create cri client")
+		return err
+	}
+
+	log.WithFields(log.Fields{"endpoint": endpoint, "version": ver}).Info("cri-o connected")
+
+	// update records
+	d.daemonInfo = daemon
+	d.criClient = cri
+	d.version = ver
+	return nil
 }
 
 func (d *crioDriver) String() string {
@@ -475,9 +528,23 @@ func (d *crioDriver) ListContainerIDs() (utils.Set, utils.Set) {
 	resp_containers, err := criListContainers(d.criClient, ctx)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Fail to list containers")
-		return ids, nil
+
+		// lost connection, wait for 5 second try reconnect
+		time.Sleep(time.Second * 5)
+		if err := d.reConnect(); err != nil {
+			log.WithFields(log.Fields{"err": err}).Error()
+			d.failedQueryCnt++	// the query is coming every 20-seconds
+			if d.failedQueryCnt > 5 {	// 100 seconds
+				// notify parent to exit container
+				if d.eventCallback != nil {
+					d.eventCallback(EventSocketError, "", 0)
+				}
+			}
+			return ids, nil
+		}
 	}
 
+	d.failedQueryCnt = 0	// reset
 	resp_sandboxes, err := criListPodSandboxes(d.criClient, ctx)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Fail to list sandboxes")
@@ -546,6 +613,7 @@ func (d *crioDriver) StopMonitorEvent() {
 
 func (d *crioDriver) MonitorEvent(cb EventCallback, cpath bool) error {
 	// crio api doesn't support this
+	d.eventCallback = cb
 	return ErrMethodNotSupported
 }
 

--- a/share/container/docker.go
+++ b/share/container/docker.go
@@ -1,9 +1,12 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
+	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -21,13 +24,15 @@ import (
 const defaultDockerSocket string = "unix:///var/run/docker.sock"
 
 type dockerDriver struct {
-	sys        *system.SystemTools
-	endpoint   string
-	evCallback EventCallback
-	client     *dockerclient.DockerClient
-	version    *dockerclient.Version
-	info       *dockerclient.Info
-	rtProcMap  utils.Set
+	sys          *system.SystemTools
+	endpoint     string
+	endpointHost string
+	evCallback   EventCallback
+	client       *dockerclient.DockerClient
+	version      *dockerclient.Version
+	info         *dockerclient.Info
+	rtProcMap    utils.Set
+	pidHost      bool
 }
 
 func _connect(endpoint string) (*dockerclient.DockerClient, *dockerclient.Version, *dockerclient.Info, error) {
@@ -62,15 +67,79 @@ func _connect(endpoint string) (*dockerclient.DockerClient, *dockerclient.Versio
 	return client, ver, info, nil
 }
 
+func getContainerSocketPath(client *dockerclient.DockerClient, id, endpoint string) (string, error) {
+	info, err := client.InspectContainer(id)
+	if err == nil {
+		endpoint = strings.TrimPrefix(endpoint, "unix://")
+		log.WithFields(log.Fields{"endpoint": endpoint}).Info("JW:")
+		for _, m := range info.Mounts {
+			log.WithFields(log.Fields{"m": m}).Info("JW:")
+			if m.Destination == endpoint {
+				return m.Source, nil
+			}
+		}
+	}
+	log.WithFields(log.Fields{"error": err, "id": id, "endpoint": endpoint}).Error("Failed to get mounting container socket")
+	return "", err
+}
+
 func dockerConnect(endpoint string, sys *system.SystemTools) (Runtime, error) {
 	client, ver, info, err := _connect(endpoint)
 	if err != nil {
 		return nil, err
 	}
 
-	driver := dockerDriver{sys: sys, endpoint: endpoint, client: client, version: ver, info: info}
+	sockPath := endpoint
+	if id, _, err := sys.GetSelfContainerID(); err == nil {
+		sockPath, err = getContainerSocketPath(client, id, endpoint)
+		log.WithFields(log.Fields{"sockPath": sockPath}).Info("JW:")
+	}
+
+	driver := dockerDriver{sys: sys, endpoint: endpoint, endpointHost: sockPath, client: client, version: ver, info: info}
 	driver.rtProcMap = utils.NewSet("runc", "docker-runc", "docker", "docker-runc-current", "docker-containerd-shim-current", "containerd", "containerd-shim")
+
+	name, _ := os.Readlink("/proc/1/exe")
+	if name == "/usr/local/bin/monitor" || strings.HasPrefix(name, "/usr/bin/python") { // when pid mode != host, 'pythohn' is for allinone
+		driver.pidHost = false
+	} else {
+		driver.pidHost = true
+	}
+
 	return &driver, nil
+}
+
+func  (d *dockerDriver) reConnect() error {
+	if !d.pidHost {
+		return errors.New("Not pidHost")
+	}
+
+	// the original socket has been recreated and its mounted path was also lost.
+	endpoint := d.endpoint
+	if d.endpointHost != "" {	// use the host
+		endpoint = "unix://" + filepath.Join("/proc/1/root", d.endpointHost)
+	}
+
+	log.WithFields(log.Fields{"endpoint": endpoint}).Info("Reconnecting ...")
+
+	client, err := dockerclient.NewDockerClientTimeout(
+		endpoint, nil, clientConnectTimeout, nil)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("Failed to create client")
+		return err
+	}
+
+	ver, err := client.Version()
+	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("Failed to get version")
+		return err
+	}
+
+	log.WithFields(log.Fields{"endpoint": endpoint, "version": ver}).Info("docker connected")
+
+	// update records
+	d.client = client
+	d.version = ver
+	return nil
 }
 
 func (d *dockerDriver) String() string {
@@ -468,9 +537,7 @@ func (d *dockerDriver) MonitorEvent(cb EventCallback, cpath bool) error {
 			// More than 10 errors within a second
 			if count > 10 {
 				count = 0
-
-				client, ver, info, err := _connect(d.endpoint)
-				if err != nil {
+				if err := d.reConnect(); err != nil {
 					log.WithFields(log.Fields{"error": err}).Error("Failed to reconnect to docker")
 
 					sendErr++
@@ -483,9 +550,6 @@ func (d *dockerDriver) MonitorEvent(cb EventCallback, cpath bool) error {
 					time.Sleep(5 * time.Second)
 				} else {
 					sendErr = 0
-					d.client = client
-					d.version = ver
-					d.info = info
 				}
 			}
 		}

--- a/share/container/dockerclient/types.go
+++ b/share/container/dockerclient/types.go
@@ -274,6 +274,76 @@ type ImageSearch struct {
 	StarCount   int    `json:"star_count,omitempty" yaml:"star_count,omitempty"`
 }
 
+// Type represents the type of a mount.
+type Type string
+
+const (
+	// TypeBind BIND
+	TypeBind Type = "bind"
+	// TypeVolume VOLUME
+	TypeVolume Type = "volume"
+)
+
+// Mount represents a mount (volume).
+type Mount struct {
+	Type     Type   `json:",omitempty"`
+	Source   string `json:",omitempty"`
+	Target   string `json:",omitempty"`
+	ReadOnly bool   `json:",omitempty"`
+
+	BindOptions   *BindOptions   `json:",omitempty"`
+	VolumeOptions *VolumeOptions `json:",omitempty"`
+}
+
+// Propagation represents the propagation of a mount.
+type Propagation string
+
+const (
+	// PropagationRPrivate RPRIVATE
+	PropagationRPrivate Propagation = "rprivate"
+	// PropagationPrivate PRIVATE
+	PropagationPrivate Propagation = "private"
+	// PropagationRShared RSHARED
+	PropagationRShared Propagation = "rshared"
+	// PropagationShared SHARED
+	PropagationShared Propagation = "shared"
+	// PropagationRSlave RSLAVE
+	PropagationRSlave Propagation = "rslave"
+	// PropagationSlave SLAVE
+	PropagationSlave Propagation = "slave"
+)
+
+// BindOptions defines options specific to mounts of type "bind".
+type BindOptions struct {
+	Propagation Propagation `json:",omitempty"`
+}
+
+// VolumeOptions represents the options for a mount of type volume.
+type VolumeOptions struct {
+	NoCopy       bool              `json:",omitempty"`
+	Labels       map[string]string `json:",omitempty"`
+	DriverConfig *Driver           `json:",omitempty"`
+}
+
+// Driver represents a volume driver.
+type Driver struct {
+	Name    string            `json:",omitempty"`
+	Options map[string]string `json:",omitempty"`
+}
+
+// MountPoint represents a mount point configuration inside the container.
+// This is used for reporting the mountpoints in use by a container.
+type MountPoint struct {
+	Type        Type   `json:",omitempty"`
+	Name        string `json:",omitempty"`
+	Source      string
+	Destination string
+	Driver      string `json:",omitempty"`
+	Mode        string
+	RW          bool
+	Propagation Propagation
+}
+
 type ContainerInfo struct {
 	Id              string
 	Created         string
@@ -301,6 +371,7 @@ type ContainerInfo struct {
 	ResolvConfPath string
 	Volumes        map[string]string
 	HostConfig     *HostConfig
+	Mounts          []MountPoint
 }
 
 type ContainerChanges struct {


### PR DESCRIPTION
For enforcers, add the reConnect() for the docker, containerd, and cri-o runtime services. The leading cause is the mounted runtime socket, which will not update its inode data during runtime service restarts. If the reconnections do not work out for certain tries, it will trigger this enforcer pod restart,

It retrieves the host's socket endpoint from the container information to facilitate reconnections.
