### PR TITLE
NVSHAS-8226, Distribute network policy to enforcer with host awareness

### DIFF
--- a/agent/cluster.go
+++ b/agent/cluster.go
@@ -802,6 +802,7 @@ func clusterLoop(existing utils.Set) {
 		// command, because they can only applied to known objects.
 		cluster.RegisterStoreWatcher(share.CLUSUniconfTargetStore(Host.ID), uniconfHandler, false)
 		cluster.RegisterStoreWatcher(share.CLUSNetworkStore, systemUpdateHandler, false)
+		cluster.RegisterStoreWatcher(share.CLUSNodeRulesKey(Host.ID), systemUpdateHandler, false)
 		cluster.RegisterStoreWatcher(share.CLUSNodeCommonProfileStore, systemUpdateHandler, agentEnv.kvCongestCtrl)
 		cluster.RegisterStoreWatcher(share.CLUSNodeProfileStoreKey(Host.ID), systemUpdateHandler, agentEnv.kvCongestCtrl)
 		cluster.RegisterStoreWatcher(share.CLUSConfigDomainStore, domainConfigUpdate, false)

--- a/controller/cache/learn.go
+++ b/controller/cache/learn.go
@@ -1258,7 +1258,13 @@ func startPolicyThread() {
 				newIPRules := calculateIPPolicyFromCache()
 				cacheMutexRUnlock()
 				policyCalculated = false
-				putPolicyIPRulesToClusterScale(newIPRules)
+				if policyApplyIngress {
+					reorgPolicyIPRulesPerNodePAI(newIPRules)
+				} else {
+					reorgPolicyIPRulesPerNode(newIPRules)
+				}
+				putPolicyIPRulesToClusterScaleNode(newIPRules)
+				resetNodePolicy()
 			case <-vulProfUpdateTimer.C:
 				scanVulProfUpdate()
 			case <-syncCheckTicker:

--- a/controller/kv/helper.go
+++ b/controller/kv/helper.go
@@ -79,6 +79,7 @@ type ClusterHelper interface {
 	DeletePolicyRule(id uint32) error
 	DeletePolicyRuleTxn(txn *cluster.ClusterTransact, id uint32) error
 	PutPolicyVer(s *share.CLUSGroupIPPolicyVer) error
+	PutPolicyVerNode(s *share.CLUSGroupIPPolicyVer) error
 	PutDlpVer(s *share.CLUSDlpRuleVer) error
 
 	GetResponseRuleList(policyName string) []*share.CLUSRuleHead
@@ -892,6 +893,12 @@ func (m clusterHelper) DeletePolicyRuleTxn(txn *cluster.ClusterTransact, id uint
 
 func (m clusterHelper) PutPolicyVer(s *share.CLUSGroupIPPolicyVer) error {
 	key := share.CLUSPolicyIPRulesKey(s.Key)
+	value, _ := enc.Marshal(s)
+	return cluster.Put(key, value)
+}
+
+func (m clusterHelper) PutPolicyVerNode(s *share.CLUSGroupIPPolicyVer) error {
+	key := share.CLUSPolicyIPRulesKeyNode(s.Key, s.NodeId)
 	value, _ := enc.Marshal(s)
 	return cluster.Put(key, value)
 }

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -20,6 +20,7 @@ const CLUSBenchStore string = "bench/"
 const CLUSRecalculateStore string = "recalculate/" //not to be watched by consul
 const CLUSFqdnStore string = "fqdn/"               //not to be watched by consul
 const CLUSNodeStore string = "node/"
+const CLUSNodeRuleStore string = "noderule/"
 
 // lock
 const CLUSLockConfigKey string = CLUSLockStore + "all"
@@ -211,6 +212,14 @@ const CLUSRecalDlpStore string = CLUSRecalculateStore + "dlp/"       //not to be
 
 func CLUSPolicyIPRulesKey(name string) string {
 	return fmt.Sprintf("%s%s", CLUSNetworkStore, name)
+}
+
+func CLUSPolicyIPRulesKeyNode(name, nodeid string) string {
+	return fmt.Sprintf("%s%s/%s", CLUSNodeRuleStore, nodeid, name)
+}
+
+func CLUSNodeRulesKey(nodeID string) string {
+	return fmt.Sprintf("%s%s/%s", CLUSNodeRuleStore, nodeID, PolicyIPRulesVersionID)
 }
 
 func CLUSRecalPolicyIPRulesKey(name string) string {
@@ -580,6 +589,10 @@ func CLUSIsPolicyZipRuleListKey(key string) bool {
 
 func CLUSNetworkKey2Subject(key string) string {
 	return CLUSKeyNthToken(key, 1)
+}
+
+func CLUSNodeRuleKey2Subject(key string) string {
+	return CLUSKeyNthToken(key, 2)
 }
 
 func CLUSScannerKey2ID(key string) string {
@@ -1179,6 +1192,9 @@ type CLUSGroupIPPolicy struct {
 type CLUSGroupIPPolicyVer struct {
 	Key                  string `json:"key"`
 	PolicyIPRulesVersion string `json:"pol_version"`
+	NodeId               string `json:"node_id"`
+	CommonSlotNo         int    `json:"common_slot_no"`
+	CommonRulesLen       int    `json:"common_rules_len"`
 	SlotNo               int    `json:"slot_no"`
 	RulesLen             int    `json:"rules_len"`
 	WorkloadSlot         int    `json:"workload_slot,omitempty"`


### PR DESCRIPTION
in current design, controller calculate network policy and push to consul, every enforcer will get same copy of policy regardless whether it is relevant to this node or not.
in this patch, controller calculate policy and reorgnize them into host-aware policy, so each enforcer only watch policy that relate to this node.

for k8s platform, whether policy is needed at node generally depends on "To" group, but in some special case it also depends on "From" group of policy.
for oc platform, whether policy is needed at node generally depends on "From" group, but in some special case it also depends on "To" group of policy.
containers group, mixed mode group , external, nodes and address group are treated differently to decide policy's desitination node.