### PR TITLE
NVSHAS 7925 - Fixes to cgroup logic

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1206,6 +1206,7 @@ func fillContainerProperties(c *containerData, parent *containerData,
 			parent.hasDatapath = false
 		}
 	}
+
 	c.cgroupMemory, _ = global.SYS.GetContainerCgroupPath(info.Pid, "memory")
 	c.cgroupCPUAcct, _ = global.SYS.GetContainerCgroupPath(info.Pid, "cpuacct")
 	c.upperDir, c.rootFs, _ = lookupContainerLayerPath(c.pid, c.id)

--- a/agent/timer.go
+++ b/agent/timer.go
@@ -224,9 +224,20 @@ func updateAgentStats(cpuSystem uint64) {
 
 func updateContainerStats(cpuSystem uint64) {
 	for _, c := range gInfo.activeContainers {
-		mem, _ := global.SYS.GetContainerMemoryUsage(c.cgroupMemory)
-		cpu, _ := global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct)
-		system.UpdateStats(&c.stats, mem, cpu, cpuSystem)
+		var uc, um uint64
+
+		// If path isn't set, we're not going to bother.
+		if c.cgroupMemory == "" || c.cgroupCPUAcct == "" {
+			return
+		}
+		if mem, err := global.SYS.GetContainerMemoryUsage(c.cgroupMemory); err == nil {
+			um = mem
+		}
+		if cpu, err := global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct); err == nil {
+			uc = cpu
+		}
+
+		system.UpdateStats(&c.stats, um, uc, cpuSystem)
 	}
 }
 

--- a/share/system/system_test.go
+++ b/share/system/system_test.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,32 +42,4 @@ func TestCgroupSelector(t *testing.T) {
 	assert.Equal(t,
 		"/host/cgroup/memory",
 		sys.cgroupMemoryDir, "For unsupported, we should default to v1")
-}
-
-func TestCgroupVersion(t *testing.T) {
-
-	var sys SystemTools
-	// When we upgrade golang, use TempDir
-	//sys.cgroupDir = T.TempDir()
-	sys.cgroupDir = "/tmp"
-	tmpcontrollerpath := "/tmp/cgroup.controllers"
-	// Make sure there isn't one here
-	os.Remove(tmpcontrollerpath) // Best effort
-
-	// Test v1
-	version := sys.DetermineCgroupVersion()
-	assert.Equal(t, cgroup_v1, version, "Should be cgroup v1")
-
-	// Test V2
-	cgroupcontroller := tmpcontrollerpath
-	fp, err := os.Create(cgroupcontroller)
-	if err != nil {
-		t.Fatalf("Could not create tmp file for testing: %s", err.Error())
-	}
-	fp.Close() // We don't need
-
-	version2 := sys.DetermineCgroupVersion()
-	assert.Equal(t, cgroup_v2, version2, "Should be cgroup v1")
-
-	os.Remove(tmpcontrollerpath) // best effort
 }

--- a/share/system/system_test.go
+++ b/share/system/system_test.go
@@ -1,7 +1,10 @@
 package system
 
 import (
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseSharedNetNS(t *testing.T) {
@@ -10,4 +13,62 @@ func TestParseSharedNetNS(t *testing.T) {
 	if pid != 11217 {
 		t.Errorf("Incorrect pid: %v\n", pid)
 	}
+}
+
+func TestCgroupSelector(t *testing.T) {
+
+	var sys SystemTools
+
+	sys.cgroupVersion = -1
+	sys.cgroupDir = "/host/cgroup"
+	sys.cgroupMemoryDir = "/"
+	sys.SetCgroupInfo(cgroup_v1)
+	assert.Equal(t,
+		"/host/cgroup/memory",
+		sys.cgroupMemoryDir, "For v1, we should use the memory directory")
+
+	sys.cgroupVersion = -1
+	sys.cgroupDir = "/host/cgroup"
+	sys.cgroupMemoryDir = "/"
+	sys.SetCgroupInfo(cgroup_v2)
+	assert.Equal(t,
+		"/host/cgroup",
+		sys.cgroupMemoryDir, "For v2, we should use the base directory")
+
+
+	sys.cgroupVersion = -1
+	sys.cgroupDir = "/host/cgroup"
+	sys.cgroupMemoryDir = "/"
+	sys.SetCgroupInfo(-1)
+	assert.Equal(t,
+		"/host/cgroup/memory",
+		sys.cgroupMemoryDir, "For unsupported, we should default to v1")
+}
+
+func TestCgroupVersion(t *testing.T) {
+
+	var sys SystemTools
+	// When we upgrade golang, use TempDir
+	//sys.cgroupDir = T.TempDir()
+	sys.cgroupDir = "/tmp"
+	tmpcontrollerpath := "/tmp/cgroup.controllers"
+	// Make sure there isn't one here
+	os.Remove(tmpcontrollerpath) // Best effort
+
+	// Test v1
+	version := sys.DetermineCgroupVersion()
+	assert.Equal(t, cgroup_v1, version, "Should be cgroup v1")
+
+	// Test V2
+	cgroupcontroller := tmpcontrollerpath
+	fp, err := os.Create(cgroupcontroller)
+	if err != nil {
+		t.Fatalf("Could not create tmp file for testing: %s", err.Error())
+	}
+	fp.Close() // We don't need
+
+	version2 := sys.DetermineCgroupVersion()
+	assert.Equal(t, cgroup_v2, version2, "Should be cgroup v1")
+
+	os.Remove(tmpcontrollerpath) // best effort
 }


### PR DESCRIPTION
Also fixes NVSHAS-7990 (probably other cgroup problems).

7990 reported error in accessing the cgroup container metrics. When I debugged the containers, the metrics were located in /host/cgroup and not in /sys/fs/cgroup. The /sys/fs/cgroup path was local to the container and not of the host so none of the paths resolved. Many places were hardcoded to use the enforcer's container's paths instead of the host mounted ones and this could cause a mismatch in information.

In 7925 - The issue was that the metrics didn't make sense in the UI. The "deployment' tab would show some vague metrics that I couldn't correlate and the container tab would sometimes show the correct values.

The issue here was the pod holders (the container that start the /pause task) would start up and the engine would seem to grab the wrong container ID. As well, the containers looked like it would fallback silently which would assume the enforcer's metrics.

This PR covers these two problems and possible future ones.

At startup, I updated the cgroup version decision making tree to make it testable.
NewSystemtools() does not change behaviour, it retains its original behaviour. It has been re-organized so its easier to test and with the start up fixes.
When a container is added, it will follow a different flow than before. It is simplified now
We now use the systemtool's proc path (which ideally will be /host/proc) to get a PID's information
Changed how we parse the cgroup file in the proc directory. Before it assumed a single type of system but I added, hopefully, more robust handlers.
It will check for the subsystem in the cgroup file. If the subsystem isn't in the file, it means the subsystem is not active (either host doesn't have it turned on or the distribution does not support it)
It will clean the paths in the cgroup file and fix the mapping if needed. I found issues with docker k8s where the paths were relative but it made no sense. I haven't found documentation why this is the case yet.
It will apply the correct v2 and v1 qualifiers to the cgroup path and then use the discovered cgroup path at startup. Ideally it will be /host/cgroup which should be a mirror of the host' /sys/fs/cgroup.
cgroup v2 hybrid is not supported. The one setup that I have (ubuntu 18.04) that does support cgroup v2 hybrid doesn't support all the subsystems in v2 mode. So rather than have more logic to deal with hybrid mode, I made it so we just assume cgroup v2 pure or v1 "pure". I did add logic to deal with it but it almost always fallbacks to v1 mode so its probably easier to just avoid it.
The previous fixes were trying to fix why /sys/fs/cgroup was not resolving correctly which was a red herring. IMO the root cause was actually because we were using the container's cgroup directory and not the host's.

I added a bunch of unit tests to cover the the different types of cgroup files that may exist. It is not exhaustive and will require more expamples.

PR was tested against

Ubuntu 18.04 Docker all in one:

 Cgroup Driver: cgroupfs
 Cgroup Version: 1
 Runtimes: runc io.containerd.runc.v2
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 3dce8eb055cbb6872793272b4f20ed16117344f8
 runc version: v1.1.7-0-g860f061
 init version: de40ad0
Ubuntu 23.04 Docker k8s (this one reliably reproduces the bug for 7925)

 Cgroup Driver: systemd
 Cgroup Version: 2
 Runtimes: io.containerd.runc.v2 runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 3dce8eb055cbb6872793272b4f20ed16117344f8
 runc version: v1.1.7-0-g860f061
AWS EKS (this one had the 7990 bug)
k8s=1.26.6-eks-a5565ad 

Currently being tested on another AWS cluster (I don't have the details yet on it).