### PR TITLE
NVSHAS-7836: Netcat is not alerted in monitor node with zero-drift enabled

### DIFF
--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -2435,6 +2435,16 @@ func (p *Probe) procProfileEval(id string, proc *procInternal, bKeepAlive bool) 
 				case share.PolicyActionLearn, share.PolicyActionCheckApp:	// exclude these two actions
 				default:
 					pp.Action = share.PolicyActionAllow
+					if !allowSuspicious && proc.action == share.PolicyActionCheckApp {
+						switch mode {
+						case share.PolicyModeLearn:
+							pp.Action = share.PolicyActionCheckApp
+						case share.PolicyModeEvaluate:
+							pp.Action = share.PolicyActionViolate
+						case share.PolicyModeEnforce:
+							pp.Action = share.PolicyActionDeny
+						}
+					}
 				}
 			} else {
 				// NVSHAS-7501 - I think we have to assume false on keep alive.


### PR DESCRIPTION
Zero-drift: the suspicious processes from the root process need to be alerted or denied. 