### PR TITLE
NVSHAS-8051: FileMonitor events are not getting aggregated

### DIFF
--- a/share/fsmon/monitor.go
+++ b/share/fsmon/monitor.go
@@ -452,6 +452,12 @@ func (w *FileWatch) learnFromEvents(rootPid int, fmod *fileMod, path string, eve
 
 	if event != fileEventAccessed ||
 		(mode == share.PolicyModeEnforce || mode == share.PolicyModeEvaluate) {
+		if fmod.finfo.Link != "" {
+			path = fmod.finfo.Link
+			if index := strings.Index(path, "/root/"); index > 0 {
+				path = path[index+5:]
+			}
+		}
 		w.sendMsg(fmod.finfo.ContainerId, path, event, fmod.pInfo, mode)
 	}
 }


### PR DESCRIPTION
For v5.2.1,

(1) File report aggregator: redo the state machine.
(2) File monitor: returning "linkto" path instead of the symbolic link file if it exists.