### PR TITLE
NVSHAS-7897 : enforcer keeps receiving stop container event from crio

### DIFF
--- a/agent/timer.go
+++ b/agent/timer.go
@@ -95,7 +95,13 @@ func statsLoop(bPassiveContainerDetect bool) {
 			gone := gInfo.allContainers.Difference(existing)
 			creates := existing.Difference(gInfo.allContainers)
 			if stops != nil {
-				stops = gInfo.allContainers.Intersect(stops)
+				// differentiate from active containers
+				for id := range stops.Iter() {
+					cid := id.(string)
+					if _, ok := gInfo.activeContainers[cid]; !ok {
+						stops.Remove(cid)
+					}
+				}
 			}
 			gInfoRUnlock()
 			if stops != nil {

--- a/share/container/crio.go
+++ b/share/container/crio.go
@@ -569,7 +569,7 @@ func (d *crioDriver) ListContainerIDs() (utils.Set, utils.Set) {
 		}
 	}
 
-	if exited_sandboxes, err := criListPodSandboxes(d.criClient, ctx, true); err == nil && exited_sandboxes != nil {
+	if exited_sandboxes, err := criListPodSandboxes(d.criClient, ctx, false); err == nil && exited_sandboxes != nil {
 		for _, pod := range exited_sandboxes.Items {
 			stops.Add(pod.Id)
 			ids.Add(pod.Id)

--- a/share/container/docker.go
+++ b/share/container/docker.go
@@ -93,8 +93,8 @@ func dockerConnect(endpoint string, sys *system.SystemTools) (Runtime, error) {
 	}
 
 	driver := dockerDriver{sys: sys, endpoint: endpoint, endpointHost: sockPath, client: client, version: ver, info: info}
-	driver.rtProcMap = utils.NewSet("runc", "docker-runc", "docker", "docker-runc-current", "docker-containerd-shim-current", "containerd", "containerd-shim")
-
+	driver.rtProcMap = utils.NewSet("runc", "docker-runc", "docker", "docker-runc-current",
+	         "docker-containerd-shim-current", "containerd-shim-runc-v1", "containerd-shim-runc-v2", "containerd", "containerd-shim")
 	name, _ := os.Readlink("/proc/1/exe")
 	if name == "/usr/local/bin/monitor" || strings.HasPrefix(name, "/usr/bin/python") { // when pid mode != host, 'pythohn' is for allinone
 		driver.pidHost = false


### PR DESCRIPTION
(1) Reducing the container STOP events from the timer scans. 

(2) Patch an error from PR#739.

(3) Add runtime processes of the docker engine.