### PR TITLE
NVSHAS-7893: ProcessProfile: Unexpected process violation incident gennerated for registry container

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -2020,10 +2020,6 @@ func taskStopContainer(id string, pid int) {
 		log.WithFields(log.Fields{"id": id, "error": err}).Error("Failed to read container. Use cached info.")
 		info = c.info
 		info.Running = false
-	} else if info.Running {
-		// not a relaible source: from process monitor
-		log.WithFields(log.Fields{"id": id}).Debug("skip stop as container is still running")
-		return
 	}
 
 	if info.FinishedAt.IsZero() {

--- a/agent/probe/incident_reporter.go
+++ b/agent/probe/incident_reporter.go
@@ -302,7 +302,7 @@ func (p *Probe) processAggregateProbeReports() int {
 			if pmsga.count > 1 {
 				go p.sendReport(*pmsga)
 				cnt++
-			} else if pmsga.bFsMonMsg && pmsga.count >= 1 {
+			} else if pmsga.bFsMonMsg && pmsga.count > 1 {	// no more adding entry
 				go p.sendReport(*pmsga)
 				cnt++
 			}

--- a/agent/probe/probe.go
+++ b/agent/probe/probe.go
@@ -400,9 +400,6 @@ func (p *Probe) processContainerChanges(pidSetNew utils.Set) {
 
 func (p *Probe) monitorProcessChanges() {
 	// netlink proc: avoid deadlocks
-	p.processContainerNewChanges()
-	p.processContainerStopChanges()
-
 	// keep an eye on the launched applications
 	p.inspectNewProcesses(false) // Evaluations
 	// p.processContainerAppPortChanges()

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -571,7 +571,7 @@ func (p *Probe) removeProcessInContainer(pid int, id string) {
 		// the container has exited, clean up
 		if containerRemoved {
 			clearContainerProcesses(c)
-			p.containerStops.Add(c.id)
+			// p.containerStops.Add(c.id)
 			delete(p.containerMap, c.id)
 			log.WithFields(log.Fields{"pid": pid, "id": c.id, "cnt": len(p.containerMap) - 2}).Debug("PROC: Container remove")
 		} else {
@@ -679,6 +679,28 @@ func (p *Probe) evaluateRuncTrigger(id string, proc *procInternal) {
 		}
 	}
 }
+
+func (p *Probe) evaluateRuntimeCmd(proc *procInternal) bool {
+	if global.RT.IsRuntimeProcess(filepath.Base(proc.ppath), nil) {
+		if global.RT.IsRuntimeProcess(filepath.Base(proc.path), nil) {
+			return true
+		}
+
+		// runc [global options] command [command options] [arguments...]
+		for i, cmd := range proc.cmds {
+			switch i {
+			case 0:
+				if !global.RT.IsRuntimeProcess(filepath.Base(cmd), nil) {
+					return false
+				}
+			case 1:
+				return cmd == "init"
+			}
+		}
+	}
+	return false
+}
+
 
 // Debug purpose:
 func (p *Probe) printProcReport(id string, proc *procInternal) {
@@ -1567,7 +1589,7 @@ func (p *Probe) initReadProcesses() bool {
 		}
 	}
 	p.walkNewProcesses()
-	p.processContainerNewChanges()
+	// p.processContainerNewChanges()
 	p.inspectNewProcesses(true) // catch existing processes
 	return foundKube
 }
@@ -1779,6 +1801,10 @@ func (p *Probe) evaluateApplication(proc *procInternal, id string, bKeepAlive bo
 	// only allowing the NS op from the agent's root session
 	if p.isAgentChildren(proc, id) {
 		// log.WithFields(log.Fields{"proc": proc, "id": id}).Debug("PROC: ignored")
+		return
+	}
+
+	if id != "" && p.evaluateRuntimeCmd(proc) {
 		return
 	}
 
@@ -2494,7 +2520,7 @@ func (p *Probe) procProfileEval(id string, proc *procInternal, bKeepAlive bool) 
 		p.reportLearnProc(svcGroup, pp)
 	}
 
-	mLog.WithFields(log.Fields{"name": proc.name, "pid": proc.pid, "action": pp.Action, "riskType": proc.riskType}).Debug("PROC:")
+	mLog.WithFields(log.Fields{"name": proc.name, "pid": proc.pid, "action": pp.Action, "riskType": proc.riskType, "svcGroup": svcGroup}).Debug("PROC:")
 	return pp.Action, true
 }
 
@@ -2765,10 +2791,6 @@ func (p *Probe) evaluateLiveApps(id string) {
 }
 
 func (p *Probe) processProfileReeval(id string, pg *share.CLUSProcessProfile, bAddContainer bool) {
-	if bAddContainer {
-		go p.PutBeginningProcEventsBackToWork(id)
-	}
-
 	go p.evaluateLiveApps(id)
 
 	// update riskApp by current policy
@@ -2933,6 +2955,11 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 	if !ok {
 		// the container was exited before we investigate into it
 		mLog.WithFields(log.Fields{"proc": proc, "id": id}).Debug("SHD: Unknown ID")
+		return true
+	}
+
+	// container is gone
+	if !osutil.IsPidValid(c.rootPid) {
 		return true
 	}
 


### PR DESCRIPTION
We are considering that the process family tree is valid after the rootpid report of the container engine. Thus, we can ignore those false-positive cases at the initial runtime stage.

(1) Remove the add/remove container events from the process's probe channel. It will help to ignore the runtime engine's container creation events. ( TODO: those unused functions will be removed later).

(2) Fix the shield evaluation if a process was gone and we can not find its original file path.

(3) Fix a minor FILE false event if no follow-up aggregate file events exist. 