### PR TITLE
NVSHAS-7837: the file_path info is missing in Host.FileAccess.Violation incident

### DIFF
--- a/agent/probe/incident_reporter.go
+++ b/agent/probe/incident_reporter.go
@@ -154,6 +154,7 @@ func (p *Probe) SendAggregateProbeReport(pmsg *ProbeMessage, bExtOp bool) bool {
 /////
 // dpkg[ubuntu, debian], yum[centos,fedora] , dnf[centos, coreos,fedora], rpm[redhat], apk[busybox], zypper[bci]
 var pkgCmds utils.Set = utils.NewSet("dpkg", "yum", "dnf", "rpm", "apk", "zypper")
+
 const (
 	fsPackageUpdate = "Software packages were updated."
 	fsComboAction   = "Files were modified or deleted."
@@ -171,12 +172,13 @@ func (p *Probe) SendAggregateFsMonReport(pmsg *fsmon.MonitorMessage) bool {
 		pmsga.expireCnt = expireCountdown
 
 		if pmsg.ProcPid != 0 && pmsga.pid == 0 {
-			pmsg.ProcPid =  pmsg.ProcPid
-			pmsga.fsMsg = pmsg	// updated
+			pmsg.ProcPid = pmsg.ProcPid
+			pmsga.fsMsg = pmsg // updated
 		} else {
 			pmsga.count++
+			pmsga.fsMsg.Path = pmsg.Path // restored
 		}
-		mLog.WithFields(log.Fields{"report_a": pmsga, "msg": pmsga.fsMsg}).Debug("PROC: accumulated")
+		mLog.WithFields(log.Fields{"report_a": pmsga, "msg": pmsga.fsMsg, "pmsg": pmsg}).Debug("PROC: accumulated")
 		return false // hold the event for further events
 	}
 
@@ -185,7 +187,7 @@ func (p *Probe) SendAggregateFsMonReport(pmsg *fsmon.MonitorMessage) bool {
 	bHasPackageInstalled := false
 	for key, pmsga := range p.pMsgAggregates {
 		if pmsga.bFsMonMsg {
-			if pmsga.fsMsg.ID != pmsg.ID {	// excludes other containers
+			if pmsga.fsMsg.ID != pmsg.ID { // excludes other containers
 				continue
 			}
 
@@ -202,17 +204,17 @@ func (p *Probe) SendAggregateFsMonReport(pmsg *fsmon.MonitorMessage) bool {
 				// (2) Unreliable timing: the report could be either at the start or the end
 				// (3) Looking any non-expired installation event by processes (bPackageOpInProgress)
 				if !strings.Contains(pmsga.fsMsg.Path, pmsg.Path) {
-					pmsg.Path = fmt.Sprintf( "%s, %s", pmsga.fsMsg.Path, pmsg.Path)
+					pmsg.Path = fmt.Sprintf("%s, %s", pmsga.fsMsg.Path, pmsg.Path)
 				}
 				pmsga.pid = pmsg.ProcPid
 				pmsga.fsMsg = nil
-				pmsga.fsMsg = pmsg    // replaced
+				pmsga.fsMsg = pmsg // replaced
 				pmsga.fsMsg.Package = true
 				// log.WithFields(log.Fields{"Path": pmsga.fsMsg.Path}).Debug("PROC: update")
 				p.pMsgAggregates[key] = pmsga
 				return false
 			} else {
-				if pmsga.pid == pmsg.ProcPid && pmsg.ProcPid != 0 {  // same process
+				if pmsga.pid == pmsg.ProcPid && pmsg.ProcPid != 0 { // same process
 					if pmsga.fsMsg.Msg != fsComboAction && pmsga.fsMsg.Msg != pmsg.Msg {
 						pmsga.fsMsg.Msg = fsComboAction
 					}
@@ -252,7 +254,7 @@ func (p *Probe) SendAggregateFsMonReport(pmsg *fsmon.MonitorMessage) bool {
 						}
 
 						if !strings.Contains(pmsga.fsMsg.Path, pmsg.Path) {
-							pmsga.fsMsg.Path = fmt.Sprintf( "%s, %s", pmsga.fsMsg.Path, pmsg.Path)
+							pmsga.fsMsg.Path = fmt.Sprintf("%s, %s", pmsga.fsMsg.Path, pmsg.Path)
 						}
 						// log.WithFields(log.Fields{"Path": pmsga.fsMsg.Path}).Debug("PROC: append")
 						p.pMsgAggregates[key] = pmsga
@@ -347,7 +349,7 @@ func (p *Probe) sendFsMonReport(fsMsg fsmon.MonitorMessage, count int, start tim
 	fsMsg.StartAt = start
 
 	// update package msg
-	if fsMsg.Package  {
+	if fsMsg.Package {
 		fsMsg.Msg = fsPackageUpdate
 	}
 


### PR DESCRIPTION
File events accumulator: restore empty file path if the same file has been reported in a period of time. 