### PR TITLE
NVSHAS-7801: In process profile rule page, backend combines rules with h the same name but the cfg-type value is not right

### DIFF
--- a/controller/common/common.go
+++ b/controller/common/common.go
@@ -644,6 +644,11 @@ func MergeProcess(list []*share.CLUSProcessProfileEntry, p *share.CLUSProcessPro
 			changed = true
 		}
 
+		if p.CfgType != share.Learned {
+			pp.CfgType = p.CfgType
+			changed = true
+		}
+
 		if changed {
 			// update entry
 			pp.UpdatedAt = time.Now().UTC()


### PR DESCRIPTION
When the not-learned process rule was inserted, we did not update the rule type before. Add this patch.