### PR TITLE
NVSHAS-7554 - Added a catch to block identical filter paths from bein…

### DIFF
--- a/controller/rest/file_monitor_test.go
+++ b/controller/rest/file_monitor_test.go
@@ -38,6 +38,8 @@ func TestNormalizeForURL(t *testing.T) {
 		"/test/../ab/*":         share.CLUSFileMonitorFilter{Path: "/ab", Regex: ".*"},
 		"/test/./ab/*":          share.CLUSFileMonitorFilter{Path: "/test/ab", Regex: ".*"},
 		"/lib/":                 share.CLUSFileMonitorFilter{Path: "/lib", Regex: ".*"},
+		"/tmp/":                 share.CLUSFileMonitorFilter{Path: "/tmp", Regex: ".*"},
+		"/tmp":                  share.CLUSFileMonitorFilter{Path: "/tmp", Regex: ""},
 	}
 	badFilters := map[string]share.CLUSFileMonitorFilter{
 		"/test/./<ab>/*": share.CLUSFileMonitorFilter{Path: "", Regex: ""},

--- a/share/fsmon/monitor.go
+++ b/share/fsmon/monitor.go
@@ -575,8 +575,7 @@ func (w *FileWatch) getCoreFile(cid string, pid int, profile *share.CLUSFileMoni
 	dirList := make(map[string]*osutil.FileInfoExt)
 	singleFiles := make([]*osutil.FileInfoExt, 0)
 
-	// get files and dirs from all filters
-	for _, filter := range profile.Filters {
+	addFilterFn := func(filter share.CLUSFileMonitorFilter){
 		flt := &filterRegex{path: filterIndexKey(filter), recursive: filter.Recursive}
 		flt.regex, _ = regexp.Compile(fmt.Sprintf("^%s$", flt.path))
 		bBlockAccess := filter.Behavior == share.FileAccessBehaviorBlock
@@ -591,25 +590,17 @@ func (w *FileWatch) getCoreFile(cid string, pid int, profile *share.CLUSFileMoni
 			singles := w.getDirAndFileList(pid, filter.Path, filter.Regex, cid, flt, filter.Recursive, bBlockAccess, bUserAdded, dirList)
 			singleFiles = append(singleFiles, singles...)
 		}
+	}
+	// get files and dirs from all filters
+	for _, filter := range profile.Filters {
+		addFilterFn(filter)
 	}
 
 	// get files and dirs from all filters
 	for _, filter := range profile.FiltersCRD {
-		flt := &filterRegex{path: filterIndexKey(filter), recursive: filter.Recursive}
-		flt.regex, _ = regexp.Compile(fmt.Sprintf("^%s$", flt.path))
-		bBlockAccess := filter.Behavior == share.FileAccessBehaviorBlock
-		bUserAdded := filter.CustomerAdd
-		if strings.Contains(filter.Path, "*") {
-			subDirs := w.getSubDirList(pid, filter.Path, cid)
-			for _, sub := range subDirs {
-				singles := w.getDirAndFileList(pid, sub, filter.Regex, cid, flt, filter.Recursive, bBlockAccess, bUserAdded, dirList)
-				singleFiles = append(singleFiles, singles...)
-			}
-		} else {
-			singles := w.getDirAndFileList(pid, filter.Path, filter.Regex, cid, flt, filter.Recursive, bBlockAccess, bUserAdded, dirList)
-			singleFiles = append(singleFiles, singles...)
-		}
+		addFilterFn(filter)
 	}
+
 	return dirList, singleFiles
 }
 


### PR DESCRIPTION
…g stored through the REST API.

The REST api will make sure the directory path for filters do not have any collisions. The bug we hit was that if a customer was allowed to add both `/tmp/` and `/tmp` but only one filter would be used. This caused confusion in the expected behaviour.
If the filter has a trailing /, it is meant to be a filter for directories. If it is ommited, it is meant to be a filter for filepaths. When the two are used in conjection, it is confusing because we can only store one filter and the behaviour may not be what the user expects.

Added comments to parseFileFilter so its clear what are the behaviours if you add a trailing /.
I cleaned up getCoreFile() because it had duplicated code.