### PR TITLE
Nvshas 7990 7925 fixes w fallback

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1209,24 +1209,27 @@ func fillContainerProperties(c *containerData, parent *containerData,
 	c.cgroupMemory, _ = global.SYS.GetContainerCgroupPath(info.Pid, "memory")
 	c.cgroupCPUAcct, _ = global.SYS.GetContainerCgroupPath(info.Pid, "cpuacct")
 
+	// Check if the memory path is valid
 	if _, err := global.SYS.GetContainerMemoryUsage(c.cgroupMemory); err != nil {
 		log.WithFields(log.Fields{"cgroupMemory": c.cgroupMemory, "pid": c.pid, "id": c.id, "error": err}).Warning("Could not get memory stats.")
 		c.cgroupMemory, _ = global.SYS.FallbackContainerStatsPaths(info.Pid, "memory")
 
-		// Try the fallback
+		// Try the fallback for memory
 		if _, err := global.SYS.GetContainerMemoryUsage(c.cgroupMemory); err != nil {
 			log.WithFields(log.Fields{"cgroupMemory": c.cgroupMemory, "pid": c.pid, "id": c.id, "error": err}).Warning("Could not get memory stats using fallback.")
-			c.cgroupMemory = ""
+			c.cgroupMemory = "" // fallback to empty
 		}
 	}
+
+	// Check if the cpu path is valid
 	if _, err := global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct); err != nil {
 		log.WithFields(log.Fields{"cgroupCPUAcct": c.cgroupCPUAcct, "pid": c.pid, "id": c.id, "error": err}).Warning("Could not get CPU stats.")
 		c.cgroupCPUAcct, _ = global.SYS.FallbackContainerStatsPaths(info.Pid, "cpuacct")
 
-		// Try the fallback
+		// Try the fallback for cpu
 		if _, err := global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct); err != nil {
 			log.WithFields(log.Fields{"cgroupCPUAcct": c.cgroupCPUAcct, "pid": c.pid, "id": c.id, "error": err}).Warning("Could not get CPU stats using fallback.")
-			c.cgroupCPUAcct = ""
+			c.cgroupCPUAcct = "" // fallback to empty
 		}
 	}
 	log.WithFields(log.Fields{"pid": info.Pid, "cgroupMemory": c.cgroupMemory, "c.cgroupCPUAcct": c.cgroupCPUAcct}).Debug("Cgroup path is complete")

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1208,6 +1208,18 @@ func fillContainerProperties(c *containerData, parent *containerData,
 	}
 	c.cgroupMemory, _ = global.SYS.GetContainerCgroupPath(info.Pid, "memory")
 	c.cgroupCPUAcct, _ = global.SYS.GetContainerCgroupPath(info.Pid, "cpuacct")
+
+	if _, err := global.SYS.GetContainerMemoryUsage(c.cgroupMemory); err != nil {
+		log.WithFields(log.Fields{"cgroupMemory": c.cgroupMemory, "pid": c.pid, "id": c.id, "error": err}).Warning("Could not get memory stats.")
+
+		c.cgroupMemory = ""
+
+	}
+	if _, err := global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct); err != nil {
+		log.WithFields(log.Fields{"cgroupMemory": c.cgroupCPUAcct, "pid": c.pid, "id": c.id, "error": err}).Warning("Could not get CPU stats.")
+		c.cgroupCPUAcct = ""
+	}
+
 	c.upperDir, c.rootFs, _ = lookupContainerLayerPath(c.pid, c.id)
 	c.propertyFilled = true
 	log.WithFields(log.Fields{"uppDir": c.upperDir, "rootFs": c.rootFs, "id": c.id}).Debug()
@@ -1663,7 +1675,6 @@ func startNeuVectorMonitors(id, role string, info *container.ContainerMetaExtra)
 		// process killer per policy: removed by evaluating other same-kind instances
 		// since the same policy might be shared by several same-kind instances in a node
 		pe.InsertNeuvectorProcessProfilePolicy(group, role)
-
 
 		// process blocker per container: can be removed by its container id
 		// applyProcessProfilePolicy(c, group)

--- a/agent/timer.go
+++ b/agent/timer.go
@@ -229,8 +229,22 @@ func updateAgentStats(cpuSystem uint64) {
 
 func updateContainerStats(cpuSystem uint64) {
 	for _, c := range gInfo.activeContainers {
-		mem, _ := global.SYS.GetContainerMemoryUsage(c.cgroupMemory)
-		cpu, _ := global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct)
+		var mem, cpu uint64 = 0, 0
+		var err error
+
+		if c.cgroupMemory != "" {
+			mem, err = global.SYS.GetContainerMemoryUsage(c.cgroupMemory)
+			if err != nil {
+				log.WithFields(log.Fields{"pid": c.pid, "id": c.id, "error": err}).Warning("Memory stats not found")
+			}
+		}
+		if c.cgroupCPUAcct != "" {
+			cpu, err = global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct)
+			if err != nil {
+				log.WithFields(log.Fields{"pid": c.pid, "id": c.id, "error": err}).Warning("CPU stats not found")
+			}
+		}
+
 		system.UpdateStats(&c.stats, mem, cpu, cpuSystem)
 	}
 }

--- a/share/system/cgroup_linux.go
+++ b/share/system/cgroup_linux.go
@@ -307,7 +307,7 @@ func getCgroupPathReaderV2(file io.ReadSeeker) string {
 			}
 		}
 	}
-	return "/sys/fs/cgroup"
+	return ""
 }
 
 // cgroup v2 is collected inside an unified file folder
@@ -321,10 +321,10 @@ func getCgroupPath_cgroup_v2(pid int) (string, error) {
 
 	f, err := os.Open(path)
 	if err != nil {
-		log.WithFields(log.Fields{"path": path, "err": err}).Warning("cgroup cannot be read, stats cannot be found")
-		return "", err
+		message := log.WithFields(log.Fields{"path": path, "pid": pid, "error": err}).Message
+		return message, nil
 	}
-	defer 	f.Close()
+	defer f.Close()
 
 	cpath := getCgroupPathReaderV2(f)
 
@@ -516,6 +516,11 @@ func getMemoryData(path, name string) (MemoryData, error) {
 
 //
 func (s *SystemTools) getMemoryStats(path string, mStats *CgroupMemoryStats, bFullSet bool) error {
+
+	if path == "" {
+		return nil
+	}
+
 	// Set stats from memory.stat.
 	filePath := filepath.Join(path, "memory.stat")
 	statsFile, err := os.Open(filePath)

--- a/share/system/cgroup_test.go
+++ b/share/system/cgroup_test.go
@@ -1046,7 +1046,7 @@ func TestDockerK8s_CPath_SelfProbe_Cgroupv2(t *testing.T) {
 	`
 	r := strings.NewReader(cgroup)
 	path := getCgroupPathReaderV2(r)
-	if path != "/sys/fs/cgroup" {
+	if path != "" {
 		t.Errorf("incorrect cgroup path: %v\n", path)
 	}
 }
@@ -1060,7 +1060,7 @@ func TestDockerK8s_CPath_Container_Cgroupv2(t *testing.T) {
 	`
 	r := strings.NewReader(cgroup)
 	path := getCgroupPathReaderV2(r) // it is not inside the container
-	if path != "/sys/fs/cgroup" {
+	if path != "" {
 		t.Errorf("incorrect cgroup path: %v\n", path)
 	}
 }

--- a/share/system/cgroup_test.go
+++ b/share/system/cgroup_test.go
@@ -1,7 +1,9 @@
 package system
 
 import (
+	"github.com/stretchr/testify/assert"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -1471,5 +1473,234 @@ func TestContainerd_Container_Cgroupv2(t *testing.T) {
 	id, _, found = getContainerIDByCgroupReaderV2(r, from_hostname)
 	if id != "f34e6ab6ed679d809c8d4a385777c4f72441f1d3ec7b1334d35c10f4d25e6f40" || !found { // pod ID
 		t.Errorf("detect wrong pod ID, cgroup:  %v, %v\n", id, found)
+	}
+}
+
+
+
+type cgroupTestCase struct {
+	name string
+	contents string
+	subsystem string
+	errIsNil bool
+	expected string
+}
+
+func CgroupFileTestTemplate(t *testing.T, testcase cgroupTestCase) {
+
+	s := SystemTools{}
+	s.cgroupVersion = cgroup_v1
+	r := strings.NewReader(testcase.contents)
+	path, err := s.parseFallbackProcCgroupFileStats(r, 42, testcase.subsystem)
+	if testcase.errIsNil {
+		assert.Nil(t, err, "cgroup_v1 %s should have no errors", testcase.name)
+	} else {
+		assert.NotNil(t, err, "cgroup_v1 %s should have errors", testcase.name)
+	}
+
+	if testcase.expected != "" {
+		expected := filepath.Join("/proc/1/root/sys/fs/cgroup", testcase.subsystem, testcase.expected)
+		assert.Equal(t, expected,
+			path, "Path is wrong")
+	}
+
+	s.cgroupVersion = cgroup_v2
+	r = strings.NewReader(testcase.contents)
+	path, err = s.parseFallbackProcCgroupFileStats(r, 42, testcase.subsystem)
+	if testcase.errIsNil {
+		assert.Nil(t, err, "cgroup_v2 %s should have no errors", testcase.name)
+	} else {
+		assert.NotNil(t, err, "cgroup_v2 %s should have errors", testcase.name)
+	}
+
+	if testcase.expected != "" {
+		expected := filepath.Join("/proc/1/root/sys/fs/cgroup", testcase.expected)
+		assert.Equal(t, expected,
+			path, "Path is wrong")
+	}
+
+}
+
+
+func TestParseFallbackProcCgroupFileStats(t *testing.T) {
+	// Test multiple variants on distributions. Not standardized
+	/*
+		In the case of cgroups v1, as the maintainer Tejun Heo admits,
+		"design followed implementation,"
+		"different decisions were taken for different controllers,"
+		and "sometimes too much flexibility causes a hindrance."
+		https://www.redhat.com/en/blog/world-domination-cgroups-rhel-8-welcome-cgroups-v2
+	*/
+
+	ubuntu18_04 := `12:hugetlb:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+11:cpuset:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+10:net_cls,net_prio:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+9:perf_event:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+8:pids:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+7:cpu,cpuacct:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+6:freezer:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+5:blkio:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+4:rdma:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+3:memory:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+2:devices:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+1:name=systemd:/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce
+0::/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce`
+
+	debian := `10:net_prio:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+9:perf_event:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+8:blkio:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+7:net_cls:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+6:freezer:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+5:devices:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+4:memory:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+3:cpuacct:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+2:cpu:/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970
+`
+
+	centos := `10:devices:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+9:blkio:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+8:memory:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+7:freezer:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+6:perf_event:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+5:hugetlb:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+4:net_cls:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+3:cpuset:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+2:cpuacct,cpu:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+1:name=systemd:/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope
+`
+
+	rancher := `9:name=systemd:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+8:memory:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+7:blkio:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+6:cpu,cpuacct:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+5:cpuset:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+4:perf_event:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+3:net_cls,net_prio:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+2:freezer:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+1:devices:/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a
+`
+
+	kubepods := `11:devices:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+10:memory:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+9:hugetlb:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+8:perf_event:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+7:freezer:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+6:pids:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+5:cpu,cpuacct:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+4:cpuset:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+3:blkio:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+2:net_cls,net_prio:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c
+1:name=systemd:/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c`
+
+	kubepods2 := `
+11:cpuset:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+10:blkio:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+9:devices:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+8:memory:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+7:freezer:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+6:perf_event:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+5:net_prio,net_cls:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+4:hugetlb:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+3:pids:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+2:cpuacct,cpu:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope
+1:name=systemd:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope`
+
+	kubepod3 := `8:pids:/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d
+7:blkio:/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d
+6:perf_event:/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d
+5:devices:/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d
+4:freezer:/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d
+3:rdma:/
+2:cpuset,cpu,cpuacct,memory,net_cls,net_prio,hugetlb:/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d
+1:name=systemd:/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d`
+
+	hostCgroup := `
+14:name=dsystemd:/
+13:name=systemd:/
+12:pids:/
+11:hugetlb:/
+10:net_prio:/
+9:perf_event:/
+8:net_cls:/
+7:freezer:/
+6:devices:/
+5:memory:/
+4:blkio:/
+3:cpuacct:/
+2:cpu:/
+1:cpuset:/`
+
+	dockerK8sBestEffort := `0::/../../kubepods-besteffort-poddee9029c_408f_4466_811d_43eea3042395.slice/docker-a737350ff4843bb79debc4e2dc98f0b1b11d40f814ea4303d9167dd70c314b95.scope`
+	dockerK8sBurstable := `0::/../../../kubepods-burstable.slice/kubepods-burstable-pode78d192d_934f_475f_af41_6fe274868dcc.slice/docker-102b2be2d2d712ee08c202e70d1372892f3c20d14771ffa006f7f8c41a30fcc1.scope`
+
+	hostCgroupSingleSlash := `0::/`
+	hostCgroupEmpty := ``
+
+	tests := []cgroupTestCase{
+		// ubunu 18.04
+		{"ubuntu18_04", ubuntu18_04, "memory", true,
+			"/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce"},
+		{"ubuntu18_04", ubuntu18_04, "cpuacct", true,
+			"/docker/b5827d5acf95f5b286ae4aa28718162a3ed2152e7f4d4048dc9d2456540c11ce"},
+		// Debian
+		{"debian", debian, "memory", true,
+			"/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970"},
+		{"debian", debian, "cpuacct", true,
+			"/4f797c539e6c745de61a93ca3ff892358ecbcaccd8414d5db545c38428142970"},
+		// centos
+		{"centos", centos, "memory", true,
+			"/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope"},
+		{"centos", centos, "cpuacct", true,
+			"/system.slice/docker-9ec39b91f3d70e1beff50a308f77067065ea6be0d91a3378375056cd4422cf3d.scope"},
+		// rancher
+		{"rancher", rancher, "memory", true,
+			"/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a"},
+		{"rancher", rancher, "cpuacct", true,
+			"/docker/a9a5ad238e59234193ee7ec3fcff5e735b3708ea1068826952255b69e3cfa413/docker/ec08435e04266c5ba381fccbb829f626d11d8ddf5f8f547263c7a2d79ab4787a"},
+		// kubepods
+		{"kubepods", kubepods, "memory", true,
+			"/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c"},
+		{"kubepods", kubepods, "cpuacct", true,
+			"/kubepods/besteffort/pod74ba62da-1a3d-11e7-bb11-080027cb0e22/cb1eadb7abe3a6545e9856411207073277838e1bdc003337c2f8685faeedc32c"},
+		// kubepods2
+		{"kubepods2", kubepods2, "memory", true,
+			"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope"},
+		{"kubepods2", kubepods2, "cpuacct", true,
+			"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod045b1e35_7f13_11e7_ac42_0050568ffca0.slice/docker-b5b6f2da8008be266864f896f93789762b2ce50792114a5c5f2cc3315af0bc70.scope"},
+		// kubepod3
+		{"kubepod3", kubepod3, "memory", true,
+			"/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d"},
+		{"kubepod3", kubepod3, "cpuacct", true,
+			"/kubepods/besteffort/pod1fe19bf5-e8ef-11e8-900c-52daee5a874d/da31e536c8d61304a6d5998d163d12400a7a9a1003e1d86369e8fadb022fc17d"},
+		// hostCgroup
+		{"hostCgroup", hostCgroup, "memory", true,
+			"/"},
+		{"hostCgroup", hostCgroup, "cpuacct", true,
+			"/"},
+		// dockerK8s Best effort
+		{"dockerK8s", dockerK8sBestEffort, "memory", true,
+			"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-poddee9029c_408f_4466_811d_43eea3042395.slice/docker-a737350ff4843bb79debc4e2dc98f0b1b11d40f814ea4303d9167dd70c314b95.scope"},
+		{"dockerK8s", dockerK8sBestEffort, "cpuacct", true,
+			"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-poddee9029c_408f_4466_811d_43eea3042395.slice/docker-a737350ff4843bb79debc4e2dc98f0b1b11d40f814ea4303d9167dd70c314b95.scope"},
+		// dockerK8s Burstable
+		{"dockerK8sBurstable", dockerK8sBurstable, "memory", true,
+			"/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pode78d192d_934f_475f_af41_6fe274868dcc.slice/docker-102b2be2d2d712ee08c202e70d1372892f3c20d14771ffa006f7f8c41a30fcc1.scope"},
+		{"dockerK8sBurstable", dockerK8sBurstable, "cpuacct", true,
+			"/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pode78d192d_934f_475f_af41_6fe274868dcc.slice/docker-102b2be2d2d712ee08c202e70d1372892f3c20d14771ffa006f7f8c41a30fcc1.scope"},
+		// Pid 0 Host Cgroup
+		{"hostCgroupSingleSlash", hostCgroupSingleSlash, "memory", true,
+			"/"},
+		{"hostCgroupSingleSlash", hostCgroupSingleSlash, "cpuacct", true,
+			"/"},
+			// Pid 0 Host Cgroup
+		{"hostCgroupEmpty", hostCgroupEmpty, "memory", false,
+			""},
+		{"hostCgroupEmpty", hostCgroupEmpty, "cpuacct", false,
+			""},
+	}
+
+	for _, test := range tests {
+		t.Logf("Testing %s suubsystem %s", test.name, test.subsystem)
+		CgroupFileTestTemplate(t, test)
 	}
 }


### PR DESCRIPTION
Changed getMemoryStats() to return an error for no files found.

Changed updateContainerStats() to deal with errors. There is a check if the container is a pod holder as those errors are valid under certain OS.
Added error handling when we first register a container in fillContainerProperties(). If the cgroup files fail to load, we blank out the path and never process it again. This should silence the errors in the logs with at least one message.

But the biggest change is adding a new fallback at start up. If the /sys/fs/cgroup fails to resolve, then we will attempt to use /proc/1/root/sys/fs/cgroup instead. Covers both v1 and v2. 