### PR TITLE
NVSHAS 7925 - Fixes to cgroup logic

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -2438,3 +2438,4 @@ func cbGetAllContainerList() utils.Set {
 	defer gInfoRUnlock()
 	return gInfo.allContainers.Clone()
 }
+                                                                                                                                     

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -2438,4 +2438,3 @@ func cbGetAllContainerList() utils.Set {
 	defer gInfoRUnlock()
 	return gInfo.allContainers.Clone()
 }
-                                                                                                                                     

--- a/agent/timer.go
+++ b/agent/timer.go
@@ -224,9 +224,20 @@ func updateAgentStats(cpuSystem uint64) {
 
 func updateContainerStats(cpuSystem uint64) {
 	for _, c := range gInfo.activeContainers {
-		mem, _ := global.SYS.GetContainerMemoryUsage(c.cgroupMemory)
-		cpu, _ := global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct)
-		system.UpdateStats(&c.stats, mem, cpu, cpuSystem)
+		var uc, um uint64
+
+		if mem, err := global.SYS.GetContainerMemoryUsage(c.cgroupMemory); err != nil {
+			log.WithFields(log.Fields{"Container": c, "error": err.Error()}).Error("Could not get memory stats")
+		} else {
+			um = mem
+		}
+		if cpu, err := global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct); err != nil {
+			log.WithFields(log.Fields{"Container": c, "error": err.Error()}).Error("Could Not get CPU stats")
+		} else {
+			uc = cpu
+		}
+
+		system.UpdateStats(&c.stats, um, uc, cpuSystem)
 	}
 }
 

--- a/share/system/cgroup_linux.go
+++ b/share/system/cgroup_linux.go
@@ -31,11 +31,7 @@ const (
 const (
 	cgroup_v1 = 1
 	cgroup_v2 = 2
-	cgroup_v2_hybrid = 3
 )
-
-const CgroupHybridPath = "/sys/fs/cgroup/unified"
-const CgroupDefaultPath = "/sys/fs/cgroup/"
 
 var errUnsupported = errors.New("not supported")
 
@@ -337,7 +333,7 @@ func getCgroupPath_cgroup_v2(pid int) (string, error) {
 }
 
 
-
+// getStatsPathFromCgroupFile - Opens the proc/<pid>/cgroup file and parses it for the subsystem and paths
 func getStatsPathFromCgroupFile(f io.Reader, subsystem string) (string, error) {
 	subsystemMap := make(map[string]string, 0)
 	scanner := bufio.NewScanner(f)
@@ -346,15 +342,16 @@ func getStatsPathFromCgroupFile(f io.Reader, subsystem string) (string, error) {
 		tokens := strings.Split(scanner.Text(), ":")
 
 		if len(tokens) > 2 {
-			// For systemd based OS, we're looking for system.slice and we're in cgroup v2
 			// https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/resource_management_guide/sec-default_cgroup_hierarchies
 			// https://docs.fedoraproject.org/en-US/quick-docs/understanding-and-administering-systemd/
+			// cgroup path is defined by <index>:<subsystem(s)>:<path>
+			// example: 2:cpuset,cpu,cpuacct,memory,net_cls,net_prio,hugetlb:/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d
 
 			// The subsystem is the second item in the line
-			//if tokens[1] == subsystem {
 			path := tokens[2]
 
-			// handle multiple keys eg:  7:cpu,cpuacct:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+			// handle multiple subsytem keys that use the same path
+			// eg:  7:cpu,cpuacct:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
 			subs := strings.Split(tokens[1], ",")
 
 			for _, sub := range subs {
@@ -363,21 +360,20 @@ func getStatsPathFromCgroupFile(f io.Reader, subsystem string) (string, error) {
 		}
 	}
 
-	log.WithFields(log.Fields{"subsystemMap": subsystemMap}).Debug("Cgroup Subsystem map")
-
-	// On docker k8s (or a host cgroup file), it only returns a single line and we will return the first item
+	// On docker k8s (or a host cgroup file), it only returns a single line so we will return the first item
 	if len(subsystemMap) == 1 {
 		for _, val := range subsystemMap {
 			return CgroupRelativePathFix(val), nil
 		}
 	}
 
-	// check if we can find it
+	// Match the subsystem we're interested in.
 	if cpath, ok := subsystemMap[subsystem]; ok {
 		return CgroupRelativePathFix(cpath), nil
 	}
 
-	return "", fmt.Errorf("[%s] subsystem not found in tokens: %+v", subsystem, subsystemMap)
+	// If the subsystem is not available, then we will have to fallback
+	return defaultHostCgroup, fmt.Errorf("[%s] subsystem not found in tokens: %+v", subsystem, subsystemMap)
 }
 
 // CgroupRelativePathFix - Applies fixes for cgroup files with certain types of paths
@@ -385,6 +381,7 @@ func CgroupRelativePathFix(path string) (string) {
 	if strings.Contains(path, "/..") {
 		// I can't find the documentation why the cgroup file will hold relative paths. For now, I'm applying these
 		// fixes as we encounter them. Documentation on this behaviour would make this code more robust.
+		// Example: 0::/../../kubepods-besteffort-poddee9029c_408f_4466_811d_43eea3042395.slice/docker-a737350ff4843bb79debc4e2dc98f0b1b11d40f814ea4303d9167dd70c314b95.scope
 
 		path  = filepath.Clean(path)
 		if strings.Contains(path, "kubepods-pod") {
@@ -418,7 +415,13 @@ func (s *SystemTools) getCgroupMetricsPath(pid int, subsystem string) (string, e
 	// shouldn't reuse path, doesn't make sense
 	cpath, err := getStatsPathFromCgroupFile(f, subsystem)
 	if err != nil {
-		return cpath, err
+		log.WithFields(log.Fields{
+			"pid": pid,
+			"path": cpath,
+			"s.cgroupDir": s.cgroupDir,
+			"s.procDir": s.procDir,
+			"s.cgroupVersion": s.cgroupVersion,}).
+			Error("Cgroup file could not be parsed, fallback used")
 	}
 
 	log.WithFields(log.Fields{
@@ -432,24 +435,32 @@ func (s *SystemTools) getCgroupMetricsPath(pid int, subsystem string) (string, e
 	return cpath, nil
 
 }
+
+// GetContainerCgroupPath - Gets a PID's cgroup path for a subsystem
+// PIDs can share containers so we can derive the pid's cgroup path by parsing proc/<pid>/cgroup
 func (s *SystemTools) GetContainerCgroupPath(pid int, subsystem string) (string, error) {
 	subsystemPath := ""
 	mpath, err  := s.getCgroupMetricsPath(pid, subsystem)
 	if err != nil {
-		// Just return the fallback
+		// Just return the fallback, callers don't care about the error!
 		return mpath, nil
 	}
+
+	// Join to the system's path for host's cgroup
 	subsystemPath = s.JoinToCgroupPath(mpath, subsystem)
 
 	return subsystemPath, nil
 }
 
+// JoinToCgroupPath - Join to the system's path for host's cgroup
+// For cgroup v1, the subsystems are directories in the root and then the namespaces are within them
+// For cgroup v2, a flat directory structure is used and the namespace's directory now holds all the subsystems files
 func (s *SystemTools) JoinToCgroupPath(path string, subsystem string) string {
 	subsystemPath := ""
 	switch s.cgroupVersion {
 	case cgroup_v2:
 		subsystemPath = filepath.Join(s.cgroupDir, path)
-	// unsupported
+	// unsupported - Found issues in ubuntu 18.04 and missing subsystem in the unified directories
 	//case cgroup_v2_hybrid:
 	//	subsystemPath = filepath.Join(s.cgroupDir, "/unified", mpath)
 	case cgroup_v1:

--- a/share/system/cgroup_linux.go
+++ b/share/system/cgroup_linux.go
@@ -1270,7 +1270,4 @@ func (s *SystemTools) ReCalculateMemoryMetrics(threshold uint64) {
 }
 
 // verify the cgroup's memory controller
-// cgroup v2 is a unified file system, it does not have the memory folder
-func (s *SystemTools) GetCgroupVersion() int {
-	return s.cgroupVersion
-}
+// cgroup v2 is a un

--- a/share/system/cgroup_linux.go
+++ b/share/system/cgroup_linux.go
@@ -457,12 +457,15 @@ func (s *SystemTools) GetContainerCgroupPath(pid int, subsystem string) (string,
 	subsystemPath := ""
 	mpath, _ := s.getCgroupMetricsPath(pid)
 	switch s.cgroupVersion {
-	case cgroup_v1:
-		subsystemPath = filepath.Join(s.cgroupDir, subsystem, mpath)
 	case cgroup_v2:
 		subsystemPath = filepath.Join(s.cgroupDir, mpath)
-	case cgroup_v2_hybrid:
-		subsystemPath = filepath.Join(s.cgroupDir, "/unified", mpath)
+	// unsupported
+	//case cgroup_v2_hybrid:
+	//	subsystemPath = filepath.Join(s.cgroupDir, "/unified", mpath)
+	case cgroup_v1:
+		fallthrough
+	default:
+		subsystemPath = filepath.Join(s.cgroupDir, subsystem, mpath)
 	}
 	log.WithFields(log.Fields{"s.cgroupVersion": s.cgroupVersion,"pid": pid, "subsystem": subsystem, "subsystemPath": subsystemPath}).Error("JAYU Susystem path created")
 	return subsystemPath, nil

--- a/share/system/cgroup_linux.go
+++ b/share/system/cgroup_linux.go
@@ -589,10 +589,6 @@ func (s *SystemTools) getMemoryStats(path string, mStats *CgroupMemoryStats, bFu
 	filePath := filepath.Join(path, "memory.stat")
 	statsFile, err := os.Open(filePath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			log.WithFields(log.Fields{"filePath": filePath, "systemtools": *s, "error": err}).Error("Could not find memory stats file")
-			return nil
-		}
 		return err
 	}
 	defer statsFile.Close()
@@ -1270,4 +1266,7 @@ func (s *SystemTools) ReCalculateMemoryMetrics(threshold uint64) {
 }
 
 // verify the cgroup's memory controller
-// cgroup v2 is a un
+// cgroup v2 is a unified file system, it does not have the memory folder
+func (s *SystemTools) GetCgroupVersion() int {
+	return s.cgroupVersion
+}

--- a/share/system/cgroup_test.go
+++ b/share/system/cgroup_test.go
@@ -1033,7 +1033,7 @@ func TestCrio_CPath_Cgroupv2(t *testing.T) {
 0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod042efd86_1f3b_4f2f_8736_f31c58e95bbc.slice/crio-f33f47b0db740bb647cb3e7ac62d96c74966dbb99cbfaf4563bfd42d387e8b44.scope
 	`
 	r := strings.NewReader(cgroup)
-	path,_ := getCgroupPathReaderV2(r)
+	path := getCgroupPathReaderV2(r)
 	if path != "/sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod042efd86_1f3b_4f2f_8736_f31c58e95bbc.slice/crio-f33f47b0db740bb647cb3e7ac62d96c74966dbb99cbfaf4563bfd42d387e8b44.scope" {
 		t.Errorf("incorrect cgroup path: %v\n", path)
 	}
@@ -1047,7 +1047,7 @@ func TestDockerK8s_CPath_SelfProbe_Cgroupv2(t *testing.T) {
 	0::/
 	`
 	r := strings.NewReader(cgroup)
-	path,_ := getCgroupPathReaderV2(r)
+	path := getCgroupPathReaderV2(r)
 	if path != "/sys/fs/cgroup" {
 		t.Errorf("incorrect cgroup path: %v\n", path)
 	}
@@ -1061,7 +1061,7 @@ func TestDockerK8s_CPath_Container_Cgroupv2(t *testing.T) {
 0::/../../kubepods-besteffort-podfd698699_eabf_4c23_92ef_cf0bbdb78261.slice/docker-2cc65c162ca1388b6b8d5ccfb701d22fc96675ccf8b2f1590c490c2c4039547f.scope
 	`
 	r := strings.NewReader(cgroup)
-	path,_ := getCgroupPathReaderV2(r) // it is not inside the container
+	path := getCgroupPathReaderV2(r) // it is not inside the container
 	if path != "/sys/fs/cgroup" {
 		t.Errorf("incorrect cgroup path: %v\n", path)
 	}

--- a/share/system/cgroup_test.go
+++ b/share/system/cgroup_test.go
@@ -1,6 +1,8 @@
 package system
 
 import (
+	"github.com/stretchr/testify/assert"
+	"log"
 	"os"
 	"strings"
 	"testing"
@@ -1471,5 +1473,239 @@ func TestContainerd_Container_Cgroupv2(t *testing.T) {
 	id, _, found = getContainerIDByCgroupReaderV2(r, from_hostname)
 	if id != "f34e6ab6ed679d809c8d4a385777c4f72441f1d3ec7b1334d35c10f4d25e6f40" || !found { // pod ID
 		t.Errorf("detect wrong pod ID, cgroup:  %v, %v\n", id, found)
+	}
+}
+
+type cgroupTestCase struct {
+	name string
+	contents string
+	subsystem string
+	errIsNil bool
+	expected string
+}
+
+func CgroupFileTestTemplate(t *testing.T, testcase cgroupTestCase) {
+
+	r := strings.NewReader(testcase.contents)
+	path, err := getStatsPathFromCgroupFile(r, testcase.subsystem)
+	if testcase.errIsNil {
+		assert.Nil(t, err, "should have no errors")
+	} else {
+		assert.NotNil(t, err, "should have errors")
+	}
+	assert.Equal(t, testcase.expected,
+		path,  "Path is wrong")
+	//
+	//r = strings.NewReader(testcase.contents)
+	//path, err = getStatsPathFromCgroupFile(r, "cpuset")
+	//assert.Nil(t, err, "should have no errors")
+	//assert.Equal(t,"/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce",
+	//	path, "Path is wrong")
+	//
+	//r = strings.NewReader(testcase.contents)
+	//path, err = getStatsPathFromCgroupFile(r, "doesnotexist")
+	//assert.NotNil(t, err, "should have have error")
+	//assert.Equal(t,"",
+	//	path, "Path is wrong")
+}
+
+func TestCgroupFile(t *testing.T) {
+	log.SetOutput(os.Stderr)
+	// Test multiple variants on distributions. Not standardized
+	/*
+	In the case of cgroups v1, as the maintainer Tejun Heo admits,
+	"design followed implementation,"
+	"different decisions were taken for different controllers,"
+	and "sometimes too much flexibility causes a hindrance."
+	https://www.redhat.com/en/blog/world-domination-cgroups-rhel-8-welcome-cgroups-v2
+	*/
+
+		ubuntu18_04 := `12:hugetlb:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+11:cpuset:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+10:net_cls,net_prio:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+9:perf_event:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+8:pids:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+7:cpu,cpuacct:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+6:freezer:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+5:blkio:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+4:rdma:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+3:memory:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+2:devices:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+1:name=systemd:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+0::/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce`
+
+	debian := `10:net_prio:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+9:perf_event:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+8:blkio:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+7:net_cls:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+6:freezer:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+5:devices:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+4:memory:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+3:cpuacct:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+2:cpu:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+`
+
+	centos := `10:devices:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+9:blkio:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+8:memory:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+7:freezer:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+6:perf_event:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+5:hugetlb:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+4:net_cls:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+3:cpuset:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+2:cpuacct,cpu:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+1:name=systemd:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+`
+
+	rancher := `9:name=systemd:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+8:memory:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+7:blkio:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+6:cpu,cpuacct:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+5:cpuset:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+4:perf_event:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+3:net_cls,net_prio:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+2:freezer:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+1:devices:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+`
+
+	kubepods := `11:devices:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+10:memory:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+9:hugetlb:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+8:perf_event:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+7:freezer:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+6:pids:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+5:cpu,cpuacct:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+4:cpuset:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+3:blkio:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+2:net_cls,net_prio:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+1:name=systemd:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c`
+
+	kubepods2 := `
+11:cpuset:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+10:blkio:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+9:devices:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+8:memory:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+7:freezer:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+6:perf_event:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+5:net_prio,net_cls:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+4:hugetlb:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+3:pids:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+2:cpuacct,cpu:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+1:name=systemd:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope`
+
+	kubepod3 := `8:pids:/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d
+7:blkio:/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d
+6:perf_event:/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d
+5:devices:/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d
+4:freezer:/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d
+3:rdma:/
+2:cpuset,cpu,cpuacct,memory,net_cls,net_prio,hugetlb:/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d
+1:name=systemd:/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d`
+
+	hostCgroup := `
+14:name=dsystemd:/
+13:name=systemd:/
+12:pids:/
+11:hugetlb:/
+10:net_prio:/
+9:perf_event:/
+8:net_cls:/
+7:freezer:/
+6:devices:/
+5:memory:/
+4:blkio:/
+3:cpuacct:/
+2:cpu:/
+1:cpuset:/`
+
+	dockerK8sBestEffort := `0::/../../kubepods-besteffort-poddee9029c_408f_4466_811d_43eea3042395.slice/docker-a737350ff4843bb79debc4e2dc98f0b1b11d40f814ea4303d9167dd70c314b95.scope`
+	dockerK8sBurstable := `0::/../../../kubepods-burstable.slice/kubepods-burstable-pode78d192d_934f_475f_af41_6fe274868dcc.slice/docker-102b2be2d2d712ee08c202e70d1372892f3c20d14771ffa006f7f8c41a30fcc1.scope`
+
+	hostCgroupEmpty := `0::/`
+
+	tests := []cgroupTestCase{
+		// ubunu 18.04
+		{"ubuntu18_04", ubuntu18_04, "memory", true,
+		"/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce"},
+		{"ubuntu18_04", ubuntu18_04, "cpuacct", true,
+		"/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce"},
+		{"ubuntu18_04", ubuntu18_04, "doesnotexist", false,
+		""},
+		// Debian
+		{"debian", debian, "memory", true,
+			"/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970"},
+		{"debian", debian, "cpuacct", true,
+			"/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970"},
+		{"debian", debian, "doesnotexist", false,
+			""},
+		// centos
+		{"centos", centos, "memory", true,
+			"/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope"},
+		{"centos", centos, "cpuacct", true,
+			"/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope"},
+		{"centos", centos, "doesnotexist", false,
+			""},
+		// rancher
+		{"rancher", rancher, "memory", true,
+			"/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a"},
+		{"rancher", rancher, "cpuacct", true,
+			"/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a"},
+		{"rancher", rancher, "doesnotexist", false,
+			""},
+		// kubepods
+		{"kubepods", kubepods, "memory", true,
+			"/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c"},
+		{"kubepods", kubepods, "cpuacct", true,
+			"/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c"},
+		{"kubepods", kubepods, "doesnotexist", false,
+			""},
+		// kubepods2
+		{"kubepods2", kubepods2, "memory", true,
+			"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope"},
+		{"kubepods2", kubepods2, "cpuacct", true,
+			"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope"},
+		{"kubepods2", kubepods2, "doesnotexist", false,
+			""},
+		// kubepod3
+		{"kubepod3", kubepod3, "memory", true,
+			"/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d"},
+		{"kubepod3", kubepod3, "cpuacct", true,
+			"/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d"},
+		{"kubepod3", kubepod3, "doesnotexist", false,
+			""},
+		// hostCgroup
+		{"hostCgroup", hostCgroup, "memory", true,
+			"/"},
+		{"hostCgroup", hostCgroup, "cpuacct", true,
+			"/"},
+		{"hostCgroup", hostCgroup, "doesnotexist", false,
+			""},
+		// dockerK8s Best effort
+		{"dockerK8s", dockerK8sBestEffort, "memory", true,
+			"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-poddee9029c_408f_4466_811d_43eea3042395.slice/docker-a737350ff4843bb79debc4e2dc98f0b1b11d40f814ea4303d9167dd70c314b95.scope"},
+		{"dockerK8s", dockerK8sBestEffort, "cpuacct", true,
+			"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-poddee9029c_408f_4466_811d_43eea3042395.slice/docker-a737350ff4843bb79debc4e2dc98f0b1b11d40f814ea4303d9167dd70c314b95.scope"},
+		{"dockerK8s", dockerK8sBestEffort, "doesnotexist", true, // True because these are exception cases. We assume the one entry is the only one we can use
+			"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-poddee9029c_408f_4466_811d_43eea3042395.slice/docker-a737350ff4843bb79debc4e2dc98f0b1b11d40f814ea4303d9167dd70c314b95.scope"},
+		// dockerK8s Burstable
+		{"dockerK8sBurstable", dockerK8sBurstable, "memory", true,
+			"/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pode78d192d_934f_475f_af41_6fe274868dcc.slice/docker-102b2be2d2d712ee08c202e70d1372892f3c20d14771ffa006f7f8c41a30fcc1.scope"},
+		{"dockerK8sBurstable", dockerK8sBurstable, "cpuacct", true,
+			"/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pode78d192d_934f_475f_af41_6fe274868dcc.slice/docker-102b2be2d2d712ee08c202e70d1372892f3c20d14771ffa006f7f8c41a30fcc1.scope"},
+		{"dockerK8sBurstable", dockerK8sBurstable, "doesnotexist", true, // True because these are exception cases. We assume the one entry is the only one we can use
+			"/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pode78d192d_934f_475f_af41_6fe274868dcc.slice/docker-102b2be2d2d712ee08c202e70d1372892f3c20d14771ffa006f7f8c41a30fcc1.scope"},
+		// Pid 0 Host Cgroup
+		{"hostCgroupEmpty", hostCgroupEmpty, "memory", true,
+			"/"},
+		{"hostCgroupEmpty", hostCgroupEmpty, "cpuacct", true,
+			"/"},
+		{"hostCgroupEmpty", hostCgroupEmpty, "doesnotexist", true, // True because these are exception cases. We assume the one entry is the only one we can use
+			"/"},
+
+	}
+
+	for _, test := range tests {
+		t.Logf("Testing %s suubsystem %s", test.name, test.subsystem)
+		CgroupFileTestTemplate(t, test)
 	}
 }

--- a/share/system/cgroup_test.go
+++ b/share/system/cgroup_test.go
@@ -1495,18 +1495,6 @@ func CgroupFileTestTemplate(t *testing.T, testcase cgroupTestCase) {
 	}
 	assert.Equal(t, testcase.expected,
 		path,  "Path is wrong")
-	//
-	//r = strings.NewReader(testcase.contents)
-	//path, err = getStatsPathFromCgroupFile(r, "cpuset")
-	//assert.Nil(t, err, "should have no errors")
-	//assert.Equal(t,"/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce",
-	//	path, "Path is wrong")
-	//
-	//r = strings.NewReader(testcase.contents)
-	//path, err = getStatsPathFromCgroupFile(r, "doesnotexist")
-	//assert.NotNil(t, err, "should have have error")
-	//assert.Equal(t,"",
-	//	path, "Path is wrong")
 }
 
 func TestCgroupFile(t *testing.T) {
@@ -1630,56 +1618,56 @@ func TestCgroupFile(t *testing.T) {
 		{"ubuntu18_04", ubuntu18_04, "cpuacct", true,
 		"/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce"},
 		{"ubuntu18_04", ubuntu18_04, "doesnotexist", false,
-		""},
+		"/sys/fs/cgroup"},
 		// Debian
 		{"debian", debian, "memory", true,
 			"/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970"},
 		{"debian", debian, "cpuacct", true,
 			"/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970"},
 		{"debian", debian, "doesnotexist", false,
-			""},
+			"/sys/fs/cgroup"},
 		// centos
 		{"centos", centos, "memory", true,
 			"/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope"},
 		{"centos", centos, "cpuacct", true,
 			"/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope"},
 		{"centos", centos, "doesnotexist", false,
-			""},
+			"/sys/fs/cgroup"},
 		// rancher
 		{"rancher", rancher, "memory", true,
 			"/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a"},
 		{"rancher", rancher, "cpuacct", true,
 			"/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a"},
 		{"rancher", rancher, "doesnotexist", false,
-			""},
+			"/sys/fs/cgroup"},
 		// kubepods
 		{"kubepods", kubepods, "memory", true,
 			"/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c"},
 		{"kubepods", kubepods, "cpuacct", true,
 			"/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c"},
 		{"kubepods", kubepods, "doesnotexist", false,
-			""},
+			"/sys/fs/cgroup"},
 		// kubepods2
 		{"kubepods2", kubepods2, "memory", true,
 			"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope"},
 		{"kubepods2", kubepods2, "cpuacct", true,
 			"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope"},
 		{"kubepods2", kubepods2, "doesnotexist", false,
-			""},
+			"/sys/fs/cgroup"},
 		// kubepod3
 		{"kubepod3", kubepod3, "memory", true,
 			"/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d"},
 		{"kubepod3", kubepod3, "cpuacct", true,
 			"/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d"},
 		{"kubepod3", kubepod3, "doesnotexist", false,
-			""},
+			"/sys/fs/cgroup"},
 		// hostCgroup
 		{"hostCgroup", hostCgroup, "memory", true,
 			"/"},
 		{"hostCgroup", hostCgroup, "cpuacct", true,
 			"/"},
 		{"hostCgroup", hostCgroup, "doesnotexist", false,
-			""},
+			"/sys/fs/cgroup"},
 		// dockerK8s Best effort
 		{"dockerK8s", dockerK8sBestEffort, "memory", true,
 			"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-poddee9029c_408f_4466_811d_43eea3042395.slice/docker-a737350ff4843bb79debc4e2dc98f0b1b11d40f814ea4303d9167dd70c314b95.scope"},
@@ -1708,4 +1696,41 @@ func TestCgroupFile(t *testing.T) {
 		t.Logf("Testing %s suubsystem %s", test.name, test.subsystem)
 		CgroupFileTestTemplate(t, test)
 	}
+}
+
+func TestCgroupPathJoin(t *testing.T) {
+	sys := SystemTools{}
+	sys.cgroupDir = "/sys/fs/cgroup"
+
+	path := "/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pode78d192d_934f_475f_af41_6fe274868dcc.slice/docker-102b2be2d2d712ee08c202e70d1372892f3c20d14771ffa006f7f8c41a30fcc1.scope"
+
+	// Test v1
+	sys.cgroupVersion = cgroup_v1
+	fpath := sys.JoinToCgroupPath(path, "memory")
+
+	assert.Equal(t, fpath, "/sys/fs/cgroup/memory/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pode78d192d_934f_475f_af41_6fe274868dcc.slice/docker-102b2be2d2d712ee08c202e70d1372892f3c20d14771ffa006f7f8c41a30fcc1.scope")
+
+	// Test v1 bad subsystem
+	sys.cgroupVersion = cgroup_v1
+	path = "/"
+	fpath = sys.JoinToCgroupPath(path, "memory")
+	assert.Equal(t, fpath, "/sys/fs/cgroup/memory")
+
+
+	// Test v2
+	// In v2 - it is a flat directory structure so the subsystem doesn't actually matter
+	path = "/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pode78d192d_934f_475f_af41_6fe274868dcc.slice/docker-102b2be2d2d712ee08c202e70d1372892f3c20d14771ffa006f7f8c41a30fcc1.scope"
+	sys.cgroupVersion = cgroup_v2
+	fpath = sys.JoinToCgroupPath(path, "memory")
+
+	assert.Equal(t, fpath, "/sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pode78d192d_934f_475f_af41_6fe274868dcc.slice/docker-102b2be2d2d712ee08c202e70d1372892f3c20d14771ffa006f7f8c41a30fcc1.scope")
+
+	// Test v2
+	// if the path is /, we just want to return the cgroup directory root
+	path = "/"
+	sys.cgroupVersion = cgroup_v2
+	fpath = sys.JoinToCgroupPath(path, "memory")
+
+	assert.Equal(t, fpath, "/sys/fs/cgroup")
+
 }

--- a/share/system/cgroup_test.go
+++ b/share/system/cgroup_test.go
@@ -1031,7 +1031,7 @@ func TestCrio_CPath_Cgroupv2(t *testing.T) {
 0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod042efd86_1f3b_4f2f_8736_f31c58e95bbc.slice/crio-f33f47b0db740bb647cb3e7ac62d96c74966dbb99cbfaf4563bfd42d387e8b44.scope
 	`
 	r := strings.NewReader(cgroup)
-	path := getCgroupPathReaderV2(r)
+	path,_ := getCgroupPathReaderV2(r)
 	if path != "/sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod042efd86_1f3b_4f2f_8736_f31c58e95bbc.slice/crio-f33f47b0db740bb647cb3e7ac62d96c74966dbb99cbfaf4563bfd42d387e8b44.scope" {
 		t.Errorf("incorrect cgroup path: %v\n", path)
 	}
@@ -1045,7 +1045,7 @@ func TestDockerK8s_CPath_SelfProbe_Cgroupv2(t *testing.T) {
 	0::/
 	`
 	r := strings.NewReader(cgroup)
-	path := getCgroupPathReaderV2(r)
+	path,_ := getCgroupPathReaderV2(r)
 	if path != "/sys/fs/cgroup" {
 		t.Errorf("incorrect cgroup path: %v\n", path)
 	}
@@ -1059,7 +1059,7 @@ func TestDockerK8s_CPath_Container_Cgroupv2(t *testing.T) {
 0::/../../kubepods-besteffort-podfd698699_eabf_4c23_92ef_cf0bbdb78261.slice/docker-2cc65c162ca1388b6b8d5ccfb701d22fc96675ccf8b2f1590c490c2c4039547f.scope
 	`
 	r := strings.NewReader(cgroup)
-	path := getCgroupPathReaderV2(r) // it is not inside the container
+	path,_ := getCgroupPathReaderV2(r) // it is not inside the container
 	if path != "/sys/fs/cgroup" {
 		t.Errorf("incorrect cgroup path: %v\n", path)
 	}

--- a/share/system/system_linux.go
+++ b/share/system/system_linux.go
@@ -121,7 +121,7 @@ func (s *SystemTools) SetCgroupInfo(version int) {
 		"cgroupMemory": s.cgroupMemoryDir,
 		"cgroupdir": s.cgroupDir,
 		"procdir": s.procDir,
-	}).Debug("filled in cgroup configuration")
+	}).Debug("Setup up system tools cgroup configuration")
 }
 
 // DetermineCgroupVersion - Determines the cgroup version by checking for known files in the cgroup directory

--- a/share/system/system_linux.go
+++ b/share/system/system_linux.go
@@ -157,13 +157,14 @@ func (s *SystemTools) DetermineCgroupPath() (int, string) {
 			"cgroupPath": cgroupPath,
 			"cgroupControllerPath": cgroupControllerPath,
 		"err": err.Error()}).Errorf("v1 mode")
+		// unsupported -- tested on ubuntu 18.04 and it's missing files we need.
 		// check if in cgroup v2 hybrid mode
-		if cgroupIsHybridMode(s.cgroupDir) {
-			s.cgroupVersion = cgroup_v2_hybrid
-			log.WithFields(log.Fields{"s.cgroupDir": s.cgroupDir,
-				"cgroupPath": cgroupPath,
-				"cgroupControllerPath": cgroupControllerPath}).Errorf("v2 hybrid")
-		}
+		//if cgroupIsHybridMode(s.cgroupDir) {
+		//	s.cgroupVersion = cgroup_v2_hybrid
+		//	log.WithFields(log.Fields{"s.cgroupDir": s.cgroupDir,
+		//		"cgroupPath": cgroupPath,
+		//		"cgroupControllerPath": cgroupControllerPath}).Errorf("v2 hybrid")
+		//}
 	}
 	return s.cgroupVersion, s.cgroupMemoryDir
 }

--- a/share/system/system_linux.go
+++ b/share/system/system_linux.go
@@ -114,9 +114,7 @@ func (s *SystemTools) SetCgroupInfo(version int) {
 		fallthrough
 	default:
 		s.cgroupVersion = cgroup_v1
-		//s.cgroupMemoryDir = defaultHostCgroupMemory
 		s.cgroupMemoryDir = filepath.Join(s.cgroupDir, "memory")
-		// cgroup v2 hybrid is not supported
 	}
 
 	log.WithFields(log.Fields{"cgroupVersion": s.cgroupVersion,
@@ -132,8 +130,7 @@ func (s *SystemTools) DetermineCgroupVersion() (int) {
 	// We will use the group.controller to determine cgroup version
 	// https://github.com/opencontainers/runc/blob/master/docs/cgroup-v2.md
 	version := cgroup_v1
-	cgroupPath := s.cgroupDir // filepath.Join(s.cgroupDir, CgroupDefaultPath)
-	cgroupControllerPath := filepath.Join(cgroupPath, "/cgroup.controllers")
+	cgroupControllerPath := filepath.Join(s.cgroupDir, "/cgroup.controllers")
 	if _, err := os.Stat(cgroupControllerPath); err == nil {
 		version = cgroup_v2
 	}

--- a/share/system/system_linux.go
+++ b/share/system/system_linux.go
@@ -35,7 +35,7 @@ import (
 
 const defaultHostProc string = "/proc/"
 const mappedHostProc string = "/host/proc/"
-const defaultHostCgroup string = "/sys/fs/cgroup/"
+const defaultHostCgroup string = "/sys/fs/cgroup"
 const mappedHostCgroup string = "/host/cgroup/"
 const maxStatCmdLen = 15
 const (
@@ -87,19 +87,24 @@ func NewSystemTools() *SystemTools {
 
 	s := &SystemTools{
 		bEnable: true,
-		procDir: procDir, cgroupDir: cgroupDir,
+		procDir: procDir,
+		cgroupDir: cgroupDir,
 		clockTicksPerSecond: uint64(getClockTicks()),
 	}
 
+	log.WithFields(log.Fields{"system tools": s}).Errorf("Jayu dummping mount info")
 	s.info.SetRootPathPrefix(fmt.Sprintf("%s1/root/", procDir))
 	s.info.GetSysInfo()
+	log.WithFields(log.Fields{"system tools": s}).Errorf("Jayu dummping sys info")
 
-	// fill cgroup info
-	// https://github.com/opencontainers/runc/blob/master/docs/cgroup-v2.md
+	//// fill cgroup info
+	//// https://github.com/opencontainers/runc/blob/master/docs/cgroup-v2.md
+	//// Use this to determine cgroup type
+	//// https://lists.freedesktop.org/archives/systemd-devel/2018-November/041644.html
 	if _, err := os.Stat("/sys/fs/cgroup/cgroup.controllers"); err == nil {
 		s.cgroupVersion = cgroup_v2
 		// update cgroup v2 path
-		if path, err := getCgroupPath_cgroup_v2(0); err == nil {
+		if path, err := getCgroupPath_cgroup_v2(0, defaultHostCgroup); err == nil {
 			s.cgroupMemoryDir = path
 		} else {
 			s.cgroupMemoryDir = "/sys/fs/cgroup" // last resort
@@ -108,7 +113,75 @@ func NewSystemTools() *SystemTools {
 		s.cgroupVersion = cgroup_v1
 		s.cgroupMemoryDir = "/sys/fs/cgroup/memory"
 	}
+	log.WithFields(log.Fields{"s": s}).Error("JAYU Dumping original cgroup selection")
+
+	s.DetermineCgroupPath()
+
+	switch(s.cgroupVersion) {
+	case cgroup_v1:
+		s.cgroupMemoryDir = "/sys/fs/cgroup/memory"
+	case cgroup_v2:
+		s.cgroupVersion = cgroup_v2
+		s.cgroupMemoryDir = "/sys/fs/cgroup"
+		fallthrough
+	case cgroup_v2_hybrid:
+		// update cgroup v2 path
+		s.cgroupMemoryDir = "/proc/self/cgroup"
+	}
+
+	log.WithFields(log.Fields{"s": s}).Error("JAYU Dumping cgroup selection")
 	return s
+}
+
+func (s *SystemTools) DetermineCgroupPath() (int, string) {
+
+	// fill cgroup info
+	// https://github.com/opencontainers/runc/blob/master/docs/cgroup-v2.md
+	// Use this to determine cgroup type
+	log.WithFields(log.Fields{"s.cgroupDir": s.cgroupDir}).Errorf("Jayu getting cgroup dir")
+
+	// check root path
+	// Check cgroup version using cgroup.controllers and if v2 pure, hybrid, legacy
+	// https://lists.freedesktop.org/archives/systemd-devel/2018-November/041644.html
+	cgroupPath := s.cgroupDir // filepath.Join(s.cgroupDir, CgroupDefaultPath)
+	cgroupControllerPath := filepath.Join(cgroupPath, "/cgroup.controllers")
+	if _, err := os.Stat(cgroupControllerPath); err == nil {
+		s.cgroupVersion = cgroup_v2
+		log.WithFields(log.Fields{"s.cgroupDir": s.cgroupDir,
+			"cgroupPath": cgroupPath,
+		"cgroupControllerPath": cgroupControllerPath}).Errorf("v2 mode")
+
+	} else {
+		s.cgroupVersion = cgroup_v1
+		log.WithFields(log.Fields{"s.cgroupDir": s.cgroupDir,
+			"cgroupPath": cgroupPath,
+			"cgroupControllerPath": cgroupControllerPath,
+		"err": err.Error()}).Errorf("v1 mode")
+		// check if in cgroup v2 hybrid mode
+		if cgroupIsHybridMode(s.cgroupDir) {
+			s.cgroupVersion = cgroup_v2_hybrid
+			log.WithFields(log.Fields{"s.cgroupDir": s.cgroupDir,
+				"cgroupPath": cgroupPath,
+				"cgroupControllerPath": cgroupControllerPath}).Errorf("v2 hybrid")
+		}
+	}
+	return s.cgroupVersion, s.cgroupMemoryDir
+}
+
+func (s *SystemTools) SetCgroupV2Path() {
+	if path, err := getCgroupPath_cgroup_v2(0, s.cgroupDir); err == nil {
+		s.cgroupMemoryDir = path
+	} else {
+		s.cgroupMemoryDir = "/sys/fs/cgroup" // last resort
+	}
+}
+
+func cgroupIsHybridMode(cgroupdir string) bool {
+	path := filepath.Join(cgroupdir, "/unified")
+	if _, err := os.Stat(path); err == nil {
+		return true
+	}
+	return false
 }
 
 func (s *SystemTools) GetCgroupsVersion() int {

--- a/share/system/system_test.go
+++ b/share/system/system_test.go
@@ -54,9 +54,12 @@ func TestCgroupVersion(t *testing.T) {
 	tmpcontrollerpath := "/tmp/cgroup.controllers"
 	// Make sure there isn't one here
 	os.Remove(tmpcontrollerpath) // Best effort
+
+	// Test v1
 	version := sys.DetermineCgroupVersion()
 	assert.Equal(t, cgroup_v1, version, "Should be cgroup v1")
 
+	// Test V2
 	cgroupcontroller := tmpcontrollerpath
 	fp, err := os.Create(cgroupcontroller)
 	if err != nil {

--- a/share/system/system_test.go
+++ b/share/system/system_test.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"io"
 	"os"
 	"testing"
 
@@ -69,17 +68,4 @@ func TestCgroupVersion(t *testing.T) {
 	assert.Equal(t, cgroup_v2, version2, "Should be cgroup v1")
 
 	os.Remove(tmpcontrollerpath) // best effort
-}
-
-type file interface {
-	io.Closer
-	io.Reader
-	io.ReaderAt
-	io.Seeker
-	Stat() (os.FileInfo, error)
-}
-
-type fileSystem interface {
-	Open(name string) (file, error)
-	Close()
 }


### PR DESCRIPTION
Also fixes NVSHAS-7990 (probably other cgroup problems).

7990 reported error in accessing the cgroup container metrics. When I debugged the containers, the metrics were located in `/host/cgroup` and not in `/sys/fs/cgroup`. The `/sys/fs/cgroup` path was local to the container and not of the host so none of the paths resolved. Many places were hardcoded to use the enforcer's container's paths instead of the host mounted ones and this could cause a mismatch in information. 

In 7925 - The issue was that the metrics didn't make sense in the UI. The "deployment' tab would show some vague metrics that I couldn't correlate and the container tab would sometimes show the correct values. 

The issue here was the pod holders (the container that start the /pause task) would start up and the engine would seem to grab the wrong container ID. As well, the containers looked like it would fallback silently which would assume the enforcer's metrics. 

This PR covers these two problems and possible future ones.
1. At startup, I updated the cgroup version decision making tree to make it testable.
2. NewSystemtools() does not change behaviour, it retains its original behaviour. It has been re-organized so its easier to test and with the start up fixes. 
3. When a container is added, it will follow a different flow than before. It is simplified now
4. We now use the systemtool's proc path (which ideally will be /host/proc) to get a PID's information
5. Changed how we parse the cgroup file in the proc directory. Before it assumed a single type of system but I added, hopefully, more robust handlers. 
6. It will check for the subsystem in the cgroup file. If the subsystem isn't in the file, it means the subsystem is not active (either host doesn't have it turned on or the distribution does not support it)
7. It will clean the paths in the cgroup file and fix the mapping if needed. I found issues with docker k8s where the paths were relative but it made no sense. I haven't found documentation why this is the case yet. 
8. It will apply the correct v2 and v1 qualifiers to the cgroup path and then use the discovered cgroup path at startup. Ideally it will be /host/cgroup which should be a mirror of the host' /sys/fs/cgroup.
9. cgroup v2 hybrid is not supported. The one setup that I have (ubuntu 18.04) that does support cgroup v2 hybrid doesn't support all the subsystems in v2 mode. So rather than have more logic to deal with hybrid mode, I made it so we just assume cgroup v2 pure or v1 "pure". I did add logic to deal with it but it almost always fallbacks to v1 mode so its probably easier to just avoid it. 

The previous fixes were trying to fix why /sys/fs/cgroup was not resolving correctly which was a red herring. IMO the root cause was actually because we were using the container's cgroup directory and not the host's. 

I added a bunch of unit tests to cover the the different types of cgroup files that may exist. It is not exhaustive and will require more expamples.

PR was tested against

Ubuntu 18.04 Docker all in one:  
```
 Cgroup Driver: cgroupfs
 Cgroup Version: 1
 Runtimes: runc io.containerd.runc.v2
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 3dce8eb055cbb6872793272b4f20ed16117344f8
 runc version: v1.1.7-0-g860f061
 init version: de40ad0
```

Ubuntu 23.04 Docker k8s (this one reliably reproduces the bug for 7925)
```
 Cgroup Driver: systemd
 Cgroup Version: 2
 Runtimes: io.containerd.runc.v2 runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 3dce8eb055cbb6872793272b4f20ed16117344f8
 runc version: v1.1.7-0-g860f061
```

AWS EKS  (this one had the 7990 bug)
```k8s=1.26.6-eks-a5565ad ```

Currently being tested on another AWS cluster (I don't have the details yet on it). 