### PR TITLE
NVSHAS-7983: NV protect events are not reporting name of the pod for manager, scanner and csp pods

### DIFF
--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -2263,9 +2263,12 @@ func (p *Probe) isAllowCniCommand(path string) bool {
 	return false
 }
 
-func (p *Probe) isAllowCalicoCommand(proc *procInternal) bool {
+func (p *Probe) isAllowCalicoCommand(proc *procInternal, bRtProcP bool) bool {
 	if p.bKubePlatform {
-		return proc.path == "/usr/bin/calico-node" && (len(proc.cmds) > 0 && filepath.Base(proc.cmds[0]) == "calico-node")
+		if bRtProcP {
+			return proc.path == "/usr/bin/calico-node" && (len(proc.cmds) > 0 && filepath.Base(proc.cmds[0]) == "calico-node")
+		}
+		return proc.ppath == "/usr/bin/calico-node" && filepath.Dir(proc.path) == "/usr/local/bin"
 	}
 	return false
 }
@@ -2333,7 +2336,7 @@ func (p *Probe) isProcessException(proc *procInternal, group, id string, bParent
 	}
 
 	// network plug-in: calico-node
-	if bRtProcP && p.isAllowCalicoCommand(proc) {
+	if p.isAllowCalicoCommand(proc, bRtProcP) {
 		log.WithFields(log.Fields{"name": proc.name, "path": proc.path, "pname": proc.pname}).Debug("PROC:")
 		return true
 	}

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -166,6 +166,7 @@ var hostCacheMap map[string]*hostCache = make(map[string]*hostCache)         // 
 var k8sHostInfoMap map[string]*k8sHostCache = make(map[string]*k8sHostCache) // key is the host name seen by enforcer. only used in k8s/oc env
 var agentCacheMap map[string]*agentCache = make(map[string]*agentCache)
 var ctrlCacheMap map[string]*ctrlCache = make(map[string]*ctrlCache)
+var nvwlCacheMap map[string]*workloadCache = make(map[string]*workloadCache)
 var wlCacheMap map[string]*workloadCache = make(map[string]*workloadCache)
 var ipHostMap map[string]*hostDigest = make(map[string]*hostDigest)
 var tunnelHostMap map[string]string = make(map[string]string)
@@ -586,6 +587,15 @@ func getNvName(id string) *workloadNames {
 		return names
 	}
 
+	if cache, ok := nvwlCacheMap[id]; ok {
+		wl := cache.workload
+		names := &workloadNames{
+			name:    cache.podName,
+			domain:  wl.Domain,
+			image:   wl.Image,
+		}
+		return names
+	}
 	return nil
 }
 

--- a/controller/cache/group.go
+++ b/controller/cache/group.go
@@ -349,7 +349,9 @@ func isNeuvectorContainerGroup(group string) bool {
 				name == "nv.neuvector-scanner-pod" ||
 				name == "nv.neuvector-controller-pod" ||
 				name == "nv.neuvector-enforcer-pod" ||
-				name == "nv.neuvector-updater-pod" {
+				name == "nv.neuvector-updater-pod" ||
+				name == "nv.neuvector-csp-pod" ||
+				name == "nv.neuvector-registry-adapter-pod" {
 				return true
 			}
 		}
@@ -1923,7 +1925,7 @@ func (m CacheMethod) GetService(name string, view string, withCap bool, acc *acc
 }
 
 func isNeuvectorContainerName(name string) bool {
-	if matched, err := regexp.MatchString(`^neuvector-(controller|enforcer|manager|allinone|updater|scanner)-pod`, name); err == nil {
+	if matched, err := regexp.MatchString(`^neuvector-(controller|enforcer|manager|allinone|updater|scanner|csp|registry-adapter)-pod`, name); err == nil {
 		return matched
 	}
 	return false


### PR DESCRIPTION
Controllers:
(1) Add pod name display with nv pods.
(2) Add nv pod/group names identification function.

Enforcers:
Add calico-node processes.