### PR TITLE
NVSHAS-7941: the workload event may be missing during lead change

### DIFF
--- a/share/cluster/api/status.go
+++ b/share/cluster/api/status.go
@@ -1,5 +1,10 @@
 package api
 
+import (
+	"context"
+	"time"
+)
+
 // Status can be used to query the Status endpoints
 type Status struct {
 	c *Client
@@ -12,7 +17,11 @@ func (c *Client) Status() *Status {
 
 // Leader is used to query for a known leader
 func (s *Status) Leader() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+
 	r := s.c.newRequest("GET", "/v1/status/leader")
+	r.setQueryOptions(&QueryOptions{ctx:ctx})
 	_, resp, err := requireOK(s.c.doRequest(r))
 	if err != nil {
 		return "", err


### PR DESCRIPTION
The consul API requests from the leader watcher might enter an indefinite wait when the leader is missing. In this case, the DNS record was incorrect. 

To avoid the indefinite wait, this PR adds a timeout; then the watcher gets leader changes in time.