### PR TITLE
NVSHAS-8212: allow using separate keys for jwt token

### DIFF
--- a/controller/rest/auth.go
+++ b/controller/rest/auth.go
@@ -1145,8 +1145,10 @@ func rsaReadKeys(certFile, keyFile string) (error, *rsa.PublicKey, *rsa.PrivateK
 
 func jwtReadKeys() error {
 	var err error
-	err, jwtPublicKey, jwtPrivateKey = rsaReadKeys(defaultSSLCertFile, defaultSSLKeyFile)
+	err, jwtPublicKey, jwtPrivateKey = rsaReadKeys(defaultJWTCertFile, defaultJWTKeyFile)
 	if err != nil {
+		log.WithError(err).Info("failed to open default jwt keys, falling back...")
+		err, jwtPublicKey, jwtPrivateKey = rsaReadKeys(defaultSSLCertFile, defaultSSLKeyFile)
 		return err
 	}
 

--- a/controller/rest/rest.go
+++ b/controller/rest/rest.go
@@ -82,6 +82,9 @@ var _teleFreq uint
 const defaultSSLCertFile = "/etc/neuvector/certs/ssl-cert.pem"
 const defaultSSLKeyFile = "/etc/neuvector/certs/ssl-cert.key"
 
+const defaultJWTCertFile = "/etc/neuvector/certs/jwt-signing.pem"
+const defaultJWTKeyFile = "/etc/neuvector/certs/jwt-signing.key"
+
 const defFedSSLCertFile = "/etc/neuvector/certs/fed-ssl-cert.pem"
 const defFedSSLKeyFile = "/etc/neuvector/certs/fed-ssl-cert.key"
 


### PR DESCRIPTION
This commit allows user to use a separate JWT signing key when available.