### PR TITLE
NVSHAS-8111 - Custom scripts not running

### DIFF
--- a/controller/kv/dispatcher.go
+++ b/controller/kv/dispatcher.go
@@ -296,9 +296,9 @@ func (dpt *kvDispatcher) WorkloadJoin(node, group, id string, customGrps utils.S
 	bBuildLocalGroup := dpt.refreshServiceGroup2Nodes(group, node, id, false)
 	// dpt.dump()
 
+	txn := cluster.Transact()
+	dpt.buildCustomGroups(node, customGrps, txn)
 	if bLeader {
-		txn := cluster.Transact()
-		dpt.buildCustomGroups(node, customGrps, txn)
 		if bBuildLocalGroup || bNewGroup || bNewNode {       // add a group on the node
 			// log.WithFields(log.Fields{"group": group, "node": node}).Debug("DPT: local group")
 			dpt.copyProfileKeys(node, group, txn)
@@ -307,8 +307,8 @@ func (dpt *kvDispatcher) WorkloadJoin(node, group, id string, customGrps utils.S
 		if ok, err := txn.Apply(); err != nil || !ok {
 			log.WithFields(log.Fields{"ok": ok, "error": err, "group": group, "node": node}).Error("write failed")
 		}
-		txn.Close()
 	}
+	txn.Close()
 }
 
 // from cacher


### PR DESCRIPTION
Adding a function called AddNodeToCustomGroup() to synchronize the followers with the leader. This function updates dpt.group2node set so its always up to date with the WorkloadJoin/Leave events.

Before, if a leadership transfered happened to a follower, custom scripts would stop getting updated because the group2node set was always empty. We had only updated the set on the leader in the WorkloadJoin() function. So followers wouldn't update their set until all the clients rejoined the cluster.

WorkloadLeave() didn't have this issue because it called dpt.purgeCustomGroupsByNodeGroups() which would clean group2node for both leader & follower.

refreshServiceGroup2Nodes() looks like it should update the group2nodes set but custom groups are part of the function arguments so it can't refresh it implicitly. But this would compete with the leader calling dpt.buildCustomGroups(). Not the end of the world but it would be redundant on the leader maybe.