### PR TITLE
Obtain correct app container id for enforcers and controllers.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -379,7 +379,8 @@ func main() {
 	agentEnv.runWithController = *withCtlr
 	agentEnv.runInContainer = global.SYS.IsRunningInContainer()
 	if agentEnv.runInContainer {
-		selfID, agentEnv.containerInContainer, err = global.SYS.GetSelfContainerID()
+		_, agentEnv.containerInContainer, _ = global.SYS.GetSelfContainerID()
+		selfID = global.RT.GetSelfID()
 		if selfID == "" { // it is a POD ID in the k8s cgroup v2; otherwise, a real container ID
 			log.WithFields(log.Fields{"error": err}).Error("Unsupported system. Exit!")
 			os.Exit(-2)

--- a/agent/probe/probe.go
+++ b/agent/probe/probe.go
@@ -538,7 +538,7 @@ func New(pc *ProbeConfig) (*Probe, error) {
 		}
 	}
 
-	p.selfID, _, _ = global.SYS.GetSelfContainerID()
+	p.selfID = global.RT.GetSelfID()
 	p.agentSessionID = osutil.GetSessionId(p.agentPid)
 	//log.WithFields(log.Fields{"sessionID": p.agentSessionID, "container ID": p.selfID}).Info("PROC: ")
 

--- a/agent/probe/process_test.go
+++ b/agent/probe/process_test.go
@@ -25,6 +25,7 @@ func (d *dummyRTDriver) MonitorEvent(cb container.EventCallback, cpath bool) err
 }
 func (d *dummyRTDriver) StopMonitorEvent()                 {}
 func (d *dummyRTDriver) GetHost() (*share.CLUSHost, error) { return nil, nil }
+func (d *dummyRTDriver) GetSelfID() string { return "a361929b15729277ed89f11da44b0882e82fe9cc9587f1f5f8ebed49802f8834" }
 func (d *dummyRTDriver) GetDevice(id string) (*share.CLUSDevice, *container.ContainerMetaExtra, error) {
 	return nil, nil, nil
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -325,7 +325,7 @@ func main() {
 
 	ctrlEnv.runInContainer = global.SYS.IsRunningInContainer()
 	if ctrlEnv.runInContainer {
-		selfID, _, err = global.SYS.GetSelfContainerID()
+		selfID = global.RT.GetSelfID()
 		if selfID == "" {
 			log.WithFields(log.Fields{"error": err}).Error("Unsupported system. Exit!")
 			os.Exit(-2)

--- a/share/container/types.go
+++ b/share/container/types.go
@@ -25,6 +25,7 @@ type Runtime interface {
 	MonitorEvent(cb EventCallback, cpath bool) error
 	StopMonitorEvent()
 	GetHost() (*share.CLUSHost, error)
+	GetSelfID() string
 	GetDevice(id string) (*share.CLUSDevice, *ContainerMetaExtra, error)
 	GetContainer(id string) (*ContainerMetaExtra, error)
 	ListContainers(runningOnly bool) ([]*ContainerMeta, error)


### PR DESCRIPTION
The cgroup v2 will hide its container id from the process information. Thus, you can not read your container id from the container's own processes.

The controller/enforcer might fail to report its sandbox id instead of its container id on the cgroup v2 with some runtime engines. The new method is using the CRI API to match the proper criteria(s) to find the correct app's container id.
