### PR TITLE
NVSHAS-7849: patch empty service group name for exited containers during Protect mode

### DIFF
--- a/agent/group_profile.go
+++ b/agent/group_profile.go
@@ -10,12 +10,12 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/neuvector/neuvector/agent/policy"
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/cluster"
 	"github.com/neuvector/neuvector/share/fsmon"
 	"github.com/neuvector/neuvector/share/utils"
+	log "github.com/sirupsen/logrus"
 )
 
 ////  group profile
@@ -42,11 +42,11 @@ type fileMatchRule struct {
 
 //// workload profile map for policy lookups
 type workloadProfile struct {
-	groups     utils.Set
-	proc       *share.CLUSProcessProfile
-	file       *share.CLUSFileMonitorProfile
-	access     *share.CLUSFileAccessRule
-	matchRules []*fileMatchRule // local usage: match path to (estimated) group
+	groups         utils.Set
+	proc           *share.CLUSProcessProfile
+	file           *share.CLUSFileMonitorProfile
+	access         *share.CLUSFileAccessRule
+	matchRules     []*fileMatchRule // local usage: match path to (estimated) group
 	procCalculated bool
 	fileCalculated bool
 }
@@ -251,7 +251,7 @@ func updateGroupProfileCache(nType cluster.ClusterNotifyType, name string, obj i
 		}
 	case share.CLUSProcessProfile:
 		proc := obj.(share.CLUSProcessProfile)
-		if proc.Mode != grpCache.proc.Mode || len(grpCache.proc.Process)==0 || reflect.DeepEqual(proc.Process, grpCache.proc.Process) == false {
+		if proc.Mode != grpCache.proc.Mode || len(grpCache.proc.Process) == 0 || reflect.DeepEqual(proc.Process, grpCache.proc.Process) == false {
 			for _, pp := range proc.Process {
 				pp.DerivedGroup = name // late filled-up to save kv storages
 			}
@@ -263,7 +263,7 @@ func updateGroupProfileCache(nType cluster.ClusterNotifyType, name string, obj i
 		}
 	case share.CLUSFileMonitorProfile:
 		file := obj.(share.CLUSFileMonitorProfile)
-		if file.Mode != grpCache.file.Mode || len(grpCache.file.Filters)==0 || reflect.DeepEqual(file.Filters, grpCache.file.Filters) == false {
+		if file.Mode != grpCache.file.Mode || len(grpCache.file.Filters) == 0 || reflect.DeepEqual(file.Filters, grpCache.file.Filters) == false {
 			for i, _ := range file.Filters {
 				file.Filters[i].DerivedGroup = name // late filled-up to save kv storages
 			}
@@ -275,7 +275,7 @@ func updateGroupProfileCache(nType cluster.ClusterNotifyType, name string, obj i
 		}
 	case share.CLUSFileAccessRule:
 		access := obj.(share.CLUSFileAccessRule)
-		if len(grpCache.access.Filters)==0 || reflect.DeepEqual(access.Filters, grpCache.access.Filters) == false {
+		if len(grpCache.access.Filters) == 0 || reflect.DeepEqual(access.Filters, grpCache.access.Filters) == false {
 			grpCache.access = &access
 			targets = grpCache.members.Clone()
 			if targets.Cardinality() > 0 {
@@ -334,7 +334,7 @@ func isContainerSelected(c *containerData, group *share.CLUSGroup) bool {
 func refreshGroupMembers(grpCache *groupProfileData) {
 	grpCache.members.Clear()
 	if utils.IsGroupNodes(grpCache.group.Name) {
-		grpCache.members.Add("")	// only member : host
+		grpCache.members.Add("") // only member : host
 		return
 	}
 
@@ -342,7 +342,7 @@ func refreshGroupMembers(grpCache *groupProfileData) {
 	for _, c := range gInfo.activeContainers {
 		if isContainerSelected(c, grpCache.group) {
 			if c.parentNS == "" { // docker-native or k8s pod-level
-				if strings.HasPrefix(c.name, "k8s_POD_") {	// k8s pod-level
+				if strings.HasPrefix(c.name, "k8s_POD_") { // k8s pod-level
 					grpCache.members = grpCache.members.Union(c.pods)
 				}
 				grpCache.members.Add(c.id)
@@ -388,7 +388,7 @@ func procMemberChanges(members utils.Set) {
 	for cid := range members.Iter() {
 		id := cid.(string)
 		if id == "" {
-			applyHostProcGroupProfile("nodes")	// system reserved entry
+			applyHostProcGroupProfile("nodes") // system reserved entry
 			continue
 		}
 
@@ -409,7 +409,7 @@ func fileMemberChanges(members utils.Set) {
 	for cid := range members.Iter() {
 		id := cid.(string)
 		if id == "" {
-		//	log.Debug("GRP: not support nodes")
+			//	log.Debug("GRP: not support nodes")
 			continue
 		}
 
@@ -656,7 +656,7 @@ func calculateProcGroupProfile(id, svc string) (*share.CLUSProcessProfile, bool)
 	proc.HashEnable = svc_proc.HashEnable
 	proc.Process = pp.Process
 
-	if id != "" {	// container only
+	if id != "" { // container only
 		for _, p := range proc.Process { // separate CRD and other types
 			// log.WithFields(log.Fields{"proc": p, "Svc": svc}).Debug("GRP:")
 			if p.Action == share.PolicyActionAllow {
@@ -772,12 +772,12 @@ func applyHostProcGroupProfile(svc string) bool {
 		wlCacheLock.Unlock()
 
 		// put a minimum data set
-		c :=  &containerData {
-			id: 			"",
-			name: 			"host",
-			pid : 			1,
-			capBlock: 		false,	// no process blocking control but kill processes
-			pushPHistory: 	true, 	// no history
+		c := &containerData{
+			id:           "",
+			name:         "host",
+			pid:          1,
+			capBlock:     false, // no process blocking control but kill processes
+			pushPHistory: true,  // no history
 		}
 
 		// log.WithFields(log.Fields{"SVC": svc, "mode": proc.Mode}).Debug("GRP:")
@@ -888,18 +888,18 @@ func workloadJoinGroup(c *containerData) {
 		if !grpCache.members.Contains(c.id) {
 			if isContainerSelected(c, grpCache.group) {
 				if c.parentNS == "" { // docker-native or k8s pod-level
-					if strings.HasPrefix(c.name, "k8s_POD_") {	// k8s pod-level
+					if strings.HasPrefix(c.name, "k8s_POD_") { // k8s pod-level
 						grpCache.members = grpCache.members.Union(c.pods)
 						grpNotifyProc = grpNotifyProc.Union(c.pods)
 						grpNotifyFile = grpNotifyFile.Union(c.pods)
 					}
 					grpCache.members.Add(c.id)
-					groups.Add(name)	// reference
-				} else {	// k8s child-level
+					groups.Add(name) // reference
+				} else { // k8s child-level
 					// patch: the joined pod was not filled with previous pod's members.
 					if grpCache.members.Contains(c.parentNS) {
 						grpCache.members.Add(c.id)
-						groups.Add(name)	// reference
+						groups.Add(name) // reference
 					}
 				}
 			}
@@ -949,7 +949,7 @@ func workloadLeaveGroup(c *containerData) {
 
 ///////// Use GRPC to return actual policy to CTL
 func ObtainGroupProcessPolicy(id string) (*share.CLUSProcessProfile, bool) {
-	if id == "nodes" {	// from controller, workload id from runtime can not be like "nodes"
+	if id == "nodes" { // from controller, workload id from runtime can not be like "nodes"
 		id = ""
 	}
 
@@ -970,7 +970,7 @@ func ObtainGroupProcessPolicy(id string) (*share.CLUSProcessProfile, bool) {
 
 ///////// Use GRPC to return actual policy to CTL
 func ObtainGroupFilePolicies(id string) (*share.CLUSFileMonitorProfile, *share.CLUSFileAccessRule, bool) {
-	if id == "nodes" {	// TODO: from controller, workload id from runtime can not be like "nodes"
+	if id == "nodes" { // TODO: from controller, workload id from runtime can not be like "nodes"
 		id = ""
 	}
 
@@ -992,14 +992,10 @@ func ObtainGroupFilePolicies(id string) (*share.CLUSFileMonitorProfile, *share.C
 /////////////////////////////////////////////////////////////////////////////////
 ////// Estimate the rule from group name or service
 func cbEstimateDeniedProcessdByGroup(id, name, path string) (string, string) {
-	if id == "" {
-		id = "nodes"
-	}
-
 	svcGroup, ok, _ := cbGetLearnedGroupName(id)
 	if !ok {
 		log.WithFields(log.Fields{"id": id}).Error("GRP: no svc")
-		return "", share.CLUSReservedUuidNotAlllowed		// TODO: if possible
+		return "", share.CLUSReservedUuidNotAlllowed // TODO: if possible
 	}
 
 	if profile, ok := ObtainGroupProcessPolicy(id); ok && profile != nil {
@@ -1090,7 +1086,7 @@ func cbEstimateFileAlertByGroup(id, path string, bBlocked bool) string {
 }
 
 func updateContainerFamilyTrees(name string) {
-	if name =="nodes"  {
+	if name == "nodes" {
 		return
 	}
 
@@ -1142,11 +1138,11 @@ func domainChange(domain share.CLUSDomain) {
 
 	gInfoRLock()
 	for _, c := range gInfo.activeContainers {
-		targets.Add(c.id)	// include all containers
+		targets.Add(c.id) // include all containers
 	}
 
 	for _, cache := range groups {
-		cache.members.Clear()	// reset
+		cache.members.Clear() // reset
 		for _, c := range gInfo.activeContainers {
 			if isContainerSelected(c, cache.group) {
 				cache.members.Add(c.id)

--- a/agent/probe/faccess_linux.go
+++ b/agent/probe/faccess_linux.go
@@ -37,8 +37,8 @@ type faProcGrpRef struct {
 }
 
 type regWhiteRule struct {
-    decision int
-    path string
+	decision int
+	path     string
 }
 
 // whitelist per container
@@ -153,9 +153,9 @@ func (fa *FileAccessCtrl) enumExecutables(rootpid int, id string) (map[string]in
 func NewFileAccessCtrl(p *Probe) (*FileAccessCtrl, bool) {
 	log.Debug("FA: ")
 	fa := &FileAccessCtrl{
-		bEnabled: false,
-		roots:    make(map[string]*rootFd),
-		prober:   p,
+		bEnabled:      false,
+		roots:         make(map[string]*rootFd),
+		prober:        p,
 		bKubePlatform: p.bKubePlatform,
 		kubeFlavor:    p.kubeFlavor,
 	}
@@ -163,7 +163,7 @@ func NewFileAccessCtrl(p *Probe) (*FileAccessCtrl, bool) {
 	// docker cp (file changes) might change the polling behaviors,
 	// remove the non-block io to controller the polling timeouts
 	flags := fsmon.FAN_CLASS_CONTENT | fsmon.FAN_UNLIMITED_MARKS | fsmon.FAN_UNLIMITED_QUEUE | fsmon.FAN_NONBLOCK
-	fn, err := fsmon.Initialize(flags, unix.O_RDONLY | unix.O_LARGEFILE)
+	fn, err := fsmon.Initialize(flags, unix.O_RDONLY|unix.O_LARGEFILE)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("FA: Initialize")
 		return nil, false
@@ -293,7 +293,7 @@ func (fa *FileAccessCtrl) isRecursiveDirectoryList(root *rootFd, name, path stri
 
 	if index := strings.Index(path, "/*/"); index > -1 {
 		log.WithFields(log.Fields{"path": path}).Debug("FA:")
-		root.reglst = append( root.reglst, regWhiteRule{ path: path, decision: decision})
+		root.reglst = append(root.reglst, regWhiteRule{path: path, decision: decision})
 		return true
 	}
 	return false
@@ -639,13 +639,13 @@ func (fa *FileAccessCtrl) checkAllowedShieldProcess(id, name, path, svcGroup str
 	}
 
 	if res == rule_allowed_updateAlert {
-		ppe.AllowFileUpdate = false  // common case
+		ppe.AllowFileUpdate = false // common case
 	} else {
-		ppe.AllowFileUpdate = true   // user-defined
+		ppe.AllowFileUpdate = true // user-defined
 	}
 
 	if pass := fa.prober.IsAllowedShieldProcess(id, share.PolicyModeEnforce, svcGroup, proc, ppe, false); pass {
-		return ""	// no violation cause, passed
+		return "" // no violation cause, passed
 	}
 	return ppe.Uuid // cause
 }
@@ -656,7 +656,7 @@ func (fa *FileAccessCtrl) whiteListCheck(path string, pid int) (string, string, 
 	profileSetting := share.ProfileBasic
 	// check if the /proc/xxx/cgroup exists
 	id, _, _, found := global.SYS.GetContainerIDByPID(pid)
-	if id == fa.prober.selfID || !found  || !fa.bEnabled {
+	if id == fa.prober.selfID || !found || !fa.bEnabled {
 		// log.WithFields(log.Fields{"id": id}).Debug("FA: bypass")
 		return id, profileSetting, svcGroup, res // allow agent operations
 	}
@@ -720,7 +720,7 @@ func (fa *FileAccessCtrl) processEvent(ev *fsmon.EventMetadata) bool {
 			// mLog.WithFields(log.Fields{"path": path, "ppid": ppid, "id": id, "profileSetting": profileSetting, "res": res}).Debug("FA:")
 			if profileSetting == share.ProfileZeroDrift {
 				switch res {
-				case rule_denied, rule_allowed:	// matched a rule or bypass
+				case rule_denied, rule_allowed: // matched a rule or bypass
 				default:
 					if rule_uuid = fa.checkAllowedShieldProcess(id, name, path, svcGroup, ppid, res); rule_uuid == "" {
 						res = rule_allowed_zdrift
@@ -729,7 +729,7 @@ func (fa *FileAccessCtrl) processEvent(ev *fsmon.EventMetadata) bool {
 						res = rule_not_defined // reject it
 					}
 				}
-			} else {	// basic
+			} else { // basic
 				if res >= rule_allowed {
 					res = rule_allowed
 				}
@@ -750,22 +750,26 @@ func (fa *FileAccessCtrl) processEvent(ev *fsmon.EventMetadata) bool {
 						}
 
 						pmsg := &ProbeProcess{
-								ID:    id,
-								Pid:   ppid,
-								Path:  path,
-								Name:  name,
-								PPath: ppath,
-								PName: filepath.Base(ppath),
-								Msg:   msg,
-								Group: svcGroup,
-								RuleID: rule_uuid,
+							ID:     id,
+							Pid:    ppid,
+							Path:   path,
+							Name:   name,
+							PPath:  ppath,
+							PName:  filepath.Base(ppath),
+							Msg:    msg,
+							Group:  svcGroup,
+							RuleID: rule_uuid,
 						}
 
 						if fa.prober != nil {
 							if pmsg.RuleID == "" {
-								pmsg.Group, pmsg.RuleID = fa.prober.getEstimateProcGroup(pmsg.ID, pmsg.Name, pmsg.Path)
+								if grp, ruleid := fa.prober.getEstimateProcGroup(pmsg.ID, pmsg.Name, pmsg.Path); grp != "" {
+									// the container is still alive
+									pmsg.Group = grp
+									pmsg.RuleID = ruleid
+								}
 							}
-								// log.WithFields(log.Fields{"id": id, "alert": *alert}).Info("FA: Process denied")
+							// log.WithFields(log.Fields{"id": id, "alert": *alert}).Info("FA: Process denied")
 							rpt := ProbeMessage{Type: PROBE_REPORT_PROCESS_DENIED, Process: pmsg, ContainerIDs: utils.NewSet(id)}
 							fa.prober.SendAggregateProbeReport(&rpt, true)
 						}
@@ -859,7 +863,6 @@ func (fa *FileAccessCtrl) GetProbeData() *FileAccessProbeData {
 func (fa *FileAccessCtrl) isParentProcessException(ppath, path, name string) bool {
 	// mlog.WithFields(log.Fields{"ppath": ppath, "path": path}).Debug("FA:")
 
-
 	// parent: matching only from binary
 	pname := filepath.Base(ppath)
 	if name == "ps" {
@@ -877,7 +880,7 @@ func (fa *FileAccessCtrl) isParentProcessException(ppath, path, name string) boo
 
 		// oc specific
 		if fa.kubeFlavor == share.FlavorOpenShift {
-			switch pname  {
+			switch pname {
 			case "hyperkube", "coreutils":
 				return true
 			case "openshift-sdn-node":


### PR DESCRIPTION
Patch the empty reference when the container was exited before its incident reports.