### PR TITLE
NVSHAS-8038: CustomCheck is not working for pods on kubernetes cluster

### DIFF
--- a/agent/bench.go
+++ b/agent/bench.go
@@ -289,13 +289,15 @@ func (b *Bench) BenchLoop() {
 			gInfoRLock()
 			for id, name := range containers {
 				if c, ok := gInfo.activeContainers[id]; ok {
-					// skip kubernetes pod
-					if Host.Platform != share.PlatformKubernetes || c.parentNS != "" {
-						wls = append(wls, createWorkload(c.info, &c.service, &c.domain))
-						if agentEnv.scanSecrets {
-							group := makeLearnedGroupName(utils.NormalizeForURL(c.service))
-							b.taskScanner.addScanTask(c.pid, name, id, group)
-						}
+					if Host.Platform == share.PlatformKubernetes && c.parentNS == "" {
+						continue	// skip kubernetes pod
+					}
+
+					// the service name has not the namespace extension
+					wls = append(wls, createWorkload(c.info, &c.service, &c.domain))
+					if agentEnv.scanSecrets {
+						group := makeLearnedGroupName(utils.NormalizeForURL(c.service))
+						b.taskScanner.addScanTask(c.pid, name, id, group)
 					}
 				}
 			}
@@ -306,10 +308,10 @@ func (b *Bench) BenchLoop() {
 			wls := make([]*share.CLUSWorkload, 0)
 			gInfoRLock()
 			for _, c := range gInfo.activeContainers {
-				// skip kubernetes pod
-				if Host.Platform != share.PlatformKubernetes || c.parentNS != "" {
-					wls = append(wls, createWorkload(c.info, &c.service, &c.domain))
+				if Host.Platform == share.PlatformKubernetes && c.parentNS == "" {
+					continue	// skip kubernetes pod
 				}
+				wls = append(wls, createWorkload(c.info, &c.service, &c.domain))
 			}
 			gInfoRUnlock()
 

--- a/agent/cluster.go
+++ b/agent/cluster.go
@@ -452,7 +452,8 @@ func createWorkload(info *container.ContainerMetaExtra, svc, domain *string) *sh
 	}
 
 	if svc != nil && domain != nil {
-		wl.Service = utils.MakeServiceName(*domain, *svc)
+		// It must be a full service name, like "iperf.demo".
+		wl.Service = *svc
 		wl.Domain = *domain
 	}
 	return &wl

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1953,7 +1953,8 @@ func taskAddContainer(id string, info *container.ContainerMetaExtra) {
 		// service is not reported until container is running; domain should be filled.
 		// it reports the exited container as well
 		svc := global.ORCH.GetService(&info.ContainerMeta, Host.Name)
-		ev := ClusterEvent{event: EV_ADD_CONTAINER, id: id, info: info, service: &svc.Name, domain: &svc.Domain}
+		service := utils.MakeServiceName(svc.Domain, svc.Name)
+		ev := ClusterEvent{event: EV_ADD_CONTAINER, id: id, info: info, service: &service, domain: &svc.Domain}
 		ClusterEventChan <- &ev
 
 		log.Debug("Container not running")

--- a/agent/group_profile.go
+++ b/agent/group_profile.go
@@ -323,10 +323,6 @@ func deleteGroupProfileCache(name string) bool {
 func isContainerSelected(c *containerData, group *share.CLUSGroup) bool {
 	// TODO: remove "CriteriaKeyAddress" from entry ??
 	wl := createWorkload(c.info, &c.service, &c.domain)
-	wl.Running = true // from activeContainer
-	wl.Name = c.name
-	wl.Service = c.service
-	wl.Domain = c.domain
 	return share.IsGroupMember(group, wl, getDomainData(wl.Domain))
 }
 


### PR DESCRIPTION
The service name was not constructed correctly that causes the mismatched service name and failure to select workload targets.