### PR TITLE
NVSHAS-7938, NVSHAS-7951: unexpected NV.Protect incident is created

### DIFF
--- a/agent/policy/process.go
+++ b/agent/policy/process.go
@@ -386,34 +386,23 @@ func buildManagerProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		// python
 		{"support", "/usr/bin/*"}, // support
 		{"cli", "/usr/bin/*"},     // cli
-
-		// manager cores :  wildcard
 		{"*", "/usr/lib/jvm/*"}, // JVM
-		//	{"java", "/usr/lib/jvm/java-1.8-openjdk/jre/bin/java"}
+
+		// tools
+		{"ps", "*"},
+		{"lsof", "*"},
+		{"sh", "*"},
+		{"kill", "*"},
 
 		// busybox
 		{"busybox", "/bin/busybox"}, // below busybox and its symbolic links
-		{"lsof", "/bin/busybox"},    // replaced
-		{"netstat", "/bin/busybox"},
-		{"ps", "/bin/busybox"}, // replaced
-		{"sh", "/bin/busybox"},
-		{"touch", "/bin/busybox"}, // detect container layer on the AUFS
 		{"uname", "/bin/busybox"}, // cli
 		{"which", "/bin/busybox"}, // cli
-		{"cat", "*"},              // k8s readiness and openshift operations
 		{"echo", "/bin/busybox"},
 
 		// below entries for debug purpose : docker exec -ti manager sh
-		{"sh", "/bin/dash"},
 		{"ip", "/sbin/ip"},
-		{"ps", "/usr/bin/ps"},   // new procps package
-		{"top", "/usr/bin/top"}, // new procps package
-		{"kill", "/bin/kill"},   // new procps package
 		{"ls", "/bin/busybox"},
-		{"kill", "/bin/busybox"}, // replaced
-		{"top", "/bin/busybox"},  // replaced
-		{"nslookup", "/bin/busybox"},
-		{"nc", "/bin/busybox"},
 		{"tee", "/usr/bin/tee"},
 		{"stat", "/usr/bin/stat"}, // bench scripts
 		{"stty", "/bin/busybox"},  // python3.9
@@ -422,9 +411,6 @@ func buildManagerProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		{"pause", "/pause"},     // k8s, pause
 		{"pod", "/usr/bin/pod"}, // openshift, pod
 		{"mount", "*"},          // k8s volume plug-in
-		{"grep", "*"},           // CIS bench tests
-		{"pgrep", "*"},
-		{"sed", "*"},
 	}
 
 	return buildCustomizedProfile(serviceGroup, share.PolicyModeEnforce, whtLst, nil)
@@ -439,36 +425,17 @@ func buildScannerProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		{"monitor", "/usr/local/bin/monitor"},
 		{"scanner", "/usr/local/bin/scanner"},
 		{"scannerTask", "/usr/local/bin/scannerTask"},
+		{"sigstore-interface", "/usr/local/bin/sigstore-interface"},
 
-		// busybox
-		{"busybox", "/bin/busybox"}, // below busybox and its symbolic links
-		{"netstat", "/bin/busybox"},
-		{"sh", "/bin/busybox"},
-		{"uname", "/bin/busybox"},
-		{"which", "/bin/busybox"},
-		{"touch", "/bin/busybox"}, // detect container layer on the AUFS
-		{"cat", "*"},              // k8s readiness and openshift operations
-
-		// below entries for debug purpose : docker exec -ti manager sh
-		{"sh", "/bin/dash"},
-		{"ip", "/sbin/ip"},
-		{"ps", "/usr/bin/ps"}, // new procps package
-		{"kill", "/bin/kill"}, // new procps package
-		{"ls", "/bin/busybox"},
-		{"lsof", "/usr/bin/lsof"}, // new lsof package
-		{"nslookup", "/bin/busybox"},
-		{"nc", "/bin/busybox"},
-		{"echo", "/bin/busybox"},
-		{"tee", "/usr/bin/tee"},
-		{"stat", "/usr/bin/stat"}, // bench scripts
+		// tools
+		{"ps", "*"},
+		{"lsof", "*"},
+		{"sh", "*"},
 
 		// k8s or openshift environment
 		{"pause", "/pause"},     // k8s, pause
 		{"pod", "/usr/bin/pod"}, // openshift, pod
 		{"mount", "*"},          // k8s volume plug-in
-		{"grep", "*"},           // CIS bench tests
-		{"pgrep", "*"},
-		{"sed", "*"},
 	}
 
 	return buildCustomizedProfile(serviceGroup, share.PolicyModeEnforce, whtLst, nil)
@@ -480,14 +447,20 @@ func buildCspProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		/////////////////////////////////
 		// scanner cores :  wildcard
 		{"csp-billing-ada", "*"},
+		{"ldconfig", "/sbin/ldconfig"},
+		{"python3", "/usr/bin/*"},
+		{"uname", "/usr/bin/uname"},
+
+		// tools
+		{"ps", "*"},
+		{"lsof", "*"},
+		{"sh", "*"},
+		{"bash", "*"},
 
 		// k8s or openshift environment
 		{"pause", "/pause"},     // k8s, pause
 		{"pod", "/usr/bin/pod"}, // openshift, pod
 		{"mount", "*"},          // k8s volume plug-in
-		{"grep", "*"},           // CIS bench tests
-		{"pgrep", "*"},
-		{"sed", "*"},
 	}
 
 	return buildCustomizedProfile(serviceGroup, share.PolicyModeEnforce, whtLst, nil)
@@ -513,23 +486,20 @@ func buildControllerProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		{"getconf", "/usr/bin/getconf"},  // get configuration values
 		{"getent", "/usr/bin/getent"},    // get entries from Name Service Switch libraries
 		{"iconv", "/usr/bin/iconv"},      // convert encoding of given files from one encoding to another
-		{"lsof", "/usr/bin/lsof"},        // new lsof package
+		{"ps", "*"},
+		{"lsof", "*"},
+		{"sh", "*"},
+		{"cat", "*"},                     // k8s readiness and openshift operations
 
 		// busybox
 		{"busybox", "/bin/busybox"}, // below busybox and its symbolic links
 		{"mv", "/bin/busybox"},
-		{"lsof", "/bin/busybox"}, // replaced
 		{"netstat", "/bin/busybox"},
-		{"ps", "/bin/busybox"},
-		{"sh", "/bin/busybox"},
 		{"touch", "/bin/busybox"},       // detect container layer on the AUFS
-		{"cat", "*"},                    // k8s readiness and openshift operations
 		{"teardown.sh", "/bin/busybox"}, // monitor tool
 
 		// below entries for debug purpose : docker exec -ti allinone sh
-		{"sh", "/bin/dash"},
 		{"ip", "/sbin/ip"},
-		{"ps", "/usr/bin/ps"},   // new procps package
 		{"top", "/usr/bin/top"}, // new procps package
 		{"kill", "/bin/kill"},   // new procps package
 		{"ls", "/bin/busybox"},
@@ -545,9 +515,6 @@ func buildControllerProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		{"pause", "/pause"},     // k8s, pause
 		{"pod", "/usr/bin/pod"}, // openshift, pod
 		{"mount", "*"},          // k8s volume plug-in
-		{"grep", "*"},           // CIS bench tests
-		{"pgrep", "*"},
-		{"sed", "*"},
 	}
 
 	return buildCustomizedProfile(serviceGroup, share.PolicyModeEnforce, whtLst, nil)
@@ -578,25 +545,23 @@ func buildEnforcerProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		{"curl", "/usr/bin/curl"},        // cis benchmark
 		{"jq", "/usr/bin/jq"},            // cis benchmark
 		{"timeout", "/usr/bin/timeout"},  // could be used by tcpdump
+		{"ps", "*"},
+		{"lsof", "*"},
+		{"sh", "*"},
+		{"cat", "*"},                     // k8s readiness and openshift operations
 
 		// busybox
 		{"busybox", "/bin/busybox"}, // below busybox and its symbolic links
 		{"mv", "/bin/busybox"},
-		{"lsof", "/bin/busybox"}, // replaced
 		{"netstat", "/bin/busybox"},
-		{"ps", "/bin/busybox"},
-		{"sh", "/bin/busybox"},
 		{"touch", "/bin/busybox"},        // detect container layer on the AUFS
-		{"cat", "*"},                     // k8s readiness and openshift operations
 		{"configure.sh", "/bin/busybox"}, // monitor tool
 		{"teardown.sh", "/bin/busybox"},  // monitor tool
 
 		// below entries for debug purpose : docker exec -ti allinone sh
-		{"sh", "/bin/dash"},
 		{"ip", "/sbin/ip"},
 		{"iptables", "/sbin/xtables-legacy-multi"},      // dp
 		{"iptables-save", "/sbin/xtables-legacy-multi"}, // dp
-		{"ps", "/usr/bin/ps"},                           // new procps package
 		{"top", "/usr/bin/top"},                         // new procps package
 		{"kill", "/bin/kill"},                           // new procps package
 		{"ls", "/bin/busybox"},
@@ -613,8 +578,11 @@ func buildEnforcerProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		{"pod", "/usr/bin/pod"}, // openshift, pod
 		{"mount", "*"},          // k8s volume plug-in
 		{"grep", "*"},           // CIS bench tests
-		{"pgrep", "*"},
+		{"pgrep", "/usr/bin/pgrep"},
 		{"sed", "*"},
+		{"cut", "/usr/bin/cut"},
+		{"awk", "/usr/bin/awk"},
+		{"tr", "/usr/bin/tr"},
 	}
 
 	return buildCustomizedProfile(serviceGroup, share.PolicyModeEnforce, whtLst, nil)
@@ -658,28 +626,26 @@ func buildAllinOneProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		{"curl", "/usr/bin/curl"},        // cis benchmark
 		{"jq", "/usr/bin/jq"},            // cis benchmark
 		{"timeout", "/usr/bin/timeout"},  // could be used by tcpdump
+		{"ps", "*"},
+		{"lsof", "*"},
+		{"sh", "*"},
+		{"cat", "*"},                     // k8s readiness and openshift operations
 
 		// busybox
 		{"busybox", "/bin/busybox"}, // below busybox and its symbolic links
 		{"mv", "/bin/busybox"},
-		{"lsof", "/bin/busybox"}, // replaced
 		{"netstat", "/bin/busybox"},
-		{"ps", "/bin/busybox"},
-		{"sh", "/bin/busybox"},
 		{"touch", "/bin/busybox"},        // detect container layer on the AUFS
 		{"uname", "/bin/busybox"},        // cli
 		{"which", "/bin/busybox"},        // cli
-		{"cat", "*"},                     // k8s readiness and openshift operations
 		{"configure.sh", "/bin/busybox"}, // monitor tool
 		{"teardown.sh", "/bin/busybox"},  // monitor tool
 		{"stty", "/bin/busybox"},         // python3.9
 
 		// below entries for debug purpose : docker exec -ti allinone sh
-		{"sh", "/bin/dash"},
 		{"ip", "/sbin/ip"},
 		{"iptables", "/sbin/xtables-legacy-multi"},      // dp
 		{"iptables-save", "/sbin/xtables-legacy-multi"}, // dp
-		{"ps", "/usr/bin/ps"},                           // new procps package
 		{"top", "/usr/bin/top"},                         // new procps package
 		{"kill", "/bin/kill"},                           // new procps package
 		{"ls", "/bin/busybox"},
@@ -695,8 +661,11 @@ func buildAllinOneProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		{"pod", "/usr/bin/pod"}, // openshift, pod
 		{"mount", "*"},          // k8s volume plug-in
 		{"grep", "*"},           // CIS bench tests
-		{"pgrep", "*"},
+		{"pgrep", "/usr/bin/pgrep"},
 		{"sed", "*"},
+		{"cut", "/usr/bin/cut"},
+		{"awk", "/usr/bin/awk"},
+		{"tr", "/usr/bin/tr"},
 	}
 
 	return buildCustomizedProfile(serviceGroup, share.PolicyModeEnforce, whtLst, nil)

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -2295,9 +2295,16 @@ func (p *Probe) isProcessException(proc *procInternal, group, id string, bParent
 		return false
 	}
 
+	// the parent name is not ready
+	if proc.pname == "" {
+		proc.pname, _, _, _ = osutil.GetProcessUIDs(proc.ppid)
+	}
 
 	bRtProc := global.RT.IsRuntimeProcess(proc.name, nil)
 	bRtProcP := global.RT.IsRuntimeProcess(proc.pname, nil)
+	if proc.pname == "" {
+		bRtProcP = true		// not trace-able
+	}
 
 	// both names are in the runtime list
 	if bRtProc && bRtProcP {


### PR DESCRIPTION
NV Protect:

(1) Add allowed rules of the CSP pods.
(2) Add CIS benchmarks app tools to allinone and Enforcer only.

Adding NVSHAS-7914: Avoid intercept the traffic for process sigstore-interface in scanner container