### PR TITLE
NVSHAS 7790 and 7925 - Fixes to CPU/Memory stat files not found

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1208,6 +1208,16 @@ func fillContainerProperties(c *containerData, parent *containerData,
 	}
 	c.cgroupMemory, _ = global.SYS.GetContainerCgroupPath(info.Pid, "memory")
 	c.cgroupCPUAcct, _ = global.SYS.GetContainerCgroupPath(info.Pid, "cpuacct")
+
+	if _, err := global.SYS.GetContainerMemoryUsage(c.cgroupMemory); err != nil {
+		log.WithFields(log.Fields{"cgroupMemory": c.cgroupMemory, "pid": c.pid, "id": c.id, "error": err}).Warning("Could not get memory stats.")
+		c.cgroupMemory = ""
+
+	}
+	if _, err := global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct); err != nil {
+		log.WithFields(log.Fields{"cgroupMemory": c.cgroupCPUAcct, "pid": c.pid, "id": c.id, "error": err}).Warning("Could not get CPU stats.")
+		c.cgroupCPUAcct = ""
+	}
 	c.upperDir, c.rootFs, _ = lookupContainerLayerPath(c.pid, c.id)
 	c.propertyFilled = true
 	log.WithFields(log.Fields{"uppDir": c.upperDir, "rootFs": c.rootFs, "id": c.id}).Debug()

--- a/agent/timer.go
+++ b/agent/timer.go
@@ -226,13 +226,19 @@ func updateContainerStats(cpuSystem uint64) {
 	for _, c := range gInfo.activeContainers {
 		var mem, cpu uint64 = 0, 0
 		var err error
-		mem, err = global.SYS.GetContainerMemoryUsage(c.cgroupMemory)
-		if err != nil {
-			log.WithFields(log.Fields{"pid": c.pid, "id": c.id, "error": err}).Warning("Memory stats not found")
+		if c.cgroupMemory != "" {
+			mem, err = global.SYS.GetContainerMemoryUsage(c.cgroupMemory)
+			if err != nil && c.parentNS != "" {
+				// Ignore if pod holder
+				log.WithFields(log.Fields{"pid": c.pid, "id": c.id, "error": err}).Warning("Memory stats not found")
+			}
 		}
-		cpu, err = global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct)
-		if err != nil {
-			log.WithFields(log.Fields{"pid": c.pid, "id": c.id, "error": err}).Warning("CPU stats not found")
+		if c.cgroupCPUAcct != "" {
+			cpu, err = global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct)
+			if err != nil && c.parentNS != "" {
+				// Ignore if pod holder
+				log.WithFields(log.Fields{"pid": c.pid, "id": c.id, "error": err}).Warning("CPU stats not found")
+			}
 		}
 		system.UpdateStats(&c.stats, mem, cpu, cpuSystem)
 	}

--- a/agent/timer.go
+++ b/agent/timer.go
@@ -224,8 +224,16 @@ func updateAgentStats(cpuSystem uint64) {
 
 func updateContainerStats(cpuSystem uint64) {
 	for _, c := range gInfo.activeContainers {
-		mem, _ := global.SYS.GetContainerMemoryUsage(c.cgroupMemory)
-		cpu, _ := global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct)
+		var mem, cpu uint64 = 0, 0
+		var err error
+		mem, err = global.SYS.GetContainerMemoryUsage(c.cgroupMemory)
+		if err != nil {
+			log.WithFields(log.Fields{"pid": c.pid, "id": c.id, "error": err}).Warning("Memory stats not found")
+		}
+		cpu, err = global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct)
+		if err != nil {
+			log.WithFields(log.Fields{"pid": c.pid, "id": c.id, "error": err}).Warning("CPU stats not found")
+		}
 		system.UpdateStats(&c.stats, mem, cpu, cpuSystem)
 	}
 }

--- a/share/system/cgroup_linux.go
+++ b/share/system/cgroup_linux.go
@@ -521,8 +521,8 @@ func (s *SystemTools) getMemoryStats(path string, mStats *CgroupMemoryStats, bFu
 	statsFile, err := os.Open(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.WithFields(log.Fields{"filePath": filePath, "systemtools": *s, "error": err}).Error("Could not find memory stats file")
-			return nil
+			message := log.WithFields(log.Fields{"filePath": filePath, "systemtools": *s, "error": err}).Message
+			return fmt.Errorf(message)
 		}
 		return err
 	}

--- a/share/system/cgroup_test.go
+++ b/share/system/cgroup_test.go
@@ -1060,7 +1060,7 @@ func TestDockerK8s_CPath_Container_Cgroupv2(t *testing.T) {
 	`
 	r := strings.NewReader(cgroup)
 	path := getCgroupPathReaderV2(r) // it is not inside the container
-	if path != "/sys/fs/cgroup" {
+	if path != "/sys/fs/cgroup/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podfd698699_eabf_4c23_92ef_cf0bbdb78261.slice/docker-2cc65c162ca1388b6b8d5ccfb701d22fc96675ccf8b2f1590c490c2c4039547f.scope" {
 		t.Errorf("incorrect cgroup path: %v\n", path)
 	}
 }


### PR DESCRIPTION
    Changed updateContainerStats() to deal with errors.
    There is a check if the container is a pod holder as those errors are
    valid under certain OS.
    Added error handling when we first register a container in
    fillContainerProperties(). If the cgroup files fail to load, we blank
    out the path and never process it again. This should silence the errors
    in the logs with at least one message instead of a flood of them.

