### PR TITLE
NVSHAS 7990 & 7925 - cgroup error log fixes

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1206,8 +1206,19 @@ func fillContainerProperties(c *containerData, parent *containerData,
 			parent.hasDatapath = false
 		}
 	}
-	c.cgroupMemory, _ = global.SYS.GetContainerCgroupPath(info.Pid, "memory")
-	c.cgroupCPUAcct, _ = global.SYS.GetContainerCgroupPath(info.Pid, "cpuacct")
+	var err error
+	c.cgroupMemory, err = global.SYS.GetContainerCgroupPath(info.Pid, "memory")
+	if err != nil {
+		log.WithFields(log.Fields{"cgroupMemory": c.cgroupMemory, "pid": c.pid, "id": c.id, "error": err}).Warning("Could not get memory stats.")
+	}
+
+	c.cgroupCPUAcct, err = global.SYS.GetContainerCgroupPath(info.Pid, "cpuacct")
+	if err != nil {
+		log.WithFields(log.Fields{"cgroupCPUAcct": c.cgroupCPUAcct, "pid": c.pid, "id": c.id, "error": err}).Warning("Could not get CPU stats.")
+	}
+
+	log.WithFields(log.Fields{"cgroupMemory": c.cgroupMemory, "cgroupCPUAcct": c.cgroupCPUAcct, "pid": c.pid, "id": c.id, "name": c.name}).Debug("cgroup paths are set.")
+
 	c.upperDir, c.rootFs, _ = lookupContainerLayerPath(c.pid, c.id)
 	c.propertyFilled = true
 	log.WithFields(log.Fields{"uppDir": c.upperDir, "rootFs": c.rootFs, "id": c.id}).Debug()

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1217,8 +1217,6 @@ func fillContainerProperties(c *containerData, parent *containerData,
 		log.WithFields(log.Fields{"cgroupCPUAcct": c.cgroupCPUAcct, "pid": c.pid, "id": c.id, "error": err}).Warning("Could not get CPU stats.")
 	}
 
-	log.WithFields(log.Fields{"cgroupMemory": c.cgroupMemory, "cgroupCPUAcct": c.cgroupCPUAcct, "pid": c.pid, "id": c.id, "name": c.name}).Debug("cgroup paths are set.")
-
 	c.upperDir, c.rootFs, _ = lookupContainerLayerPath(c.pid, c.id)
 	c.propertyFilled = true
 	log.WithFields(log.Fields{"uppDir": c.upperDir, "rootFs": c.rootFs, "id": c.id}).Debug()

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1206,16 +1206,9 @@ func fillContainerProperties(c *containerData, parent *containerData,
 			parent.hasDatapath = false
 		}
 	}
-	var err error
-	c.cgroupMemory, err = global.SYS.GetContainerCgroupPath(info.Pid, "memory")
-	if err != nil {
-		log.WithFields(log.Fields{"cgroupMemory": c.cgroupMemory, "pid": c.pid, "id": c.id, "error": err}).Warning("Could not get memory stats.")
-	}
 
-	c.cgroupCPUAcct, err = global.SYS.GetContainerCgroupPath(info.Pid, "cpuacct")
-	if err != nil {
-		log.WithFields(log.Fields{"cgroupCPUAcct": c.cgroupCPUAcct, "pid": c.pid, "id": c.id, "error": err}).Warning("Could not get CPU stats.")
-	}
+	c.cgroupMemory, _ = global.SYS.GetContainerCgroupPath(info.Pid, "memory")
+	c.cgroupCPUAcct, _ = global.SYS.GetContainerCgroupPath(info.Pid, "cpuacct")
 
 	c.upperDir, c.rootFs, _ = lookupContainerLayerPath(c.pid, c.id)
 	c.propertyFilled = true

--- a/agent/timer.go
+++ b/agent/timer.go
@@ -229,8 +229,22 @@ func updateAgentStats(cpuSystem uint64) {
 
 func updateContainerStats(cpuSystem uint64) {
 	for _, c := range gInfo.activeContainers {
-		mem, _ := global.SYS.GetContainerMemoryUsage(c.cgroupMemory)
-		cpu, _ := global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct)
+		var mem, cpu uint64 = 0, 0
+		var err error
+
+		if c.cgroupMemory != "" {
+			mem, err = global.SYS.GetContainerMemoryUsage(c.cgroupMemory)
+			if err != nil {
+				log.WithFields(log.Fields{"pid": c.pid, "id": c.id, "cgroupMemory": c.cgroupMemory, "error": err}).Warning("Memory stats not found")
+			}
+		}
+		if c.cgroupCPUAcct != "" {
+			cpu, err = global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct)
+			if err != nil {
+				log.WithFields(log.Fields{"pid": c.pid, "id": c.id, "cgroupCPUAcct": c.cgroupCPUAcct, "error": err}).Warning("CPU stats not found")
+			}
+		}
+
 		system.UpdateStats(&c.stats, mem, cpu, cpuSystem)
 	}
 }

--- a/agent/timer.go
+++ b/agent/timer.go
@@ -230,19 +230,12 @@ func updateAgentStats(cpuSystem uint64) {
 func updateContainerStats(cpuSystem uint64) {
 	for _, c := range gInfo.activeContainers {
 		var mem, cpu uint64 = 0, 0
-		var err error
 
 		if c.cgroupMemory != "" {
-			mem, err = global.SYS.GetContainerMemoryUsage(c.cgroupMemory)
-			if err != nil {
-				log.WithFields(log.Fields{"pid": c.pid, "id": c.id, "cgroupMemory": c.cgroupMemory, "error": err}).Warning("Memory stats not found")
-			}
+			mem, _ = global.SYS.GetContainerMemoryUsage(c.cgroupMemory)
 		}
 		if c.cgroupCPUAcct != "" {
-			cpu, err = global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct)
-			if err != nil {
-				log.WithFields(log.Fields{"pid": c.pid, "id": c.id, "cgroupCPUAcct": c.cgroupCPUAcct, "error": err}).Warning("CPU stats not found")
-			}
+			cpu, _ = global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct)
 		}
 
 		system.UpdateStats(&c.stats, mem, cpu, cpuSystem)

--- a/share/system/cgroup_linux.go
+++ b/share/system/cgroup_linux.go
@@ -383,8 +383,10 @@ func (s *SystemTools) GetContainerCgroupPath(pid int, subsystem string) (string,
 			return "", err
 		}
 		if cpathv2 == "" {
-			return "", fmt.Errorf("cgroup file does not have valid cgroup paths")
+			// path wasn't parsed, so we'll default to v1 style for best effort
+			cpathv2 = filepath.Join(s.procDir, strconv.Itoa(pid), "root/sys/fs/cgroup")
 		}
+		// Now verify and return
 		return s.VerifyContainerCgroupPath(cpathv2, subsystem)
 	}
 

--- a/share/system/cgroup_linux.go
+++ b/share/system/cgroup_linux.go
@@ -379,10 +379,7 @@ func (s *SystemTools) GetContainerCgroupPath(pid int, subsystem string) (string,
 	case cgroup_v2:
 		// unified file structure
 		cpathv2, err := getCgroupPath_cgroup_v2(pid)
-		if err != nil {
-			return "", err
-		}
-		if cpathv2 == "" {
+		if err != nil || cpathv2 == "" {
 			// path wasn't parsed, so we'll default to v1 style for best effort
 			cpathv2 = filepath.Join(s.procDir, strconv.Itoa(pid), "root/sys/fs/cgroup")
 		}

--- a/share/system/cgroup_linux.go
+++ b/share/system/cgroup_linux.go
@@ -307,7 +307,7 @@ func getCgroupPathReaderV2(file io.ReadSeeker) string {
 			}
 		}
 	}
-	return "/sys/fs/cgroup"
+	return ""
 }
 
 // cgroup v2 is collected inside an unified file folder
@@ -332,6 +332,30 @@ func getCgroupPath_cgroup_v2(pid int) (string, error) {
 
 }
 
+// VerifyContainerCgroupPath - Checks if a cgroup path for a subsystem is valid
+// We only support checking "memory" and "cpuacct" cgroup subsystems.
+// If not valid, return empty string to avoid getting stats for it.
+func (s *SystemTools) VerifyContainerCgroupPath(path string, subsystem string) (string, error) {
+	switch subsystem {
+	case "memory":
+		if _, err := s.GetContainerMemoryUsage(path); err != nil {
+			return "", err
+		}
+	case "cpuacct":
+		if _, err := s.GetContainerCPUUsage(path); err != nil {
+			return "", err
+		}
+	default:
+		// For everything else, just check if the directory/file exists
+		if _, err := os.Stat(path); err != nil {
+			return "", err
+		}
+	}
+
+	// No issues with paths, we can continue
+	return path, nil
+}
+
 func (s *SystemTools) GetContainerCgroupPath(pid int, subsystem string) (string, error) {
 	/*
 		mnt, err := FindCgroupMountpoint(subsystem)
@@ -350,11 +374,18 @@ func (s *SystemTools) GetContainerCgroupPath(pid int, subsystem string) (string,
 		} else {
 			path = filepath.Join(s.procDir, strconv.Itoa(pid), "root/sys/fs/cgroup", subsystem)
 		}
-		return path, nil
+		return s.VerifyContainerCgroupPath(path, subsystem)
 
 	case cgroup_v2:
 		// unified file structure
-		return getCgroupPath_cgroup_v2(pid)
+		cpathv2, err := getCgroupPath_cgroup_v2(pid)
+		if err != nil {
+			return "", err
+		}
+		if cpathv2 == "" {
+			return "", fmt.Errorf("cgroup file does not have valid cgroup paths")
+		}
+		return s.VerifyContainerCgroupPath(cpathv2, subsystem)
 	}
 
 	// However, the k8s POD does not have those subsystem folders
@@ -516,14 +547,15 @@ func getMemoryData(path, name string) (MemoryData, error) {
 
 //
 func (s *SystemTools) getMemoryStats(path string, mStats *CgroupMemoryStats, bFullSet bool) error {
+
+	if path == "" {
+		return fmt.Errorf("empty path not supported")
+	}
+
 	// Set stats from memory.stat.
 	filePath := filepath.Join(path, "memory.stat")
 	statsFile, err := os.Open(filePath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			log.WithFields(log.Fields{"filePath": filePath, "systemtools": *s, "error": err}).Error("Could not find memory stats file")
-			return nil
-		}
 		return err
 	}
 	defer statsFile.Close()
@@ -595,6 +627,9 @@ func (s *SystemTools) getMemoryStats(path string, mStats *CgroupMemoryStats, bFu
 
 // https://github.com/opencontainers/runc/blob/master/libcontainer/cgroups/fs2/cpu.go
 func (s *SystemTools) statCpu(path string, stats *CpuStats) error {
+	if path == "" {
+		return fmt.Errorf("empty path not supported")
+	}
 	f, err := os.Open(filepath.Join(path, "cpu.stat"))
 	if err != nil {
 		return err

--- a/share/system/cgroup_test.go
+++ b/share/system/cgroup_test.go
@@ -1046,7 +1046,7 @@ func TestDockerK8s_CPath_SelfProbe_Cgroupv2(t *testing.T) {
 	`
 	r := strings.NewReader(cgroup)
 	path := getCgroupPathReaderV2(r)
-	if path != "/sys/fs/cgroup" {
+	if path != "" {
 		t.Errorf("incorrect cgroup path: %v\n", path)
 	}
 }
@@ -1060,7 +1060,7 @@ func TestDockerK8s_CPath_Container_Cgroupv2(t *testing.T) {
 	`
 	r := strings.NewReader(cgroup)
 	path := getCgroupPathReaderV2(r) // it is not inside the container
-	if path != "/sys/fs/cgroup" {
+	if path != "" {
 		t.Errorf("incorrect cgroup path: %v\n", path)
 	}
 }


### PR DESCRIPTION
Changed getMemoryStats() to return an error for no files found.

Changed updateContainerStats() to deal with errors. There is a check if the container is a pod holder as those errors are valid under certain OS.
Added error handling when we first register a container in fillContainerProperties(). If the cgroup files fail to load, we blank out the path and never process it again. This should silence the errors in the logs with at least one message.