### PR TITLE
NVSHAS-8109: unexpected NV.Protect incidents are found

### DIFF
--- a/agent/policy/process.go
+++ b/agent/policy/process.go
@@ -599,6 +599,7 @@ func buildEnforcerProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		{"pod", "/usr/bin/pod"}, // openshift, pod
 		{"mount", "*"},          // k8s volume plug-in
 		{"grep", "*"},           // monitor, CIS bench tests
+		{"which", "*"},
 		{"pgrep", "/usr/bin/pgrep"},
 		{"sed", "*"},
 		{"cut", "*"},
@@ -683,6 +684,7 @@ func buildAllinOneProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		{"pod", "/usr/bin/pod"}, // openshift, pod
 		{"mount", "*"},          // k8s volume plug-in
 		{"grep", "*"},           // monitor, CIS bench tests
+		{"which", "*"},
 		{"pgrep", "/usr/bin/pgrep"},
 		{"sed", "*"},
 		{"cut", "*"},


### PR DESCRIPTION
The CIS bench scripts need "which" to identify the node's utility command paths. Add an allow rule for allinone and enforcer profile.