### PR TITLE
NVSHAS-7925 - Deployment stats did not make sense in UI.

### DIFF
--- a/agent/timer.go
+++ b/agent/timer.go
@@ -208,9 +208,20 @@ func updateAgentStats(cpuSystem uint64) {
 
 func updateContainerStats(cpuSystem uint64) {
 	for _, c := range gInfo.activeContainers {
-		mem, _ := global.SYS.GetContainerMemoryUsage(c.cgroupMemory)
-		cpu, _ := global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct)
-		system.UpdateStats(&c.stats, mem, cpu, cpuSystem)
+		var uc, um uint64
+
+		if mem, err := global.SYS.GetContainerMemoryUsage(c.cgroupMemory); err != nil {
+			log.WithFields(log.Fields{"Container": c, "error": err.Error()}).Error("Could not get memory stats")
+		} else {
+			um = mem
+		}
+		if cpu, err := global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct); err != nil {
+			log.WithFields(log.Fields{"Container": c, "error": err.Error()}).Error("Could Not get CPU stats")
+		} else {
+			uc = cpu
+		}
+
+		system.UpdateStats(&c.stats, um, uc, cpuSystem)
 	}
 }
 

--- a/share/system/cgroup_test.go
+++ b/share/system/cgroup_test.go
@@ -1031,7 +1031,7 @@ func TestCrio_CPath_Cgroupv2(t *testing.T) {
 0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod042efd86_1f3b_4f2f_8736_f31c58e95bbc.slice/crio-f33f47b0db740bb647cb3e7ac62d96c74966dbb99cbfaf4563bfd42d387e8b44.scope
 	`
 	r := strings.NewReader(cgroup)
-	path := getCgroupPathReaderV2(r)
+	path,_ := getCgroupPathReaderV2(r)
 	if path != "/sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod042efd86_1f3b_4f2f_8736_f31c58e95bbc.slice/crio-f33f47b0db740bb647cb3e7ac62d96c74966dbb99cbfaf4563bfd42d387e8b44.scope" {
 		t.Errorf("incorrect cgroup path: %v\n", path)
 	}
@@ -1045,7 +1045,7 @@ func TestDockerK8s_CPath_SelfProbe_Cgroupv2(t *testing.T) {
 	0::/
 	`
 	r := strings.NewReader(cgroup)
-	path := getCgroupPathReaderV2(r)
+	path,_ := getCgroupPathReaderV2(r)
 	if path != "/sys/fs/cgroup" {
 		t.Errorf("incorrect cgroup path: %v\n", path)
 	}
@@ -1059,7 +1059,7 @@ func TestDockerK8s_CPath_Container_Cgroupv2(t *testing.T) {
 0::/../../kubepods-besteffort-podfd698699_eabf_4c23_92ef_cf0bbdb78261.slice/docker-2cc65c162ca1388b6b8d5ccfb701d22fc96675ccf8b2f1590c490c2c4039547f.scope
 	`
 	r := strings.NewReader(cgroup)
-	path := getCgroupPathReaderV2(r) // it is not inside the container
+	path,_ := getCgroupPathReaderV2(r) // it is not inside the container
 	if path != "/sys/fs/cgroup" {
 		t.Errorf("incorrect cgroup path: %v\n", path)
 	}


### PR DESCRIPTION
I followed the paths in k8s and noticed that the cgroup file was not did not have a valid path and fellback to /sys/fs/cgroup on Docker K8s. When I debugged it, I noticed that the path to
/proc/<pid>/root/sys/fs/cgroup was working in this scenario. The fix I created here will attempt to fallback to /proc/<pid>/root/sys/fs/cgroup and check if the files exist within it. If the files do not exist, then we will finally fallback to /sys/fs/cgroup.

