### PR TITLE
NVSHAS-7825 and various API key cases

### DIFF
--- a/controller/access/access.go
+++ b/controller/access/access.go
@@ -1546,3 +1546,18 @@ func (acc *AccessControl) AuthorizeOwn(obj share.AccessObject, f share.GetAccess
 
 	return authz
 }
+
+func (acc *AccessControl) GetRoleDomains() map[string][]string{
+	var roleDomains = make(map[string][]string)
+
+	for d, role := range acc.roles {
+		roleDomains[role] = append(roleDomains[role], d)
+	}
+
+	return roleDomains
+}
+
+func ContainsNonSupportRole(role string) bool {
+	var roles = utils.NewSet(api.UserRoleFedAdmin, api.UserRoleFedReader, api.UserRoleIBMSA, api.UserRoleImportStatus)
+	return roles.Contains(role)
+}

--- a/controller/access/access_test.go
+++ b/controller/access/access_test.go
@@ -1314,6 +1314,9 @@ func TestCompileApiUrisMappingMapping(t *testing.T) {
 			"v1/user",
 			"v1/user/*",
 			"v1/selfuser", // Any user is allowed to use the login token to retrieve his/her own user info. temporarily given PERM_AUTHORIZATION for retrieving caller's user info
+			"v1/api_key",
+			"v1/api_key/*",
+			"v1/selfapikey",
 		},
 		CONST_API_PWD_PROFILE: []string{
 			"v1/password_profile",
@@ -1411,6 +1414,7 @@ func TestCompileApiUrisMappingMapping(t *testing.T) {
 		CONST_API_AUTHORIZATION: []string{
 			"v1/user_role",
 			"v1/user",
+			"v1/api_key",
 		},
 		CONST_API_PWD_PROFILE: []string{
 			"v1/password_profile",
@@ -1556,6 +1560,7 @@ func TestCompileApiUrisMappingMapping(t *testing.T) {
 		CONST_API_AUTHORIZATION: []string{
 			"v1/user_role/*",
 			"v1/user/*",
+			"v1/api_key/*",
 		},
 		CONST_API_PWD_PROFILE: []string{
 			"v1/password_profile/*",

--- a/controller/rest/auth.go
+++ b/controller/rest/auth.go
@@ -572,6 +572,11 @@ func restReq2User(r *http.Request) (*loginSession, int, string) {
 				}
 				roles[access.AccessDomainGlobal] = apikeyAccount.Role
 
+				_, _, err := access.GetDomainPermissions(apikeyAccount.Role, apikeyAccount.RoleDomains)
+				if err != nil {
+					return nil, userInvalidRequest, rsessToken
+				}
+
 				s := &loginSession{
 					id:          utils.GetRandomID(idLength, ""),
 					fullname:    apikeyAccount.Name,

--- a/controller/rest/federation.go
+++ b/controller/rest/federation.go
@@ -319,11 +319,6 @@ func isFedOpAllowed(expectedFedRole string, roleRequired RoleRquired, w http.Res
 	if acc == nil {
 		return nil, nil
 	} else {
-		if login.loginType == 1 {
-			// skip apikey handling for fed specific operation
-			return nil, nil
-		}
-		
 		var ok bool
 		switch roleRequired {
 		case _fedAdminRequired:


### PR DESCRIPTION
- NVSHAS-7818
- NVSHAS-7825
- NVSHAS-7826
- NVSHAS-7808
- NVSHAS-7795
- NVSHAS-7796
- max length of apikey.name is 32
- apikey cannot bind fedAdmin/fedReader