### PR TITLE
NVSHAS-7954: containerd, show running in workload object for the stopped container

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -2026,8 +2026,12 @@ func taskStopContainer(id string, pid int) {
 		info = c.info
 		info.Running = false
 	} else if info.Running {
-		// Wait for the updated container info
-		return
+		if osutil.IsPidValid(info.Pid) && info.FinishedAt.IsZero() {
+			// Wait for the updated container info
+			// log.WithFields(log.Fields{"info": info}).Debug()
+			return
+		}
+		info.Running = false	// update
 	}
 
 	if info.FinishedAt.IsZero() {


### PR DESCRIPTION
containerd:

Its callback monitor does not reflect the not-running status but showed its exited time.