### PR TITLE
NVSHAS-8114, NVSHAS-8109: false-positive cases for the NV Protect events

### DIFF
--- a/agent/policy/process.go
+++ b/agent/policy/process.go
@@ -392,6 +392,7 @@ func buildManagerProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		{"ps", "*"},
 		{"lsof", "*"},
 		{"sh", "*"},
+		{"dash", "*"},
 		{"kill", "*"},
 
 		// busybox
@@ -568,6 +569,7 @@ func buildEnforcerProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		{"ps", "*"},
 		{"lsof", "*"},
 		{"sh", "*"},
+		{"dash", "*"},
 		{"cat", "*"},                     // k8s readiness and openshift operations
 
 		// busybox
@@ -651,6 +653,7 @@ func buildAllinOneProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		{"ps", "*"},
 		{"lsof", "*"},
 		{"sh", "*"},
+		{"dash", "*"},
 		{"cat", "*"},                     // k8s readiness and openshift operations
 
 		// busybox
@@ -678,6 +681,7 @@ func buildAllinOneProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		{"nc", "/bin/busybox"},
 		{"echo", "/bin/busybox"},
 		{"tee", "/usr/bin/tee"},
+		{"stat", "/usr/bin/stat"}, // bench scripts
 
 		// k8s or openshift environment
 		{"pause", "/pause"},     // k8s, pause


### PR DESCRIPTION
(1) NV-8114: the process rule, "stat" was missing from the allinone profile.
(2) NV-8109: add the process rule, "dash", for manager (cli), enforcer, and allinone.