### PR TITLE
NVSHAS-7983 v2: NV protect events are not reporting name of the pod for manager, scanner and csp pods.

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1670,6 +1670,10 @@ func startNeuVectorMonitors(id, role string, info *container.ContainerMetaExtra)
 			go fileWatcher.StartWatch(id, info.Pid, conf, false, true)
 		}
 	}
+
+	nvRole := container.PlatformContainerNeuVector
+	ev := ClusterEvent{event: EV_ADD_CONTAINER, id: id, info: info, role: &nvRole, service: &c.service, domain: &c.domain}
+	ClusterEventChan <- &ev
 }
 
 //////


### PR DESCRIPTION
At enforcers (runtime: containerd/docker), the nv app pods are not reported to the controller.