### PR TITLE
NVSHAS-8170 v2: make auto-profile default and adjustable memory threshold

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -275,7 +275,7 @@ func main() {
 	disable_auto_benchmark := flag.Bool("no_auto_benchmark", false, "disable auto benchmark")
 	disable_system_protection := flag.Bool("no_sys_protect", false, "disable system protections")
 	policy_puller := flag.Int("policy_puller", 0, "set policy pulling period")
-	autoProfile := flag.Bool("apc", false, "Enable auto profile collection")
+	autoProfile := flag.Int("apc", 1, "Enable auto profile collection")
 	flag.Parse()
 
 	if *debug {
@@ -320,8 +320,14 @@ func main() {
 		log.WithFields(log.Fields{"period": *policy_puller}).Info("policy pull regulator")
 	}
 
-	if *autoProfile {
-		agentEnv.autoProfieCapture = *autoProfile
+	agentEnv.autoProfieCapture = 1	// default
+	if *autoProfile != 1 {
+		if *autoProfile < 0 {
+			agentEnv.autoProfieCapture = 0	// no profile
+			log.WithFields(log.Fields{"auto-profile": *autoProfile}).Error("Invalid value, disable auto-profile")
+		} else {
+			agentEnv.autoProfieCapture = (uint64)(*autoProfile)
+		}
 		log.WithFields(log.Fields{"auto-profile": agentEnv.autoProfieCapture}).Info()
 	}
 

--- a/agent/cluster.go
+++ b/agent/cluster.go
@@ -219,7 +219,7 @@ func logWorkload(ev share.TLogEvent, wl *share.CLUSWorkload, msg *string) {
 
 var snapshotIndex int
 func memorySnapshot(usage uint64) {
-	if agentEnv.autoProfieCapture {
+	if agentEnv.autoProfieCapture > 0 {
 		log.WithFields(log.Fields{"usage": usage}).Debug()
 		if usage > agentEnv.peakMemoryUsage {
 			agentEnv.peakMemoryUsage = usage + agentEnv.snapshotMemStep  // level up
@@ -229,7 +229,7 @@ func memorySnapshot(usage uint64) {
 				label = strconv.Itoa(snapshotIndex)
 			}
 			log.WithFields(log.Fields{"label": label, "next": agentEnv.peakMemoryUsage}).Debug()
-			utils.PerfSnapshot(Agent.Pid, agentEnv.memoryLimit, usage, share.SnaphotFolder, Agent.ID, "enf.", label)
+			utils.PerfSnapshot(Agent.Pid, agentEnv.memoryLimit, agentEnv.autoProfieCapture, usage, share.SnaphotFolder, Agent.ID, "enf.", label)
 		}
 	}
 }

--- a/agent/timer.go
+++ b/agent/timer.go
@@ -74,8 +74,13 @@ func statsLoop(bPassiveContainerDetect bool) {
 	agentEnv.snapshotMemStep = agentEnv.memoryLimit/10
 	memSnapshotMark := agentEnv.memoryLimit*3/5				// 60% as starting point
 	memStatsEnforcerResetMark = agentEnv.memoryLimit*3/4	// 75% as starting point
+	if agentEnv.autoProfieCapture > 1 {
+		var mark uint64 = (uint64)(agentEnv.autoProfieCapture * 1024 * 1024) // into mega bytes
+		memSnapshotMark = mark * 3/5
+		agentEnv.snapshotMemStep = mark/10
+	}
 
-	if agentEnv.autoProfieCapture {
+	if agentEnv.autoProfieCapture > 0 {
 		log.WithFields(log.Fields{"Step": agentEnv.snapshotMemStep, "Snapshot_At": memSnapshotMark}).Info("Memory Snapshots")
 	} else {
 		memCheckTicker.Stop()

--- a/agent/types.go
+++ b/agent/types.go
@@ -22,7 +22,7 @@ type AgentEnvInfo struct {
 	autoBenchmark        bool
 	systemProfiles       bool
 	netPolicyPuller      int
-	autoProfieCapture    bool
+	autoProfieCapture    uint64
 	memoryLimit          uint64
 	peakMemoryUsage      uint64
 	snapshotMemStep      uint64

--- a/controller/cluster.go
+++ b/controller/cluster.go
@@ -230,7 +230,7 @@ func logController(ev share.TLogEvent) {
 
 var snapshotIndex int
 func memorySnapshot(usage uint64) {
-	if ctrlEnv.autoProfieCapture {
+	if ctrlEnv.autoProfieCapture > 0 {
 		log.WithFields(log.Fields{"usage": usage}).Debug()
 		if usage > ctrlEnv.peakMemoryUsage {
 			ctrlEnv.peakMemoryUsage = usage + ctrlEnv.snapshotMemStep  // level up
@@ -240,7 +240,7 @@ func memorySnapshot(usage uint64) {
 				label = strconv.Itoa(snapshotIndex)
 			}
 			log.WithFields(log.Fields{"label": label, "next": ctrlEnv.peakMemoryUsage}).Debug()
-			utils.PerfSnapshot(1, ctrlEnv.memoryLimit, usage, share.SnaphotFolder, Ctrler.ID, "ctl.", label)
+			utils.PerfSnapshot(1, ctrlEnv.memoryLimit, ctrlEnv.autoProfieCapture, usage, share.SnaphotFolder, Ctrler.ID, "ctl.", label)
 		}
 	}
 }

--- a/monitor/monitor.c
+++ b/monitor/monitor.c
@@ -414,9 +414,8 @@ static pid_t fork_exec(int i)
             args[a++] = csp_pause_interval;
         }
         if ((enable = getenv(ENV_AUTOPROFILE_CLT)) != NULL) {
-            if (checkImplicitEnableFlag(enable) == 1) {
-                args[a ++] = "-apc";
-            }
+            args[a++] = "-apc";
+            args[a++] = enable;
         }
         args[a] = NULL;
         break;
@@ -498,9 +497,8 @@ static pid_t fork_exec(int i)
             args[a ++] = policy_pull_period;
         }
         if ((enable = getenv(ENV_AUTOPROFILE_CLT)) != NULL) {
-            if (checkImplicitEnableFlag(enable) == 1) {
-                args[a ++] = "-apc";
-            }
+            args[a++] = "-apc";
+            args[a++] = enable;
         }
         args[a] = NULL;
         break;


### PR DESCRIPTION
(1) Make the auto-profile as default setting( no required flag)
(2) Adjustable memory threshold.

For example, without a k8s resource limits:
(1) AUTO_PROFILE_COLLECT=0, no snapshot.
(2) AUTO_PROFILE_COLLECT=1 (default), snapshots above 60% of the ctl[6GB <= 3.6GB] and enf[3GB <= 1.8GB]
(3) AUTO_PROFILE_COLLECT=300 (300MB), snapshots above 60% of 300MB <= 180MB
(4) AUTO_PROFILE_COLLECT=-100 (invalid), no snapshot.