### PR TITLE
NVSHAS-7954: show running in workload object for the stopped container

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -2025,6 +2025,9 @@ func taskStopContainer(id string, pid int) {
 		log.WithFields(log.Fields{"id": id, "error": err}).Error("Failed to read container. Use cached info.")
 		info = c.info
 		info.Running = false
+	} else if info.Running {
+		// Wait for the updated container info
+		return
 	}
 
 	if info.FinishedAt.IsZero() {


### PR DESCRIPTION
docker and containerd:

The container info shows that it is still running. The enforcer should wait for the actual container "stop" events. The updated "stop" container info will be updated from these two runtime event listeners.