### PR TITLE
NVSHAS-8136(enforcer update): container is selected based on image=xxx criteria, add related containers to group

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1877,7 +1877,7 @@ func taskInterceptContainer(id string, info *container.ContainerMetaExtra) {
 		gInfoUnlock()
 	}
 	// entry to apply group policies
-	workloadJoinGroup(c)
+	workloadJoinGroup(c, parent)
 	updateAppPorts(c, parent)
 	notifyContainerChanges(c, parent, changeInit)
 }


### PR DESCRIPTION
Add pod-level inclusion of the matching custom group criteria on the process/file profile membership.