### PR TITLE
NVSHAS-8080: neuvector csp container will be added into workload object

### DIFF
--- a/agent/cluster.go
+++ b/agent/cluster.go
@@ -585,8 +585,13 @@ func clusterStopContainer(ev *ClusterEvent) {
 		if ev.info == nil {
 			return
 		}
+
 		// Container might not be intercepted and reported yet.
 		wl := createWorkload(ev.info, ev.service, ev.domain)
+		if _, ok := getNeuVectorRole(ev.info); ok {
+			// nuVector pod
+			wl.PlatformRole = container.PlatformContainerNeuVector
+		}
 		putWorkload(wl)
 		wlCacheMap[ev.id] = &workloadInfo{wl: wl}
 

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -317,6 +317,16 @@ func isNeuVectorContainer(info *container.ContainerMetaExtra) (string, bool) {
 	return "", false
 }
 
+func getNeuVectorRole(info *container.ContainerMetaExtra) (string, bool) {
+	labels := info.Labels
+	if Agent.Domain != "" && Agent.Domain != global.ORCH.GetDomain(labels) { // orchestra
+		return "", false
+	}
+
+	role, ok := labels[share.NeuVectorLabelRole]
+	return role, ok
+}
+
 func isSidecarContainer(labels map[string]string) bool {
 	//check if container is a sidecar that is linkerd-proxy or istio-proxy
 	sc_containername, _ := labels[container.KubeKeyContainerName]


### PR DESCRIPTION
When we detect the container's stop event, the previous nv pod was not established because its rootPid process was exited.