### PR TITLE
NVSHAS-7984: request correct manifest schema for signature images

### DIFF
--- a/controller/scan/image.go
+++ b/controller/scan/image.go
@@ -16,6 +16,7 @@ import (
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/httptrace"
 	scanUtils "github.com/neuvector/neuvector/share/scan"
+	registryUtils "github.com/neuvector/neuvector/share/scan/registry"
 	"github.com/neuvector/neuvector/share/utils"
 )
 
@@ -261,7 +262,7 @@ func (r *base) GetAllImages() (map[share.CLUSImage][]string, error) {
 }
 
 func (r *base) GetImageMeta(ctx context.Context, domain, repo, tag string) (*scanUtils.ImageInfo, share.ScanErrorCode) {
-	rinfo, errCode := r.rc.GetImageInfo(ctx, repo, tag)
+	rinfo, errCode := r.rc.GetImageInfo(ctx, repo, tag, registryUtils.ManifestRequest_Default)
 	return rinfo, errCode
 }
 

--- a/controller/scan/jfrog.go
+++ b/controller/scan/jfrog.go
@@ -17,6 +17,7 @@ import (
 	"github.com/neuvector/neuvector/controller/rpc"
 	"github.com/neuvector/neuvector/share"
 	scanUtils "github.com/neuvector/neuvector/share/scan"
+	"github.com/neuvector/neuvector/share/scan/registry"
 	"github.com/neuvector/neuvector/share/utils"
 )
 
@@ -331,7 +332,7 @@ func (r *jfrog) GetImageMeta(ctx context.Context, domain, repo, tag string) (*sc
 		}
 		repo = subRepo
 	}
-	rinfo, errCode := rc.GetImageInfo(ctx, repo, tag)
+	rinfo, errCode := rc.GetImageInfo(ctx, repo, tag, registry.ManifestRequest_Default)
 	return rinfo, errCode
 }
 

--- a/controller/scan/openshift.go
+++ b/controller/scan/openshift.go
@@ -12,6 +12,7 @@ import (
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/global"
 	scanUtils "github.com/neuvector/neuvector/share/scan"
+	"github.com/neuvector/neuvector/share/scan/registry"
 )
 
 const unusedAccount string = "UNUSED"
@@ -147,7 +148,7 @@ func (r *openshift) GetImageMeta(ctx context.Context, domain, repo, tag string) 
 		return nil, share.ScanErrorCode_ScanErrContainerAPI
 	}
 
-	rinfo, errCode := r.rc.GetImageInfo(ctx, repo, tag)
+	rinfo, errCode := r.rc.GetImageInfo(ctx, repo, tag, registry.ManifestRequest_Default)
 
 	if errCode == share.ScanErrorCode_ScanErrNone {
 		ibMutex.Lock()

--- a/share/scan/registry.go
+++ b/share/scan/registry.go
@@ -56,10 +56,10 @@ type SignatureData struct {
 	Payloads map[string]string `json:"Payloads"`
 }
 
-func (rc *RegClient) GetImageInfo(ctx context.Context, name, tag string) (*ImageInfo, share.ScanErrorCode) {
+func (rc *RegClient) GetImageInfo(ctx context.Context, name, tag string, manifestReqType registry.ManifestRequestType) (*ImageInfo, share.ScanErrorCode) {
 	var imageInfo ImageInfo
 
-	dg, body, err := rc.ManifestRequest(ctx, name, tag, 2)
+	dg, body, err := rc.ManifestRequest(ctx, name, tag, 2, manifestReqType)
 	if err == nil {
 		// check if response is manifest list
 		var ml manifestList.DeserializedManifestList
@@ -82,7 +82,7 @@ func (rc *RegClient) GetImageInfo(ctx context.Context, name, tag string) (*Image
 			dg = tag
 			log.WithFields(log.Fields{"os": ml.Manifests[0].Platform.OS, "arch": ml.Manifests[0].Platform.Architecture, "tag": tag}).Debug("manifest list")
 
-			_, body, err = rc.ManifestRequest(ctx, name, tag, 2)
+			_, body, err = rc.ManifestRequest(ctx, name, tag, 2, manifestReqType)
 		}
 	}
 
@@ -234,7 +234,7 @@ func GetCosignSignatureTagFromDigest(digest string) string {
 // https://github.com/sigstore/cosign/blob/main/specs/SIGNATURE_SPEC.md
 func (rc *RegClient) GetSignatureDataForImage(ctx context.Context, repo string, digest string) (s SignatureData, errCode share.ScanErrorCode) {
 	signatureTag := GetCosignSignatureTagFromDigest(digest)
-	info, errCode := rc.GetImageInfo(ctx, repo, signatureTag)
+	info, errCode := rc.GetImageInfo(ctx, repo, signatureTag, registry.ManifestRequest_CosignSignature)
 	if errCode != share.ScanErrorCode_ScanErrNone {
 		return SignatureData{}, errCode
 	}


### PR DESCRIPTION
Some registries (quay.io), instead of returning an error like we expect (for example "Accept header does not support OCI manifests") will return a morphed version of the requested manifest, meant to be compatible with whatever schema headers the request was made with.

This is meant to ensure that requests for signature image manifests always include the correct media type (application/vnd.oci.image.manifest.v1+json).