### PR TITLE
NVSHAS-7764: "Maximum concurrent syslog message reached Check syslog server settings " ERROR log can be rate limited

### DIFF
--- a/controller/common/output.go
+++ b/controller/common/output.go
@@ -75,6 +75,10 @@ func (s *Syslogger) Close() {
 	}
 }
 
+func (s *Syslogger) Identifier() string {
+	return s.proto + ":" + s.addr + ":" + s.serverCert  // a string to identify its connection criteria
+}
+
 func (s *Syslogger) Send(elog interface{}, level, cat, header string) error {
 	if !s.catSet.Contains(cat) {
 		return nil


### PR DESCRIPTION
Suppress those relative error messages by every 30 minutes. When the target address or certificate path changes, we reset the timer again.