### PR TITLE
NV Protect: keep temporary agent's process records to improve the false-positive cases

### DIFF
--- a/share/system/system_linux.go
+++ b/share/system/system_linux.go
@@ -712,14 +712,6 @@ func (s *SystemTools) IsOpenshift() (bool, error) {
 	return false, nil
 }
 
-func (s *SystemTools) KillCommandSubtree(pgid int, info string) {
-	if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
-		log.WithFields(log.Fields{"pgid": pgid, "error": err}).Debug("TOOLP: can not signal")
-	} else {
-		log.WithFields(log.Fields{"pgid": pgid}).Debug("TOOLP:")
-	}
-}
-
 //return true if file size over limit
 func (s *SystemTools) NsGetFile(filePath string, pid int, binary bool, start, len int) ([]byte, error) {
 	var errb bytes.Buffer


### PR DESCRIPTION
Some agent's children's processes run swiftly and our process monitor can not probe them in time. Then, those who exited tool processes would not be traced by their ancestors and considered "nv protect" incidents. A good retaining record will improve the false-positive events.