### PR TITLE
NVSHAS-6217: Controller Implementation

### DIFF
--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -2836,7 +2836,7 @@ type RESTDerivedDlpRuleMacData struct {
 	Macs []*RESTDerivedDlpRuleMac `json:"macs"`
 }
 
-//waf
+// waf
 const MinWafRuleID = 40000
 const MaxWafRuleID = 50000
 

--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -3460,3 +3460,29 @@ type RESTSelfApikeyData struct {
 	GlobalPermits []*RESTRolePermission            `json:"global_permissions,omitempty"`
 	DomainPermits map[string][]*RESTRolePermission `json:"domain_permissions,omitempty"` // domain -> permissions
 }
+
+type RESTSigstoreRootOfTrust struct {
+	Name           *string                         `json:"name"`
+	RekorPublicKey *string                         `json:"rekor_public_key,omitempty"`
+	RootCert       *string                         `json:"root_cert,omitempty"`
+	SCTPublicKey   *string                         `json:"sct_public_key,omitempty"`
+	Verifiers      map[string]RESTSigstoreVerifier `json:"verifiers,omitempty"`
+}
+
+type RESTSigstoreVerifier struct {
+	Name           *string                             `json:"name"`
+	Type           *string                             `json:"type"`
+	IgnoreTLog     *bool                               `json:"ignore_tlog"`
+	IgnoreSCT      *bool                               `json:"ignore_sct"`
+	KeypairOptions *RESTSigstoreVerifierKeypairOptions `json:"keypair_options,omitempty"`
+	KeylessOptions *RESTSigstoreVerifierKeylessOptions `json:"keyless_options,omitempty"`
+}
+
+type RESTSigstoreVerifierKeypairOptions struct {
+	PublicKey *string `json:"public_key"`
+}
+
+type RESTSigstoreVerifierKeylessOptions struct {
+	CertIssuer  *string `json:"cert_issuer"`
+	CertSubject *string `json:"cert_subject"`
+}

--- a/controller/rest/rest.go
+++ b/controller/rest/rest.go
@@ -1540,6 +1540,18 @@ func StartRESTServer() {
 	r.GET("/v1/scan/registry/:name/layers/:id", handlerRegistryLayersReport)
 	r.GET("/v1/scan/asset", handlerAssetVulnerability) // skip API document
 
+	// Sigstore Configuration
+	r.GET("/v1/scan/sigstore/root_of_trust", handlerSigstoreRootOfTrustGetAll)
+	r.POST("/v1/scan/sigstore/root_of_trust", handlerSigstoreRootOfTrustPost)
+	r.GET("/v1/scan/sigstore/root_of_trust/:root_name", handlerSigstoreRootOfTrustGetByName)
+	r.PATCH("/v1/scan/sigstore/root_of_trust/:root_name", handlerSigstoreRootOfTrustPatchByName)
+	r.DELETE("/v1/scan/sigstore/root_of_trust/:root_name", handlerSigstoreRootOfTrustDeleteByName)
+	r.GET("/v1/scan/sigstore/root_of_trust/:root_name/verifier", handlerSigstoreVerifierGetAll)
+	r.POST("/v1/scan/sigstore/root_of_trust/:root_name/verifier", handlerSigstoreVerifierPost)
+	r.GET("/v1/scan/sigstore/root_of_trust/:root_name/verifier/:verifier_name", handlerSigstoreVerifierGetByName)
+	r.PATCH("/v1/scan/sigstore/root_of_trust/:root_name/verifier/:verifier_name", handlerSigstoreVerifierPatchByName)
+	r.DELETE("/v1/scan/sigstore/root_of_trust/:root_name/verifier/:verifier_name", handlerSigstoreVerifierDeleteByName)
+
 	// compliance
 	r.GET("/v1/compliance/asset", handlerAssetCompliance) // Skip API document
 	r.GET("/v1/bench/host/:id/docker", handlerDockerBench)

--- a/controller/rest/rest.go
+++ b/controller/rest/rest.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/julienschmidt/httprouter"
 	log "github.com/sirupsen/logrus"
+
 	//	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 
 	"github.com/neuvector/neuvector/controller/access"

--- a/controller/rest/sigstore.go
+++ b/controller/rest/sigstore.go
@@ -1,0 +1,379 @@
+package rest
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/neuvector/neuvector/controller/api"
+	"github.com/neuvector/neuvector/share"
+)
+
+func handlerSigstoreRootOfTrustPost(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	body, _ := ioutil.ReadAll(r.Body)
+	var rootOfTrust api.RESTSigstoreRootOfTrust
+	err := json.Unmarshal(body, &rootOfTrust)
+	if err != nil {
+		msg := fmt.Sprintf("could not unmarshal request body: %s", err.Error())
+		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, msg)
+		return
+	}
+
+	if *rootOfTrust.Name == "" {
+		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, "Field \"name\" cannot be empty.")
+		return
+	}
+
+	clusRootOfTrust := share.CLUSSigstoreRootOfTrust{
+		Name:           *rootOfTrust.Name,
+		RekorPublicKey: *rootOfTrust.RekorPublicKey,
+		RootCert:       *rootOfTrust.RootCert,
+		SCTPublicKey:   *rootOfTrust.SCTPublicKey,
+	}
+
+	err = clusHelper.PutSigstoreRootOfTrust(&clusRootOfTrust)
+	if err != nil {
+		msg := fmt.Sprintf("could not save root of trust to kv store: %s", err.Error())
+		restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailWriteCluster, msg)
+		return
+	}
+
+	msg := fmt.Sprintf("Added verifier \"%s\"", clusRootOfTrust.Name)
+	restRespSuccess(w, r, nil, nil, nil, nil, msg)
+}
+
+func handlerSigstoreRootOfTrustGetByName(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	rootName := ps.ByName("root_name")
+	rootOfTrust, err := clusHelper.GetSigstoreRootOfTrust(rootName)
+	if err != nil {
+		restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailReadCluster, err.Error())
+		return
+	}
+	if rootOfTrust == nil {
+		restRespError(w, http.StatusNotFound, api.RESTErrNotFound)
+	}
+	resp := CLUSRootToRESTRoot(rootOfTrust)
+	if withVerifiers(r) {
+		verifiers, err := clusHelper.GetAllSigstoreVerifiersForRoot(rootName)
+		if err != nil {
+			msg := fmt.Sprintf("could not retrieve verifiers for root \"%s\": %s", rootName, err.Error())
+			restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailReadCluster, msg)
+			return
+		}
+		resp.Verifiers = make(map[string]api.RESTSigstoreVerifier, len(verifiers))
+		for name, verifier := range verifiers {
+			resp.Verifiers[name] = CLUSVerifierToRESTVerifier(verifier)
+		}
+	}
+	restRespSuccess(w, r, resp, nil, nil, nil, fmt.Sprintf("Retrieved Sigstore Root Of Trust \"%s\"", rootName))
+}
+
+func handlerSigstoreRootOfTrustPatchByName(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	rootName := ps.ByName("root_name")
+	clusRootOfTrust, err := clusHelper.GetSigstoreRootOfTrust(rootName)
+	if err != nil {
+		restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailReadCluster, err.Error())
+		return
+	}
+	if clusRootOfTrust == nil {
+		restRespError(w, http.StatusNotFound, api.RESTErrNotFound)
+	}
+
+	body, _ := ioutil.ReadAll(r.Body)
+	var restRootOfTrust *api.RESTSigstoreRootOfTrust
+	err = json.Unmarshal(body, restRootOfTrust)
+	if err != nil {
+		msg := fmt.Sprintf("could not unmarshal request body: %s", err.Error())
+		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, msg)
+		return
+	}
+
+	updateCLUSRoot(clusRootOfTrust, restRootOfTrust)
+
+	err = clusHelper.PutSigstoreRootOfTrust(clusRootOfTrust)
+	if err != nil {
+		msg := fmt.Sprintf("could not save root of trust to kv store: %s", err.Error())
+		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, msg)
+		return
+	}
+
+	msg := fmt.Sprintf("Added root of trust \"%s\"", clusRootOfTrust.Name)
+	restRespSuccess(w, r, nil, nil, nil, nil, msg)
+}
+
+func handlerSigstoreRootOfTrustDeleteByName(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	rootName := ps.ByName("root_name")
+	err := clusHelper.DeleteSigstoreRootOfTrust(rootName)
+	if err != nil {
+		msg := fmt.Sprintf("could not delete root of trust \"%s\" from kv store: %s", rootName, err.Error())
+		restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailWriteCluster, msg)
+		return
+	}
+	msg := fmt.Sprintf("Deleted root of trust \"%s\"", rootName)
+	restRespSuccess(w, r, nil, nil, nil, nil, msg)
+}
+
+func handlerSigstoreRootOfTrustGetAll(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	rootsOfTrust, err := clusHelper.GetAllSigstoreRootsOfTrust()
+	if err != nil {
+		msg := fmt.Sprintf("could not retrieve sigstore roots of trust from kv store: %s", err.Error())
+		restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailReadCluster, msg)
+		return
+	}
+
+	resp := make(map[string]api.RESTSigstoreRootOfTrust, len(rootsOfTrust))
+	for key, rootOfTrust := range rootsOfTrust {
+		restRootOfTrust := CLUSRootToRESTRoot(rootOfTrust)
+		if withVerifiers(r) {
+			verifiers, err := clusHelper.GetAllSigstoreVerifiersForRoot(key)
+			if err != nil {
+				msg := fmt.Sprintf("could not retrieve verifiers for root \"%s\": %s", key, err.Error())
+				restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailReadCluster, msg)
+				return
+			}
+			restRootOfTrust.Verifiers = make(map[string]api.RESTSigstoreVerifier, len(verifiers))
+			for name, verifier := range verifiers {
+				restRootOfTrust.Verifiers[name] = CLUSVerifierToRESTVerifier(verifier)
+			}
+		}
+		resp[key] = restRootOfTrust
+	}
+	restRespSuccess(w, r, &resp, nil, nil, nil, "Get all sigstore roots of trust")
+}
+
+func handlerSigstoreVerifierPost(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	body, _ := ioutil.ReadAll(r.Body)
+	var verifier api.RESTSigstoreVerifier
+	err := json.Unmarshal(body, &verifier)
+	if err != nil {
+		msg := fmt.Sprintf("could not unmarshal request body: %s", err.Error())
+		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, msg)
+		return
+	}
+
+	if validationError := validateRESTVerifier(verifier); validationError != nil {
+		msg := fmt.Sprintf("Invalid verifier in request: %s", validationError.Error())
+		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, msg)
+		return
+	}
+
+	clusVerifier := share.CLUSSigstoreVerifier{
+		Name:       *verifier.Name,
+		Type:       *verifier.Type,
+		IgnoreTLog: *verifier.IgnoreTLog,
+		IgnoreSCT:  *verifier.IgnoreSCT,
+	}
+
+	if *verifier.Type == "keypair" {
+		clusVerifier.KeypairOptions.PublicKey = *verifier.KeypairOptions.PublicKey
+	} else {
+		clusVerifier.KeylessOptions.CertIssuer = *verifier.KeylessOptions.CertIssuer
+		clusVerifier.KeylessOptions.CertSubject = *verifier.KeylessOptions.CertSubject
+	}
+
+	err = clusHelper.PutSigstoreVerifier(ps.ByName("root_name"), &clusVerifier)
+	if err != nil {
+		msg := fmt.Sprintf("could not save verifier to kv store: %s", err.Error())
+		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, msg)
+		return
+	}
+
+	msg := fmt.Sprintf("Added verifier \"%s\"", clusVerifier.Name)
+	restRespSuccess(w, r, nil, nil, nil, nil, msg)
+}
+
+func handlerSigstoreVerifierGetByName(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	rootName := ps.ByName("root_name")
+	verifierName := ps.ByName("verifier_name")
+	verifier, err := clusHelper.GetSigstoreVerifier(rootName, verifierName)
+	if err != nil {
+		restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailReadCluster, err.Error())
+		return
+	}
+	if verifier == nil {
+		restRespError(w, http.StatusNotFound, api.RESTErrNotFound)
+	}
+	resp := CLUSVerifierToRESTVerifier(verifier)
+	restRespSuccess(w, r, resp, nil, nil, nil, fmt.Sprintf("Retrieved Sigstore Verifier \"%s/%s\"", rootName, verifierName))
+}
+
+func handlerSigstoreVerifierPatchByName(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	rootName := ps.ByName("root_name")
+	verifierName := ps.ByName("verifier_name")
+	clusVerifier, err := clusHelper.GetSigstoreVerifier(rootName, verifierName)
+	if err != nil {
+		restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailReadCluster, err.Error())
+		return
+	}
+	if clusVerifier == nil {
+		restRespError(w, http.StatusNotFound, api.RESTErrNotFound)
+	}
+
+	body, _ := ioutil.ReadAll(r.Body)
+	var restVerifier *api.RESTSigstoreVerifier
+	err = json.Unmarshal(body, restVerifier)
+	if err != nil {
+		msg := fmt.Sprintf("could not unmarshal request body: %s", err.Error())
+		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, msg)
+		return
+	}
+
+	updateCLUSVerifier(clusVerifier, restVerifier)
+
+	if validationError := validateRESTVerifier(CLUSVerifierToRESTVerifier(clusVerifier)); validationError != nil {
+		msg := fmt.Sprintf("Patch would result in invalid verifier: %s", validationError.Error())
+		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, msg)
+		return
+	}
+
+	err = clusHelper.PutSigstoreVerifier(rootName, clusVerifier)
+	if err != nil {
+		msg := fmt.Sprintf("could not save verifier to kv store: %s", err.Error())
+		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, msg)
+		return
+	}
+
+	msg := fmt.Sprintf("Added verifier \"%s\"", clusVerifier.Name)
+	restRespSuccess(w, r, nil, nil, nil, nil, msg)
+}
+
+func handlerSigstoreVerifierDeleteByName(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	rootName := ps.ByName("root_name")
+	verifierName := ps.ByName("verifier_name")
+	err := clusHelper.DeleteSigstoreVerifier(rootName, verifierName)
+	if err != nil {
+		msg := fmt.Sprintf("could not delete verifier \"%s/%s\" from kv store: %s", rootName, verifierName, err.Error())
+		restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailWriteCluster, msg)
+		return
+	}
+	msg := fmt.Sprintf("Deleted root of trust \"%s/%s\"", rootName, verifierName)
+	restRespSuccess(w, r, nil, nil, nil, nil, msg)
+}
+
+func handlerSigstoreVerifierGetAll(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	rootName := ps.ByName("root_name")
+	verifiers, err := clusHelper.GetAllSigstoreVerifiersForRoot(rootName)
+	if err != nil {
+		msg := fmt.Sprintf("could not retrieve sigstore verifiers from kv store for root \"%s\": %s", rootName, err.Error())
+		restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailReadCluster, msg)
+		return
+	}
+
+	resp := make(map[string]api.RESTSigstoreVerifier, len(verifiers))
+	for key, verifier := range verifiers {
+		resp[key] = CLUSVerifierToRESTVerifier(verifier)
+	}
+	restRespSuccess(w, r, &resp, nil, nil, nil, "Get all sigstore verifiers")
+}
+
+func CLUSRootToRESTRoot(clusRoot *share.CLUSSigstoreRootOfTrust) api.RESTSigstoreRootOfTrust {
+	return api.RESTSigstoreRootOfTrust{
+		Name:           &clusRoot.Name,
+		RekorPublicKey: &clusRoot.RekorPublicKey,
+		RootCert:       &clusRoot.RootCert,
+		SCTPublicKey:   &clusRoot.SCTPublicKey,
+	}
+}
+
+func CLUSVerifierToRESTVerifier(clusVerifier *share.CLUSSigstoreVerifier) api.RESTSigstoreVerifier {
+	return api.RESTSigstoreVerifier{
+		Name:       &clusVerifier.Name,
+		Type:       &clusVerifier.Type,
+		IgnoreTLog: &clusVerifier.IgnoreTLog,
+		IgnoreSCT:  &clusVerifier.IgnoreSCT,
+		KeypairOptions: &api.RESTSigstoreVerifierKeypairOptions{
+			PublicKey: &clusVerifier.KeypairOptions.PublicKey,
+		},
+		KeylessOptions: &api.RESTSigstoreVerifierKeylessOptions{
+			CertIssuer:  &clusVerifier.KeylessOptions.CertIssuer,
+			CertSubject: &clusVerifier.KeylessOptions.CertSubject,
+		},
+	}
+}
+
+func withVerifiers(r *http.Request) bool {
+	q := r.URL.Query()
+	return q.Get("with_verifiers") == "true"
+}
+
+func validateRESTVerifier(verifier api.RESTSigstoreVerifier) error {
+	if *verifier.Name == "" || *verifier.Type == "" {
+		return errors.New("fields \"name\" and \"type\" cannot be empty")
+	}
+
+	if *verifier.Type != "keyless" && *verifier.Type != "keypair" {
+		return errors.New("field \"type\" must be either \"keyless\" or \"keypair\"")
+	}
+
+	if *verifier.Type == "keypair" {
+		if verifier.KeypairOptions == nil {
+			return errors.New("field \"keypair_options\" is required for a verifier of type \"keypair\"")
+		}
+		if *verifier.KeypairOptions.PublicKey == "" {
+			return errors.New("field \"public_key\" cannot be empty for a verifier of type \"keypair\"")
+		}
+	} else {
+		if verifier.KeylessOptions == nil {
+			return errors.New("field \"keyless_options\" is required for a verifier of type \"keyless\"")
+		}
+		if *verifier.KeylessOptions.CertIssuer == "" || *verifier.KeylessOptions.CertSubject == "" {
+			return errors.New("fields \"cert_subject\" and \"cert_issuer\" in field \"keyless_options\" cannot be empty for a verifier of type \"keyless\"")
+		}
+	}
+	return nil
+}
+
+func updateCLUSRoot(clusRoot *share.CLUSSigstoreRootOfTrust, updates *api.RESTSigstoreRootOfTrust) {
+	if updates.Name != nil {
+		clusRoot.Name = *updates.Name
+	}
+
+	if updates.RekorPublicKey != nil {
+		clusRoot.RekorPublicKey = *updates.RekorPublicKey
+	}
+
+	if updates.RootCert != nil {
+		clusRoot.RootCert = *updates.RootCert
+	}
+
+	if updates.SCTPublicKey != nil {
+		clusRoot.SCTPublicKey = *updates.SCTPublicKey
+	}
+}
+
+func updateCLUSVerifier(clusVerifier *share.CLUSSigstoreVerifier, updates *api.RESTSigstoreVerifier) {
+	if updates.Name != nil {
+		clusVerifier.Name = *updates.Name
+	}
+
+	if updates.Type != nil {
+		clusVerifier.Type = *updates.Type
+	}
+
+	if updates.IgnoreTLog != nil {
+		clusVerifier.IgnoreTLog = *updates.IgnoreTLog
+	}
+
+	if updates.IgnoreSCT != nil {
+		clusVerifier.IgnoreSCT = *updates.IgnoreSCT
+	}
+
+	if updates.KeylessOptions != nil {
+		if updates.KeylessOptions.CertIssuer != nil {
+			clusVerifier.KeylessOptions.CertIssuer = *updates.KeylessOptions.CertIssuer
+		}
+
+		if updates.KeylessOptions.CertSubject != nil {
+			clusVerifier.KeylessOptions.CertSubject = *updates.KeylessOptions.CertSubject
+		}
+	}
+
+	if updates.KeypairOptions != nil {
+		if updates.KeypairOptions.PublicKey != nil {
+			clusVerifier.KeypairOptions.PublicKey = *updates.KeypairOptions.PublicKey
+		}
+	}
+}

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -43,34 +43,35 @@ const CLUSLockApikeyKey string = CLUSLockStore + "apikey"
 // !!! NOTE: When adding new config items, update the import/export list as well !!!
 
 const (
-	CFGEndpointSystem           = "system"
-	CFGEndpointEULA             = "eula_oss"
-	CFGEndpointScan             = "scan"
-	CFGEndpointUser             = "user"
-	CFGEndpointServer           = "server"
-	CFGEndpointGroup            = "group"
-	CFGEndpointPolicy           = "policy"
-	CFGEndpointLicense          = "license"
-	CFGEndpointResponseRule     = "response_rule"
-	CFGEndpointProcessProfile   = "process_profile"
-	CFGEndpointRegistry         = "registry"
-	CFGEndpointDomain           = "domain"
-	CFGEndpointFileMonitor      = "file_monitor"
-	CFGEndpointFileAccessRule   = "file_rule"
-	CFGEndpointAdmissionControl = "admission_control"
-	CFGEndpointCrd              = "crd"
-	CFGEndpointFederation       = "federation"
-	CFGEndpointDlpRule          = "dlp_rule"
-	CFGEndpointDlpGroup         = "dlp_group"
-	CFGEndpointWafRule          = "waf_rule"
-	CFGEndpointWafGroup         = "waf_group"
-	CFGEndpointScript           = "script"
-	CFGEndpointCloud            = "cloud"
-	CFGEndpointCompliance       = "compliance"
-	CFGEndpointVulnerability    = "vulnerability"
-	CFGEndpointUserRole         = "user_role"
-	CFGEndpointPwdProfile       = "pwd_profile"
-	CFGEndpointApikey           = "apikey"
+	CFGEndpointSystem               = "system"
+	CFGEndpointEULA                 = "eula_oss"
+	CFGEndpointScan                 = "scan"
+	CFGEndpointUser                 = "user"
+	CFGEndpointServer               = "server"
+	CFGEndpointGroup                = "group"
+	CFGEndpointPolicy               = "policy"
+	CFGEndpointLicense              = "license"
+	CFGEndpointResponseRule         = "response_rule"
+	CFGEndpointProcessProfile       = "process_profile"
+	CFGEndpointRegistry             = "registry"
+	CFGEndpointDomain               = "domain"
+	CFGEndpointFileMonitor          = "file_monitor"
+	CFGEndpointFileAccessRule       = "file_rule"
+	CFGEndpointAdmissionControl     = "admission_control"
+	CFGEndpointCrd                  = "crd"
+	CFGEndpointFederation           = "federation"
+	CFGEndpointDlpRule              = "dlp_rule"
+	CFGEndpointDlpGroup             = "dlp_group"
+	CFGEndpointWafRule              = "waf_rule"
+	CFGEndpointWafGroup             = "waf_group"
+	CFGEndpointScript               = "script"
+	CFGEndpointCloud                = "cloud"
+	CFGEndpointCompliance           = "compliance"
+	CFGEndpointVulnerability        = "vulnerability"
+	CFGEndpointUserRole             = "user_role"
+	CFGEndpointPwdProfile           = "pwd_profile"
+	CFGEndpointApikey               = "apikey"
+	CFGEndpointSigstoreRootsOfTrust = "sigstore_roots_of_trust"
 )
 const CLUSConfigStore string = CLUSObjectStore + "config/"
 const CLUSConfigSystemKey string = CLUSConfigStore + CFGEndpointSystem
@@ -101,6 +102,7 @@ const CLUSConfigDomainStore string = CLUSConfigStore + CFGEndpointDomain + "/"
 const CLUSConfigUserRoleStore string = CLUSConfigStore + CFGEndpointUserRole + "/"
 const CLUSConfigPwdProfileStore string = CLUSConfigStore + CFGEndpointPwdProfile + "/"
 const CLUSConfigApikeyStore string = CLUSConfigStore + CFGEndpointApikey + "/"
+const CLUSConfigSigstoreRootsOfTrust string = CLUSConfigStore + CFGEndpointSigstoreRootsOfTrust + "/"
 
 // !!! NOTE: When adding new config items, update the import/export list as well !!!
 
@@ -630,6 +632,14 @@ func CLUSFileMonitorKey2Group(key string) string {
 
 func CLUSGroupKey2GroupName(key string) string {
 	return CLUSKeyNthToken(key, 3)
+}
+
+func CLUSSigstoreRootOfTrustKey(rootName string) string {
+	return fmt.Sprintf("%s%s", CLUSConfigSigstoreRootsOfTrust, rootName)
+}
+
+func CLUSSigstoreVerifierKey(rootName string, verifierName string) string {
+	return fmt.Sprintf("%s/%s", CLUSSigstoreRootOfTrustKey(rootName), verifierName)
 }
 
 type CLUSDistLocker struct {
@@ -2712,4 +2722,29 @@ type CLUSApikey struct {
 	ExpirationTimestamp int64               `json:"expiration_timestamp"`
 	CreatedTimestamp    int64               `json:"created_timestamp"`
 	CreatedByEntity     string              `json:"created_by_entity"` // it could be username or apikey (access key)
+}
+
+type CLUSSigstoreRootOfTrust struct {
+	Name           string `json:"name"`
+	RekorPublicKey string `json:"rekor_public_key"`
+	RootCert       string `json:"root_cert"`
+	SCTPublicKey   string `json:"sct_public_key"`
+}
+
+type CLUSSigstoreVerifier struct {
+	Name           string                             `json:"name"`
+	Type           string                             `json:"type"`
+	IgnoreTLog     bool                               `json:"ignore_tlog"`
+	IgnoreSCT      bool                               `json:"ignore_sct"`
+	KeypairOptions CLUSSigstoreVerifierKeypairOptions `json:"keypair_options"`
+	KeylessOptions CLUSSigstoreVerifierKeylessOptions `json:"keyless_options"`
+}
+
+type CLUSSigstoreVerifierKeypairOptions struct {
+	PublicKey string `json:"public_key"`
+}
+
+type CLUSSigstoreVerifierKeylessOptions struct {
+	CertIssuer  string `json:"cert_issuer"`
+	CertSubject string `json:"cert_subject"`
 }

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -203,7 +203,7 @@ const CLUSScannerStatsStore string = CLUSScanStore + "scanner_stats/"
 const CLUSScannerDBVersionID string = "NeuVectorCVEDBVersion" // used for indicate db version changed
 const CLUSScannerDBStore string = CLUSScanStore + "database/"
 
-//recalculate
+// recalculate
 const CLUSRecalPolicyStore string = CLUSRecalculateStore + "policy/" //not to be watched by consul
 const CLUSRecalDlpStore string = CLUSRecalculateStore + "dlp/"       //not to be watched by consul
 
@@ -219,7 +219,7 @@ func CLUSRecalDlpWlRulesKey(name string) string {
 	return fmt.Sprintf("%s%s", CLUSRecalDlpStore, name)
 }
 
-//fqdn
+// fqdn
 const CLUSFqdnIpStore string = CLUSFqdnStore + "ip/" //not to be watched by consul
 
 func CLUSFqdnIpKey(hostID string, fqdname string) string {
@@ -2188,7 +2188,7 @@ type CLUSFedScanRevisions struct {
 	Restoring      bool              `json:"restoring"`        // fed registry revision
 }
 
-//dlp rule
+// dlp rule
 const (
 	DlpRuleKeyPattern string = "pattern"
 )
@@ -2313,7 +2313,7 @@ type CLUSDlpGroup struct {
 	CfgType TCfgType          `json:"cfg_type"`
 }
 
-//waf
+// waf
 type CLUSWafCriteriaEntry struct {
 	Key     string `json:"key"`
 	Value   string `json:"value"`
@@ -2372,14 +2372,15 @@ type CLUSCrdEventRecord struct {
 	CrdEventRecord []string
 }
 
-////// Process UUID Rules
-//     Reserved(256 entries): 	00000000-0000-0000-0000-0000000000XX
-//     Default rules:			00000000-0000-0000-0000-00000000000X
-//     Linux-specific:  		00000000-0000-0000-0000-00000000001X ans 2X
-//     Windows-specific:  		00000000-0000-0000-0000-00000000003X ans 4X
+// //// Process UUID Rules
+//
+//	Reserved(256 entries): 	00000000-0000-0000-0000-0000000000XX
+//	Default rules:			00000000-0000-0000-0000-00000000000X
+//	Linux-specific:  		00000000-0000-0000-0000-00000000001X ans 2X
+//	Windows-specific:  		00000000-0000-0000-0000-00000000003X ans 4X
 const CLUSReservedUuidPrefix string = "00000000-0000-0000-0000-0000000000" // reserved the last 2 digits
 
-//////
+// ////
 const CLUSReservedUuidNotAlllowed string = "00000000-0000-0000-0000-000000000000"    // processes beyond white list
 const CLUSReservedUuidRiskyApp string = "00000000-0000-0000-0000-000000000001"       // riskApp
 const CLUSReservedUuidTunnelProc string = "00000000-0000-0000-0000-000000000002"     // tunnel
@@ -2499,7 +2500,7 @@ type SecretLog struct {
 	RuleDesc string `json:"rule_desc"` // rule description
 }
 
-/////// Secret Types
+// ///// Secret Types
 const (
 	SecretPrivateKey string = "privatekey" // Private Key
 	SecretX509       string = "x.509"      // X.509 certificates (ignored)
@@ -2531,7 +2532,7 @@ type CLUSSetIdPermLog struct {
 	Evidence string `json:"evidence"` // file attributes
 }
 
-/////// For custom roles
+// ///// For custom roles
 func CLUSUserRoleKey(name string) string {
 	return fmt.Sprintf("%s%s", CLUSConfigUserRoleStore, name)
 }


### PR DESCRIPTION
### API Notes
 
The Rest API has the following endpoints
```
Get all roots of trust
GET /v1/scan/sigstore/root_of_trust

Create a new root of trust
POST /v1/scan/sigstore/root_of_trust

Get a single root of trust by name
GET /v1/scan/sigstore/root_of_trust/:root_name

Update a single root of trust by name
PATCH /v1/scan/sigstore/root_of_trust/:root_name

Delete a single root of trust by name
DELETE /v1/scan/sigstore/root_of_trust/:root_name

Get all verifiers that belong to a given root of trust
GET /v1/scan/sigstore/root_of_trust/:root_name/verifier

Create a single verifier under a given root of trust
POST /v1/scan/sigstore/root_of_trust/:root_name/verifier

Get a single verifier by name under a given root of trust
GET /v1/scan/sigstore/root_of_trust/:root_name/verifier/:verifier_name

Update a single verifier by name under a given root of trust
PATCH /v1/scan/sigstore/root_of_trust/:root_name/verifier/:verifier_name

Delete a single verifier by name under a given root of trust
DELETE /v1/scan/sigstore/root_of_trust/:root_name/verifier/:verifier_name
```

The 2 endpoints associated with getting roots of trust (`GET /v1/scan/sigstore/root_of_trust` and `GET /v1/scan/sigstore/root_of_trust/:root_name`) can be provided with a query parameter `with_verifiers` that will include all of the verifiers associated with that root of trust in the response object. Verifiers cannot be updated or created through the root of trust endpoints.

The Root of Trust object is structured as follows
```
{
  name: string
  rekor_public_key: string
  root_cert: string
  sct_public_key: string
  Verifiers: map of verifiers with their name as keys
}
```
Empty fields will not be returned in GET responses. Verifiers will only be returned if requested by the `with_verifiers` query parameter. Verifiers are not necessary (and have no effect if included) in any of the endpoints used to create or update a root of trust.

The Verifier Object is structured as follows
```
{
  name: string
  type: string
  ignore_tlog: bool
  ignore_sct: bool
  keypair_options: {
    public_key: string
  }
  keyless_options: {
    cert_issuer: string
    cert_subject: string
  }
}
```
The `type` field must only have a value of either `keyless` or `keypair`. The corresponding options fields must be populated based on the value of the `type` field. For example, if the `type` field has the value `keyless`, then the `keyless_options` field must be populated.