### PR TITLE
NVSHAS-7554 - Creating new files in watched directories don't trigger incidents

### DIFF
--- a/share/fsmon/monitor.go
+++ b/share/fsmon/monitor.go
@@ -578,7 +578,7 @@ func (w *FileWatch) getCoreFile(cid string, pid int, profile *share.CLUSFileMoni
 	// get files and dirs from all filters
 	for _, filter := range profile.Filters {
 		flt := &filterRegex{path: filterIndexKey(filter), recursive: filter.Recursive}
-		flt.regex, _ = regexp.Compile(fmt.Sprintf("^%s$", flt.path))
+		flt.regex, _ = regexp.Compile(fmt.Sprintf("^%s", flt.path))
 		bBlockAccess := filter.Behavior == share.FileAccessBehaviorBlock
 		bUserAdded := filter.CustomerAdd
 		if strings.Contains(filter.Path, "*") {
@@ -596,7 +596,7 @@ func (w *FileWatch) getCoreFile(cid string, pid int, profile *share.CLUSFileMoni
 	// get files and dirs from all filters
 	for _, filter := range profile.FiltersCRD {
 		flt := &filterRegex{path: filterIndexKey(filter), recursive: filter.Recursive}
-		flt.regex, _ = regexp.Compile(fmt.Sprintf("^%s$", flt.path))
+		flt.regex, _ = regexp.Compile(fmt.Sprintf("^%s", flt.path))
 		bBlockAccess := filter.Behavior == share.FileAccessBehaviorBlock
 		bUserAdded := filter.CustomerAdd
 		if strings.Contains(filter.Path, "*") {


### PR DESCRIPTION
Looks like the issue was ultimately due to a bad regex filter. Changed `flt.regex, _ = regexp.Compile(fmt.Sprintf("^%s$", flt.path))` to
`flt.regex, _ = regexp.Compile(fmt.Sprintf("^%s", flt.path))` where the change is removing the `$` anchor.

The regex expression looks alright until we get to the `$` symbol. This tells the regex to match "end of string". But the path we give to the regex filter is the full linkpath and not just the directory path. So the regex filter will always fail when creating new files in a watched directory. Example: We're trying to match `/tmp/filename.txt` but the regex's anchor will cause it always fail. 

Actual definition follows
> By default, the match must occur at the end of the string or before \n
at the end of the string; in multiline mode, it must occur before the end of the line or before \n at the end of the line.
- Source https://learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-language-quick-reference