### PR TITLE
NVSHAS-7844, NVSHAS-3170: file monitor patches

### DIFF
--- a/agent/probe/incident_reporter.go
+++ b/agent/probe/incident_reporter.go
@@ -172,12 +172,13 @@ func (p *Probe) SendAggregateFsMonReport(pmsg *fsmon.MonitorMessage) bool {
 		pmsga.expireCnt = expireCountdown
 
 		if pmsg.ProcPid != 0 && pmsga.pid == 0 {
+			pmsga.expireCnt = 1
 			pmsg.ProcPid = pmsg.ProcPid
 			pmsga.fsMsg = pmsg // updated
 		} else {
-			pmsga.count++
 			pmsga.fsMsg.Path = pmsg.Path // restored
 		}
+		pmsga.count++
 		mLog.WithFields(log.Fields{"report_a": pmsga, "msg": pmsga.fsMsg, "pmsg": pmsg}).Debug("PROC: accumulated")
 		return false // hold the event for further events
 	}


### PR DESCRIPTION
NVSHAS-7844: "unable to create Container.FileAccess.Violation incident successfully if the file is modified"
 --  There is another filter by a federal group referenced first to report incidents. We need to match all possible rules and report all possible learned process requests to controllers.

NVSHAS-3170: "Host.FileAccess.Violation incidents are missing" 
-- The aggregate incident worker's behavior was changed by the previous PR#821. The count must be incremented for the catchup events, too.  