### PR TITLE
NVSHAS-7957 & NVSHAS-7984

### DIFF
--- a/controller/scan/image.go
+++ b/controller/scan/image.go
@@ -16,6 +16,7 @@ import (
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/httptrace"
 	scanUtils "github.com/neuvector/neuvector/share/scan"
+	registryUtils "github.com/neuvector/neuvector/share/scan/registry"
 	"github.com/neuvector/neuvector/share/utils"
 )
 
@@ -261,7 +262,7 @@ func (r *base) GetAllImages() (map[share.CLUSImage][]string, error) {
 }
 
 func (r *base) GetImageMeta(ctx context.Context, domain, repo, tag string) (*scanUtils.ImageInfo, share.ScanErrorCode) {
-	rinfo, errCode := r.rc.GetImageInfo(ctx, repo, tag)
+	rinfo, errCode := r.rc.GetImageInfo(ctx, repo, tag, registryUtils.ManifestRequest_Default)
 	return rinfo, errCode
 }
 

--- a/controller/scan/jfrog.go
+++ b/controller/scan/jfrog.go
@@ -17,6 +17,7 @@ import (
 	"github.com/neuvector/neuvector/controller/rpc"
 	"github.com/neuvector/neuvector/share"
 	scanUtils "github.com/neuvector/neuvector/share/scan"
+	"github.com/neuvector/neuvector/share/scan/registry"
 	"github.com/neuvector/neuvector/share/utils"
 )
 
@@ -331,7 +332,7 @@ func (r *jfrog) GetImageMeta(ctx context.Context, domain, repo, tag string) (*sc
 		}
 		repo = subRepo
 	}
-	rinfo, errCode := rc.GetImageInfo(ctx, repo, tag)
+	rinfo, errCode := rc.GetImageInfo(ctx, repo, tag, registry.ManifestRequest_Default)
 	return rinfo, errCode
 }
 

--- a/controller/scan/openshift.go
+++ b/controller/scan/openshift.go
@@ -12,6 +12,7 @@ import (
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/global"
 	scanUtils "github.com/neuvector/neuvector/share/scan"
+	"github.com/neuvector/neuvector/share/scan/registry"
 )
 
 const unusedAccount string = "UNUSED"
@@ -147,7 +148,7 @@ func (r *openshift) GetImageMeta(ctx context.Context, domain, repo, tag string) 
 		return nil, share.ScanErrorCode_ScanErrContainerAPI
 	}
 
-	rinfo, errCode := r.rc.GetImageInfo(ctx, repo, tag)
+	rinfo, errCode := r.rc.GetImageInfo(ctx, repo, tag, registry.ManifestRequest_Default)
 
 	if errCode == share.ScanErrorCode_ScanErrNone {
 		ibMutex.Lock()

--- a/controller/scan/registry.go
+++ b/controller/scan/registry.go
@@ -806,6 +806,10 @@ func (rs *Registry) getScanImages(sctx *scanContext, drv registryDriver, dryrun 
 					continue
 				}
 
+				if info.IsSignatureImage {
+					continue
+				}
+
 				image := share.CLUSImage{Domain: itf.Domain, Repo: itf.Repo, Tag: tag, RegMod: itf.RegMod}
 				if exist, ok := imageMap[info.ID]; ok {
 					exist.Add(image)
@@ -1362,6 +1366,10 @@ func (rs *Registry) scheduleScanImages(
 
 			total++
 			newImage := false
+
+			if info.IsSignatureImage {
+				continue
+			}
 
 			// Add to the map to be returned
 			image := share.CLUSImage{Domain: itf.Domain, Repo: itf.Repo, Tag: tag, RegMod: itf.RegMod}

--- a/share/scan/registry.go
+++ b/share/scan/registry.go
@@ -56,10 +56,10 @@ type SignatureData struct {
 	Payloads map[string]string `json:"Payloads"`
 }
 
-func (rc *RegClient) GetImageInfo(ctx context.Context, name, tag string) (*ImageInfo, share.ScanErrorCode) {
+func (rc *RegClient) GetImageInfo(ctx context.Context, name, tag string, manifestReqType registry.ManifestRequestType) (*ImageInfo, share.ScanErrorCode) {
 	var imageInfo ImageInfo
 
-	dg, body, err := rc.ManifestRequest(ctx, name, tag, 2)
+	dg, body, err := rc.ManifestRequest(ctx, name, tag, 2, manifestReqType)
 	if err == nil {
 		// check if response is manifest list
 		var ml manifestList.DeserializedManifestList
@@ -82,7 +82,7 @@ func (rc *RegClient) GetImageInfo(ctx context.Context, name, tag string) (*Image
 			dg = tag
 			log.WithFields(log.Fields{"os": ml.Manifests[0].Platform.OS, "arch": ml.Manifests[0].Platform.Architecture, "tag": tag}).Debug("manifest list")
 
-			_, body, err = rc.ManifestRequest(ctx, name, tag, 2)
+			_, body, err = rc.ManifestRequest(ctx, name, tag, 2, manifestReqType)
 		}
 	}
 
@@ -234,7 +234,7 @@ func GetCosignSignatureTagFromDigest(digest string) string {
 // https://github.com/sigstore/cosign/blob/main/specs/SIGNATURE_SPEC.md
 func (rc *RegClient) GetSignatureDataForImage(ctx context.Context, repo string, digest string) (s SignatureData, errCode share.ScanErrorCode) {
 	signatureTag := GetCosignSignatureTagFromDigest(digest)
-	info, errCode := rc.GetImageInfo(ctx, repo, signatureTag)
+	info, errCode := rc.GetImageInfo(ctx, repo, signatureTag, registry.ManifestRequest_CosignSignature)
 	if errCode != share.ScanErrorCode_ScanErrNone {
 		return SignatureData{}, errCode
 	}

--- a/share/scan/registry.go
+++ b/share/scan/registry.go
@@ -3,6 +3,7 @@ package scan
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"sort"
 	"strings"
@@ -18,6 +19,10 @@ import (
 	"github.com/neuvector/neuvector/share/scan/registry"
 )
 
+const MediaTypeCosign = "application/vnd.dev.cosign.simplesigning.v1+json"
+const QuayRegistryURL = "https://quay.io"
+const CosignSignatureTagSuffix = ".sig"
+
 type RegClient struct {
 	*registry.Registry
 }
@@ -32,18 +37,19 @@ func NewRegClient(url, token, username, password, proxy string, trace httptrace.
 }
 
 type ImageInfo struct {
-	Layers      []string
-	ID          string
-	Digest      string
-	Author      string
-	Signed      bool
-	RunAsRoot   bool
-	Envs        []string
-	Cmds        []string
-	Labels      map[string]string
-	Sizes       map[string]int64
-	RepoTags    []string
-	RawManifest []byte
+	Layers           []string
+	ID               string
+	Digest           string
+	Author           string
+	Signed           bool
+	RunAsRoot        bool
+	Envs             []string
+	Cmds             []string
+	Labels           map[string]string
+	Sizes            map[string]int64
+	RepoTags         []string
+	IsSignatureImage bool
+	RawManifest      []byte
 }
 
 // SignatureData represents signature image data retrieved from the registry to be
@@ -56,11 +62,75 @@ type SignatureData struct {
 	Payloads map[string]string `json:"Payloads"`
 }
 
+func IsPotentialCosignSignatureTag(tag string) bool {
+	if len(tag) < len(CosignSignatureTagSuffix) {
+		return false
+	}
+	last4CharactersOfTag := tag[len(tag)-4:]
+	return last4CharactersOfTag == CosignSignatureTagSuffix
+}
+
+func IsQuayRegistry(rc *RegClient) bool {
+	return strings.EqualFold(rc.URL[:len(QuayRegistryURL)], QuayRegistryURL)
+}
+
+func BuildV2ImageInfo(dg string, body []byte) (imageInfo ImageInfo, parsedSchemaVersion int, err error) {
+	var manV2 manifestV2.Manifest
+	err = json.Unmarshal(body, &manV2)
+	if err != nil {
+		return ImageInfo{}, manV2.SchemaVersion, err
+	}
+	if manV2.SchemaVersion != 2 {
+		return ImageInfo{}, manV2.SchemaVersion, fmt.Errorf("unexpected manifest schema version: %d", manV2.SchemaVersion)
+	}
+	log.WithFields(log.Fields{"layers": len(manV2.Layers), "version": manV2.SchemaVersion, "digest": dg}).Debug("v2 manifest request")
+	// use v2 config.Digest as repo id
+	imageInfo.ID = string(manV2.Config.Digest)
+	imageInfo.Digest = dg
+	if len(manV2.Layers) > 0 {
+		layerLen := len(manV2.Layers)
+		imageInfo.Layers = make([]string, layerLen)
+		imageInfo.Envs = make([]string, 0)
+		imageInfo.Cmds = make([]string, layerLen)
+		imageInfo.Labels = make(map[string]string, 0)
+		imageInfo.Sizes = make(map[string]int64, 0)
+		allLayersAreCosignPayloads := true
+		for i, des := range manV2.Layers {
+			// reverse the order for v2
+			imageInfo.Layers[layerLen-i-1] = string(des.Digest)
+			imageInfo.Sizes[string(des.Digest)] = des.Size
+			if des.MediaType != MediaTypeCosign {
+				allLayersAreCosignPayloads = false
+			}
+			// log.WithFields(log.Fields{"layer": string(des.Digest)}).Debug("v2 manifest request ====")
+		}
+		imageInfo.IsSignatureImage = allLayersAreCosignPayloads
+	}
+	return imageInfo, manV2.SchemaVersion, nil
+}
+
 func (rc *RegClient) GetImageInfo(ctx context.Context, name, tag string, manifestReqType registry.ManifestRequestType) (*ImageInfo, share.ScanErrorCode) {
 	var imageInfo ImageInfo
+	var dg string
+	var body []byte
+	var err error
+	var isQuaySpecialCase = false
 
-	dg, body, err := rc.ManifestRequest(ctx, name, tag, 2, manifestReqType)
-	if err == nil {
+	if IsPotentialCosignSignatureTag(tag) && IsQuayRegistry(rc) {
+		dg, body, err = rc.ManifestRequest(ctx, name, tag, 2, registry.ManifestRequest_CosignSignature)
+		if err == nil {
+			imageInfo, _, err = BuildV2ImageInfo(dg, body)
+			if err == nil {
+				isQuaySpecialCase = true
+			}
+		}
+	}
+
+	if !isQuaySpecialCase {
+		dg, body, err = rc.ManifestRequest(ctx, name, tag, 2, manifestReqType)
+	}
+
+	if err == nil && !isQuaySpecialCase {
 		// check if response is manifest list
 		var ml manifestList.DeserializedManifestList
 		if err = ml.UnmarshalJSON(body); err == nil && len(ml.Manifests) > 0 &&
@@ -87,31 +157,11 @@ func (rc *RegClient) GetImageInfo(ctx context.Context, name, tag string, manifes
 	}
 
 	// get schema v2 first
-	if err == nil {
-		// log.WithFields(log.Fields{"body": string(body[:])}).Info("=========")
-
-		var manV2 manifestV2.Manifest
-		if err = json.Unmarshal(body, &manV2); err == nil && manV2.SchemaVersion == 2 {
-			log.WithFields(log.Fields{"layers": len(manV2.Layers), "version": manV2.SchemaVersion, "digest": dg}).Debug("v2 manifest request")
-			// use v2 config.Digest as repo id
-			imageInfo.ID = string(manV2.Config.Digest)
-			imageInfo.Digest = dg
-			if len(manV2.Layers) > 0 {
-				layerLen := len(manV2.Layers)
-				imageInfo.Layers = make([]string, layerLen)
-				imageInfo.Envs = make([]string, 0)
-				imageInfo.Cmds = make([]string, layerLen)
-				imageInfo.Labels = make(map[string]string, 0)
-				imageInfo.Sizes = make(map[string]int64, 0)
-				for i, des := range manV2.Layers {
-					// reverse the order for v2
-					imageInfo.Layers[layerLen-i-1] = string(des.Digest)
-					imageInfo.Sizes[string(des.Digest)] = des.Size
-					// log.WithFields(log.Fields{"layer": string(des.Digest)}).Debug("v2 manifest request ====")
-				}
-			}
-		} else {
-			log.WithFields(log.Fields{"error": err, "schema": manV2.SchemaVersion}).Debug("Failed to get manifest schema v2")
+	if err == nil && !isQuaySpecialCase {
+		var parsedSchemaVersion int
+		imageInfo, parsedSchemaVersion, err = BuildV2ImageInfo(dg, body)
+		if err != nil {
+			log.WithFields(log.Fields{"error": err, "schema": parsedSchemaVersion}).Debug("Failed to get manifest schema v2")
 		}
 	}
 


### PR DESCRIPTION
For 7984:
Some registries (quay.io), instead of returning an error like we expect (for example "Accept header does not support OCI manifests") will return a morphed version of the requested manifest, meant to be compatible with whatever schema headers the request was made with.

This is meant to ensure that requests for signature image manifests always include the correct media type (application/vnd.oci.image.manifest.v1+json).

For 7957:
If an image is determined to be a signature image, it is not scanned. For an image to be considered a signature image, all of its layers must be of the media type `application/vnd.dev.cosign.simplesigning.v1+json`, which is the cosign specific mediatype for signatures.

The `QuaySpecialCase` logic is meant to handle the odd issue that arises with how Quay handles manifest requests without the correct OCI headers, instead of returning an error (which is how we usually determine a retry with an OCI header) it returns a v1 compatible manifest instead. Since our scanning logic does not understand what each image is meant to look like (we only know the repo and tag), we cannot determine whether this compatibility response is actually the correct response for a given repo and tag.

In the quay special case (which is triggered when the registry is Quay.io, and the tag ends with `.sig`), we request the manifest as if the image is a signature image, since that will force a v2 manifest to be returned (if it is available). If a v2 manifest is not returned, or if the returned v2 manifest does not only contain layers with the media type `application/vnd.dev.cosign.simplesigning.v1+json`, we will then know the current image is not a signature image.