### PR TITLE
NVSHAS-7768: Process from a mounted directory being blocked by NeuVector even if it is whitelisted

### DIFF
--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -2924,11 +2924,13 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 
 	bNotImageButNewlyAdded := false
 	bImageFile = true
-	if global.SYS.IsNotContainerFile(c.rootPid, ppe.Path) {
+	if yes, mounted := global.SYS.IsNotContainerFile(c.rootPid, ppe.Path); yes || mounted {
 		// We will not monitor files under the mounted folder
 		// The mounted condition: utils.IsContainerMountFile(c.rootPid, ppe.Path)
 		if c.bPrivileged {
 			mLog.WithFields(log.Fields{"file": ppe.Path, "id": id}).Debug("SHD: priviiged system pod")
+		} else if mounted {
+			mLog.WithFields(log.Fields{"file": ppe.Path, "id": id}).Debug("SHD: mounted")
 		} else {
 			// this file is not existed
 			bImageFile = false

--- a/share/container/docker.go
+++ b/share/container/docker.go
@@ -71,9 +71,7 @@ func getContainerSocketPath(client *dockerclient.DockerClient, id, endpoint stri
 	info, err := client.InspectContainer(id)
 	if err == nil {
 		endpoint = strings.TrimPrefix(endpoint, "unix://")
-		log.WithFields(log.Fields{"endpoint": endpoint}).Info("JW:")
 		for _, m := range info.Mounts {
-			log.WithFields(log.Fields{"m": m}).Info("JW:")
 			if m.Destination == endpoint {
 				return m.Source, nil
 			}

--- a/share/system/system_linux.go
+++ b/share/system/system_linux.go
@@ -30,6 +30,7 @@ import (
 	namespace "github.com/neuvector/neuvector/share/system/ns"
 	sk "github.com/neuvector/neuvector/share/system/sidekick"
 	"github.com/neuvector/neuvector/share/system/sysinfo"
+	"github.com/neuvector/neuvector/share/utils"
 )
 
 const defaultHostProc string = "/proc/"
@@ -614,9 +615,10 @@ func (s *SystemTools) ContainerFilePath(pid int, path string) string {
 	return fmt.Sprintf("%s%d/root%s", s.procDir, pid, path)
 }
 
-func (s *SystemTools) IsNotContainerFile(pid int, path string) bool {
-	_, err := os.Stat(s.ContainerFilePath(pid, path))
-	return os.IsNotExist(err)
+func (s *SystemTools) IsNotContainerFile(pid int, path string) (bool, bool) {
+	rpath := s.ContainerFilePath(pid, path)
+	_, err := os.Stat(rpath); os.IsNotExist(err)
+	return os.IsNotExist(err), utils.IsMountPoint(filepath.Dir(rpath))
 }
 
 func (s *SystemTools) ReadContainerFile(filePath string, pid, start, length int) ([]byte, error) {

--- a/share/utils/utils.go
+++ b/share/utils/utils.go
@@ -1055,12 +1055,22 @@ func EncryptURLSafe(password string) string {
 // Determine if a directory is a mountpoint, by comparing the device for the directory
 // with the device for it's parent.  If they are the same, it's not a mountpoint, if they're
 // different, it is.
+var reProcessRootPath = regexp.MustCompile("/proc/\\d+/root/")
 func IsMountPoint(path string) bool {
 	stat, err := os.Stat(path)
 	if err != nil {
 		return false
 	}
-	rootStat, err := os.Lstat(path + "/..")
+
+	var rootPath string
+	rpath := path + "/"
+	if indexes := reProcessRootPath.FindStringIndex(rpath); len(indexes) > 1 {
+		// take the first matched
+		rootPath = rpath[0:indexes[1]] // container scope
+	} else {
+		rootPath = rpath + ".."  // relative: compare its upper folder
+	}
+	rootStat, err := os.Lstat(rootPath)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
Zero-drift baseline process profile: We consider the mounted directories in the containers as internal files. Patch a bug to distinguish the sub-directory from a mounted point. 