### PR TITLE
NVSHAS-8048: exit_code is not correct if container is stopped in native docker setup

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -2026,6 +2026,10 @@ func taskStopContainer(id string, pid int) {
 		info = c.info
 		info.Running = false
 	} else if info.Running {
+		// docker will have a catchup event to show its Exit code
+		if global.RT.String() == container.RuntimeDocker {
+			return
+		}
 		if osutil.IsPidValid(info.Pid) && info.FinishedAt.IsZero() {
 			// Wait for the updated container info
 			// log.WithFields(log.Fields{"info": info}).Debug()


### PR DESCRIPTION
docker runtime engine only:

There are two notifications from the docker watcher. The first event has the "FinishedAt". The second event includes the correct "exit" code. However, the containerd does not have the 2nd event. We need to add a check on waiting for the docker event's second event.