### PR TITLE
NVSHAS-8170: Auto profile collection feature to capture profile data at the maximum memory

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -275,6 +275,7 @@ func main() {
 	disable_auto_benchmark := flag.Bool("no_auto_benchmark", false, "disable auto benchmark")
 	disable_system_protection := flag.Bool("no_sys_protect", false, "disable system protections")
 	policy_puller := flag.Int("policy_puller", 0, "set policy pulling period")
+	autoProfile := flag.Bool("apc", false, "Enable auto profile collection")
 	flag.Parse()
 
 	if *debug {
@@ -317,6 +318,11 @@ func main() {
 	agentEnv.netPolicyPuller = *policy_puller
 	if *policy_puller != 0 {
 		log.WithFields(log.Fields{"period": *policy_puller}).Info("policy pull regulator")
+	}
+
+	if *autoProfile {
+		agentEnv.autoProfieCapture = *autoProfile
+		log.WithFields(log.Fields{"auto-profile": agentEnv.autoProfieCapture}).Info()
 	}
 
 	if *join != "" {

--- a/agent/service.go
+++ b/agent/service.go
@@ -1174,6 +1174,6 @@ func (rs *RPCService) GetContainerIntercept(ctx context.Context, f *share.CLUSFi
 }
 
 func (rs *RPCService) ProfilingCmd(ctx context.Context, req *share.CLUSProfilingRequest) (*share.RPCVoid, error) {
-	go utils.PerfProfile(req, "enf.")
+	go utils.PerfProfile(req, share.ProfileFolder, "enf.")
 	return &share.RPCVoid{}, nil
 }

--- a/agent/types.go
+++ b/agent/types.go
@@ -22,6 +22,10 @@ type AgentEnvInfo struct {
 	autoBenchmark        bool
 	systemProfiles       bool
 	netPolicyPuller      int
+	autoProfieCapture    bool
+	memoryLimit          uint64
+	peakMemoryUsage      uint64
+	snapshotMemStep      uint64
 }
 
 const (

--- a/controller/grpc.go
+++ b/controller/grpc.go
@@ -526,7 +526,7 @@ func (cs *ControllerService) TriggerSyncLearnedPolicy(ctx context.Context, v *sh
 }
 
 func (cs *ControllerService) ProfilingCmd(ctx context.Context, req *share.CLUSProfilingRequest) (*share.RPCVoid, error) {
-	go utils.PerfProfile(req, "ctl.")
+	go utils.PerfProfile(req, share.ProfileFolder, "ctl.")
 	return &share.RPCVoid{}, nil
 }
 

--- a/monitor/monitor.c
+++ b/monitor/monitor.c
@@ -55,6 +55,7 @@
 #define ENV_NO_DEFAULT_ADMIN   "NO_DEFAULT_ADMIN"
 #define ENV_CSP_ENV            "CSP_ENV"
 #define ENV_CSP_PAUSE_INTERVAL "CSP_PAUSE_INTERVAL"
+#define ENV_AUTOPROFILE_CLT    "AUTO_PROFILE_COLLECT"
 
 #define ENV_SCANNER_DOCKER_URL  "SCANNER_DOCKER_URL"
 #define ENV_SCANNER_LICENSE     "SCANNER_LICENSE"
@@ -413,6 +414,11 @@ static pid_t fork_exec(int i)
             args[a++] = "-csp_pause_interval";
             args[a++] = csp_pause_interval;
         }
+        if ((enable = getenv(ENV_AUTOPROFILE_CLT)) != NULL) {
+            if (checkImplicitEnableFlag(enable) == 1) {
+                args[a ++] = "-apc";
+            }
+        }
         args[a] = NULL;
         break;
     case PROC_AGENT:
@@ -492,7 +498,11 @@ static pid_t fork_exec(int i)
             args[a ++] = "-policy_puller";
             args[a ++] = policy_pull_period;
         }
-
+        if ((enable = getenv(ENV_AUTOPROFILE_CLT)) != NULL) {
+            if (checkImplicitEnableFlag(enable) == 1) {
+                args[a ++] = "-apc";
+            }
+        }
         args[a] = NULL;
         break;
 

--- a/share/types.go
+++ b/share/types.go
@@ -11,10 +11,11 @@ const CompactCVEDBName = "cvedb.compact"
 const RegularCVEDBName = "cvedb.regular"
 const CVEDatabaseFolder = "/etc/neuvector/db/"
 
-const ProfileFolder string = "/var/neuvector/profile/"
-const ProfileMemoryFileFmt string = ProfileFolder + "%smemory.prof"
-const ProfileGoroutineFileFmt string = ProfileFolder + "%sgoroutine.prof"
-const ProfileCPUFileFmt string = ProfileFolder + "%scpu.prof"
+const ProfileFolder string = "/var/neuvector/profile"
+const SnaphotFolder string = "/var/neuvector/snapshot"
+const ProfileMemoryFileFmt string = "%smemory.prof"
+const ProfileGoroutineFileFmt string = "%sgoroutine.prof"
+const ProfileCPUFileFmt string = "%scpu.prof"
 
 const CustomScriptFailedPrefix string = "Failed to run the custom check"
 

--- a/share/utils/perf.go
+++ b/share/utils/perf.go
@@ -1,13 +1,18 @@
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
-	"runtime"
+	"path/filepath"
 	"runtime/pprof"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
+	"github.com/codeskyblue/go-sh"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/neuvector/neuvector/share"
@@ -15,7 +20,7 @@ import (
 
 var profiling int32
 
-func PerfProfile(req *share.CLUSProfilingRequest, prefix string) {
+func PerfProfile(req *share.CLUSProfilingRequest, folder, prefix string) {
 	log.WithFields(log.Fields{"methods": req.Methods}).Debug()
 
 	if !atomic.CompareAndSwapInt32(&profiling, 0, 1) {
@@ -25,34 +30,29 @@ func PerfProfile(req *share.CLUSProfilingRequest, prefix string) {
 
 	defer atomic.StoreInt32(&profiling, 0)
 
-	if _, err := os.Stat(share.ProfileFolder); os.IsNotExist(err) {
-		if err = os.MkdirAll(share.ProfileFolder, 0775); err != nil {
+	if _, err := os.Stat(folder); os.IsNotExist(err) {
+		if err = os.MkdirAll(folder, 0775); err != nil {
 			log.WithFields(log.Fields{"error": err}).Error("Failed to create profile folder")
 			return
 		}
 	}
 
+	var filename string
 	for _, m := range req.Methods {
 		switch m {
 		case share.ProfilingMethod_Memory:
 			log.Debug("profiling memory")
-			if f, err := os.Create(fmt.Sprintf(share.ProfileMemoryFileFmt, prefix)); err != nil {
+			filename = filepath.Join(folder, fmt.Sprintf(share.ProfileMemoryFileFmt, prefix))
+			if f, err := os.Create(filename); err != nil {
 				log.WithFields(log.Fields{"error": err}).Error("Failed to create memory profiling file")
 			} else {
 				pprof.WriteHeapProfile(f)
 				f.Close()
 			}
-
-			if f, err := os.Create(fmt.Sprintf(share.ProfileMemoryFileFmt, prefix + "gc.")); err != nil {
-				log.WithFields(log.Fields{"error": err}).Error("Failed to create memory profiling gc file")
-			} else {
-				runtime.GC()    // get up-to-date statistics
-				pprof.WriteHeapProfile(f)
-				f.Close()
-			}
 		case share.ProfilingMethod_CPU:
 			log.Debug("profiling cpu/goroutine")
-			if f, err := os.Create(fmt.Sprintf(share.ProfileCPUFileFmt, prefix)); err != nil {
+			filename = filepath.Join(folder, fmt.Sprintf(share.ProfileCPUFileFmt, prefix))
+			if f, err := os.Create(filename); err != nil {
 				log.WithFields(log.Fields{"error": err}).Error("Failed to create cpu profiling file")
 			} else {
 				pprof.StartCPUProfile(f)
@@ -60,7 +60,9 @@ func PerfProfile(req *share.CLUSProfilingRequest, prefix string) {
 				pprof.StopCPUProfile()
 				f.Close()
 			}
-			if f, err := os.Create(fmt.Sprintf(share.ProfileGoroutineFileFmt, prefix)); err != nil {
+
+			filename = filepath.Join(folder, fmt.Sprintf(share.ProfileGoroutineFileFmt, prefix))
+			if f, err := os.Create(filename); err != nil {
 				log.WithFields(log.Fields{"error": err}).Error("Failed to create goroutine profiling file")
 			} else {
 				pprof.Lookup("goroutine").WriteTo(f, 0)
@@ -70,4 +72,67 @@ func PerfProfile(req *share.CLUSProfilingRequest, prefix string) {
 	}
 
 	log.Debug("Profiling is done.")
+}
+
+////////////////////////////////////////////////////////////
+var lastSnapshot time.Time
+const snapshotWindow = time.Duration(time.Minute * 5)
+func PerfSnapshot(pid int, memLimit, usage uint64, folder, cid, prefix, label string) {
+	type snapshotData struct {
+		RecordedAt      time.Time
+		MemoryLimit     uint64
+		WorkingMemory   uint64
+		MemPercentage   int
+		Cid             string
+		Lsof            []string
+		Ps              []string
+	}
+
+	if time.Since(lastSnapshot) < snapshotWindow {
+		log.Debug("skip")
+		return
+	}
+
+	lastSnapshot = time.Now()
+	go func() {
+		workFolder := filepath.Join(folder, cid) // add cid to avoid the collision in the PV
+		log.WithFields(log.Fields{"pid": pid, "memLimit": memLimit, "workingSet": usage, "workFolder": workFolder, "prefix": prefix, "label": label, "at": lastSnapshot}).Info()
+		mem_percentage := -1
+		if memLimit > 0 {
+			mem_percentage = (int)(usage * 100 / memLimit)
+		}
+
+		// get auxiliary data
+		lsof, _ := sh.Command("lsof", "+D", "/usr/local/bin").Output()
+		ps, _ := sh.Command("ps", "-o", "%cpu,pid,ppid,pgid,vsz,rss,ni,comm", "-g", strconv.Itoa(pid)).Output()
+		data := snapshotData {
+			RecordedAt:    lastSnapshot,
+			MemoryLimit:   memLimit,
+			WorkingMemory: usage,
+			MemPercentage: mem_percentage,
+			Cid:           cid,
+			Lsof:          strings.Split(string(lsof), "\n"),
+			Ps:            strings.Split(string(ps), "\n"),
+		}
+		file, _ := json.MarshalIndent(data, "", " ")
+
+		// get golang profiles
+		req := &share.CLUSProfilingRequest{
+			Methods:  []share.ProfilingMethod{share.ProfilingMethod_CPU, share.ProfilingMethod_Memory},
+			Duration: 10, // seconds
+		}
+
+		PerfProfile(req, workFolder, prefix)
+
+		// deferred action because PerfProfile will create the tmp_folder
+		ioutil.WriteFile(filepath.Join(workFolder, "data.json"), file, 0644)
+
+		//  write the .tar.gzip
+		targetZipFile := filepath.Join(folder, fmt.Sprintf("%ssnapshot.%s.%s.zip", prefix, cid, label))
+		if err := CompressToZipFile(workFolder, targetZipFile); err == nil {
+			os.RemoveAll(workFolder)
+			log.WithFields(log.Fields{"package": targetZipFile}).Info()
+		}
+		log.Info("done")
+	} ()
 }


### PR DESCRIPTION
(1) Environmental variable to enable the feature: "AUTO_PROFILE_COLLECT"
k8s example:

```
name: AUTO_PROFILE_COLLECT
value: "1"
```
(2) Triggered by the memory pressure (cgroup v1) event and the routine memory checks( ideally, 60%, 70%, 80%, 90%, and peak memory threshold: cgroup v1/v2). We keep a maximum peak memory record when either of the two events is reached their thresholds.
```
     (a) memory pressure event: equal or above LEVEL 2
     (b) routine memory checks: 60% and above of the defined memory limit( if not set, our default memory threshold)
```

(3) It will record the highest memory peak package (a zipped file):

```
    enforcer: "/var/neuvector/snapshot/enf.snapshot.<containerID>.[1,2,3,4,p].zip"
    controller: "/var/neuvector/snapshot/ctl.snapshot.<containerID>.[1,2,3,4,p].zip"
```

(4) The package includes:
      (a) data.json: record time, lsof, and ps information (expandable).
```
             type snapshotData struct {
                     RecordedAt time.Time
                     MemoryLimit     uint64
                     WorkingMemory   uint64
                     MemPercentage      int
                     Lsof            []string
                     Ps              []string
             }
```
   (b) memory profile
   (c) CPU and goroutine profiles

(5) The skip window for a new package is 5-minute for restraining the recording efforts( no two records within 5 minutes). We might miss the "real peak memory" but it should be close enough to the peak case.

(6) Remove the memory profile after gc because it creates a hard time when the memory is squeezed. When memory usage reaches its k8s limit, Golang's "GC" operation will run indefinitely.

(7) Increase the default controller memory ceiling to 6GB. It applies when there is no k8s memory limit.



