### PR TITLE
NVSHAS-7844: unable to create Container.FileAccess.Violation incident successfully if file is modified

### DIFF
--- a/share/fsmon/monitor.go
+++ b/share/fsmon/monitor.go
@@ -815,7 +815,7 @@ func (w *FileWatch) handleFileEvents(fmod *fileMod, info os.FileInfo, fullPath s
 			//attribute is changed
 			event = fileEventAttr
 			fmod.finfo.FileMode = info.Mode()
-		} else if (fmod.mask & (syscall.IN_ACCESS|syscall.IN_CLOSE_WRITE)) > 0 {
+		} else if (fmod.mask & (syscall.IN_ACCESS|syscall.IN_CLOSE_WRITE|syscall.IN_MODIFY)) > 0 {
 			// check the hash existing and match
 			event = fileEventAccessed
 			if hash, err := osutil.GetFileHash(fullPath); err == nil {


### PR DESCRIPTION
Patching the file event mask with the file-modified flag.