### PR TITLE
NVSHAS-7769: 5.0.6, see group without namespace and unmatching group and members

### DIFF
--- a/controller/cache/group.go
+++ b/controller/cache/group.go
@@ -1219,7 +1219,7 @@ func groupWorkloadJoin(id string, param interface{}) {
 	// Join and create learned group.
 	if cache, ok := groupCacheMap[wlc.learnedGroupName]; !ok || isDummyGroupCache(cache) {
 		if isLeader() {
-			if bHasGroupProfile && !dispatchHelper.IsGroupAdded(wlc.learnedGroupName) {
+			if bHasGroupProfile {
 				createLearnedGroup(wlc, getNewServicePolicyMode(), getNewServiceProfileBaseline(), false, "", access.NewAdminAccessControl())
 				if localDev.Host.Platform == share.PlatformKubernetes {
 					updateK8sPodEvent(wlc.learnedGroupName, wlc.podName, wlc.workload.Domain)


### PR DESCRIPTION
When the groups meet the pruning schedule and unmanaged nodes, the dispatcher will fail the group creation conditions. Patch a loose condition to ensure the leaned group creations.