### PR TITLE
NVSHAS-7418 - Changed getUserName() so it updates the container's username list

### DIFF
--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -1399,7 +1399,7 @@ func (p *Probe) getUpdatedUsername(pid int, uid int) string {
 	// Get the container for our pid
 	if c, ok := p.pidContainerMap[pid]; ok {
 		// Update the usernames map
-		if root, min, err := osutil.GetAllUsers(pid, c.userns.users); err == nil {
+		if root, min, err := osutil.GetAllUsers(c.rootPid, c.userns.users); err == nil {
 			c.userns.root = root
 			c.userns.uidMin = min
 			return c.userns.users[uid]

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -1403,9 +1403,8 @@ func (p *Probe) getUserName(pid, uid int) (user string) {
 			c.userns.uidMin = min
 		}
 
-		var userok bool
-		if user, userok = c.userns.users[uid]; !userok {
-			user, _ = c.userns.users[uid]
+		if uname, userok := c.userns.users[uid]; !userok {
+			user = uname
 		}
 	}
 	return

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -1403,7 +1403,7 @@ func (p *Probe) getUserName(pid, uid int) (user string) {
 			c.userns.uidMin = min
 		}
 
-		if uname, userok := c.userns.users[uid]; !userok {
+		if uname, userok := c.userns.users[uid]; userok {
 			user = uname
 		}
 	}

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -1396,15 +1396,13 @@ func (p *Probe) handleProcUIDChange(pid, ruid, euid int) {
 
 func (p *Probe) getUserName(pid, uid int) (user string) {
 	if c, ok := p.pidContainerMap[pid]; ok {
-
-		// NVSHAS-7418 - Update c.userns.users now b/c we're not tracking deletes so usernames can change.
-		if root, min, err := osutil.GetAllUsers(pid, c.userns.users); err == nil {
-			c.userns.root = root
-			c.userns.uidMin = min
-		}
-
-		if uname, userok := c.userns.users[uid]; userok {
-			user = uname
+		var ok bool
+		if user, ok = c.userns.users[uid]; !ok {
+			if root, min, err := osutil.GetAllUsers(pid, c.userns.users); err == nil {
+				user, _ = c.userns.users[uid]
+				c.userns.root = root
+				c.userns.uidMin = min
+			}
 		}
 	}
 	return
@@ -1428,6 +1426,34 @@ func (p *Probe) checkUserGroup(escalProc *procInternal, c *procContainer) (strin
 		return "", "", false
 	}
 	return rUser, eUser, true
+}
+
+
+func (p *Probe) jayuusername(pid, uid int) (user string) {
+	log.WithFields(log.Fields{"pid": pid, "uid": uid,}).Info("JAYU checking pid container")
+
+	if c, ok := p.pidContainerMap[pid]; ok {
+		log.WithFields(log.Fields{"pid": pid, "uid": uid, "container": c.id}).Info("JAYU found container")
+
+		if root, min, err := osutil.GetAllUsers(pid, c.userns.users); err == nil {
+			log.WithFields(log.Fields{"pid": pid, "uid": uid, "user": user, "root": root, "min": min}).Info("JAYU Debugging getUserName")
+			user, _ = c.userns.users[uid]
+			c.userns.root = root
+			c.userns.uidMin = min
+			log.WithFields(log.Fields{"pid": pid, "user": user, "uid": uid,"cur list": c.userns.users}).Info("JAYU Debugging getUserName 222")
+		}
+
+		var ok bool
+		if user, ok = c.userns.users[uid]; !ok {
+			log.WithFields(log.Fields{"pid": pid, "uid": uid, "c.userns.users": c.userns.users}).Error("User is missing in the user-name map")
+		}
+	} else {
+		log.WithFields(log.Fields{"pid": pid, "uid": uid}).Error("JAYU could not find container")
+
+	}
+	log.WithFields(log.Fields{"pid": pid, "uid": uid, "user": user}).Error("JAYU found")
+
+	return
 }
 
 // Not pidNetlink: escalProc is the grandparent of proc.

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -1397,18 +1397,16 @@ func (p *Probe) handleProcUIDChange(pid, ruid, euid int) {
 func (p *Probe) getUserName(pid, uid int) (user string) {
 	if c, ok := p.pidContainerMap[pid]; ok {
 
+		// NVSHAS-7418 - Update c.userns.users now b/c we're not tracking deletes so usernames can change.
 		if root, min, err := osutil.GetAllUsers(pid, c.userns.users); err == nil {
-			log.WithFields(log.Fields{"pid": pid, "uid": uid, "user": user, "root": root, "min": min}).Info("JAYU Debugging getUserName")
 			c.userns.root = root
 			c.userns.uidMin = min
-			log.WithFields(log.Fields{"pid": pid, "user": user, "uid": uid,"cur list": c.userns.users}).Info("JAYU Debugging getUserName 222")
 		}
 
 		var userok bool
 		if user, userok = c.userns.users[uid]; !userok {
 			user, _ = c.userns.users[uid]
 		}
-
 	}
 	return
 }
@@ -1431,34 +1429,6 @@ func (p *Probe) checkUserGroup(escalProc *procInternal, c *procContainer) (strin
 		return "", "", false
 	}
 	return rUser, eUser, true
-}
-
-
-func (p *Probe) jayuusername(pid, uid int) (user string) {
-	log.WithFields(log.Fields{"pid": pid, "uid": uid,}).Info("JAYU checking pid container")
-
-	if c, ok := p.pidContainerMap[pid]; ok {
-		log.WithFields(log.Fields{"pid": pid, "uid": uid, "container": c.id}).Info("JAYU found container")
-
-		if root, min, err := osutil.GetAllUsers(pid, c.userns.users); err == nil {
-			log.WithFields(log.Fields{"pid": pid, "uid": uid, "user": user, "root": root, "min": min}).Info("JAYU Debugging getUserName")
-			user, _ = c.userns.users[uid]
-			c.userns.root = root
-			c.userns.uidMin = min
-			log.WithFields(log.Fields{"pid": pid, "user": user, "uid": uid,"cur list": c.userns.users}).Info("JAYU Debugging getUserName 222")
-		}
-
-		var ok bool
-		if user, ok = c.userns.users[uid]; !ok {
-			log.WithFields(log.Fields{"pid": pid, "uid": uid, "c.userns.users": c.userns.users}).Error("User is missing in the user-name map")
-		}
-	} else {
-		log.WithFields(log.Fields{"pid": pid, "uid": uid}).Error("JAYU could not find container")
-
-	}
-	log.WithFields(log.Fields{"pid": pid, "uid": uid, "user": user}).Error("JAYU found")
-
-	return
 }
 
 // Not pidNetlink: escalProc is the grandparent of proc.

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -1428,34 +1428,6 @@ func (p *Probe) checkUserGroup(escalProc *procInternal, c *procContainer) (strin
 	return rUser, eUser, true
 }
 
-
-func (p *Probe) jayuusername(pid, uid int) (user string) {
-	log.WithFields(log.Fields{"pid": pid, "uid": uid,}).Info("JAYU checking pid container")
-
-	if c, ok := p.pidContainerMap[pid]; ok {
-		log.WithFields(log.Fields{"pid": pid, "uid": uid, "container": c.id}).Info("JAYU found container")
-
-		if root, min, err := osutil.GetAllUsers(pid, c.userns.users); err == nil {
-			log.WithFields(log.Fields{"pid": pid, "uid": uid, "user": user, "root": root, "min": min}).Info("JAYU Debugging getUserName")
-			user, _ = c.userns.users[uid]
-			c.userns.root = root
-			c.userns.uidMin = min
-			log.WithFields(log.Fields{"pid": pid, "user": user, "uid": uid,"cur list": c.userns.users}).Info("JAYU Debugging getUserName 222")
-		}
-
-		var ok bool
-		if user, ok = c.userns.users[uid]; !ok {
-			log.WithFields(log.Fields{"pid": pid, "uid": uid, "c.userns.users": c.userns.users}).Error("User is missing in the user-name map")
-		}
-	} else {
-		log.WithFields(log.Fields{"pid": pid, "uid": uid}).Error("JAYU could not find container")
-
-	}
-	log.WithFields(log.Fields{"pid": pid, "uid": uid, "user": user}).Error("JAYU found")
-
-	return
-}
-
 // Not pidNetlink: escalProc is the grandparent of proc.
 func (p *Probe) evalRootEscal(proc, escalProc *procInternal, id, rUser, eUser string, root int) {
 	var cmds, escalCmds []string


### PR DESCRIPTION
Previously, there is an edge case where deleting and reusing uids will cause nv to not update its cache.

If you create a user and then execute an violation. The user map will be updated. 
Delete the user and them add another user and reuse the deleted user's uid. Before the fix, the name would show the old one and not the new one.
Now cause a violation and the username will be correct.