### PR TITLE
NVSHAS-8108 - Adding locks because getUpdatedUsername 

### DIFF
--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -2559,6 +2559,8 @@ func (p *Probe) procProfileEval(id string, proc *procInternal, bKeepAlive bool) 
 func (p *Probe) sendProcessIncident(bDenied bool, id, uuid, group, derivedGroup string, proc *procInternal) {
 	var s *ProbeProcess
 
+	p.lockProcMux()
+	defer p.unlockProcMux()
 	proc.user = p.getUpdatedUsername(proc.pid, proc.euid)
 
 	switch uuid {

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -2560,8 +2560,8 @@ func (p *Probe) sendProcessIncident(bDenied bool, id, uuid, group, derivedGroup 
 	var s *ProbeProcess
 
 	p.lockProcMux()
-	defer p.unlockProcMux()
 	proc.user = p.getUpdatedUsername(proc.pid, proc.euid)
+	p.unlockProcMux()
 
 	switch uuid {
 	case share.CLUSReservedUuidAnchorMode:	// zero-drift incident


### PR DESCRIPTION
Found a bug in pipeline tests that found that this was updating a map and sendProcessIncident is used as a go routine. This caused a concurrent map write and the solution is to add a lock to make it safe