### PR TITLE
NVSHAS-8289: Use env variable in enforcer for enabling/disabling custom benchmark

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -276,6 +276,7 @@ func main() {
 	disable_system_protection := flag.Bool("no_sys_protect", false, "disable system protections")
 	policy_puller := flag.Int("policy_puller", 0, "set policy pulling period")
 	autoProfile := flag.Int("apc", 1, "Enable auto profile collection")
+	enable_custom_bench := flag.Bool("cbench", false, "enable custom benchmarks")
 	flag.Parse()
 
 	if *debug {
@@ -329,6 +330,11 @@ func main() {
 			agentEnv.autoProfieCapture = (uint64)(*autoProfile)
 		}
 		log.WithFields(log.Fields{"auto-profile": agentEnv.autoProfieCapture}).Info()
+	}
+
+	if *enable_custom_bench {
+		agentEnv.customBenchmark = true
+		log.Info("Enable custom benchmark")
 	}
 
 	if *join != "" {

--- a/agent/bench.go
+++ b/agent/bench.go
@@ -303,8 +303,14 @@ func (b *Bench) BenchLoop() {
 			}
 			gInfoRUnlock()
 
-			b.doContainerCustomCheck(wls)
+			if agentEnv.customBenchmark {
+				b.doContainerCustomCheck(wls)
+			}
 		case <-b.customConTimer.C:
+			if !agentEnv.customBenchmark {
+				break
+			}
+
 			wls := make([]*share.CLUSWorkload, 0)
 			gInfoRLock()
 			for _, c := range gInfo.activeContainers {

--- a/agent/types.go
+++ b/agent/types.go
@@ -21,6 +21,7 @@ type AgentEnvInfo struct {
 	scanSecrets          bool
 	autoBenchmark        bool
 	systemProfiles       bool
+	customBenchmark      bool
 	netPolicyPuller      int
 	autoProfieCapture    uint64
 	memoryLimit          uint64

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -46,6 +46,7 @@ type ctrlEnvInfo struct {
 	cgroupCPUAcct     string
 	runInContainer    bool
 	debugCPath        bool
+	customBenchmark   bool
 	autoProfieCapture uint64
 	memoryLimit       uint64
 	peakMemoryUsage   uint64
@@ -251,6 +252,7 @@ func main() {
 	cspPauseInterval := flag.Uint("csp_pause_interval", 240, "")                       // in minutes, for testing only
 	noRmNsGrps := flag.Bool("no_rm_nsgroups", false, "Not to remove groups when namespace was deleted")
 	autoProfile := flag.Int("apc", 1, "Enable auto profile collection")
+	enable_custom_bench := flag.Bool("cbench", false, "enable custom benchmarks")
 	flag.Parse()
 
 	if *debug {
@@ -292,6 +294,10 @@ func main() {
 			ctrlEnv.autoProfieCapture = (uint64)(*autoProfile)
 		}
 		log.WithFields(log.Fields{"auto-profile": ctrlEnv.autoProfieCapture}).Info()
+	}
+	if *enable_custom_bench {
+		ctrlEnv.customBenchmark = true
+		log.Info("Enable custom benchmark")
 	}
 
 	// Set global objects at the very first

--- a/monitor/monitor.c
+++ b/monitor/monitor.c
@@ -56,6 +56,7 @@
 #define ENV_CSP_ENV            "CSP_ENV"
 #define ENV_CSP_PAUSE_INTERVAL "CSP_PAUSE_INTERVAL"
 #define ENV_AUTOPROFILE_CLT    "AUTO_PROFILE_COLLECT"
+#define ENV_SET_CUSTOM_BENCH   "ENABLE_CUSTOM_CHECK"
 
 #define ENV_SCANNER_DOCKER_URL  "SCANNER_DOCKER_URL"
 #define ENV_SCANNER_LICENSE     "SCANNER_LICENSE"
@@ -417,6 +418,11 @@ static pid_t fork_exec(int i)
             args[a++] = "-apc";
             args[a++] = enable;
         }
+        if ((enable = getenv(ENV_SET_CUSTOM_BENCH)) != NULL) {
+            if (checkImplicitEnableFlag(enable) == 1) {
+                args[a ++] = "-cbench";
+            }
+        }
         args[a] = NULL;
         break;
     case PROC_AGENT:
@@ -499,6 +505,11 @@ static pid_t fork_exec(int i)
         if ((enable = getenv(ENV_AUTOPROFILE_CLT)) != NULL) {
             args[a++] = "-apc";
             args[a++] = enable;
+        }
+        if ((enable = getenv(ENV_SET_CUSTOM_BENCH)) != NULL) {
+            if (checkImplicitEnableFlag(enable) == 1) {
+                args[a ++] = "-cbench";
+            }
         }
         args[a] = NULL;
         break;


### PR DESCRIPTION
Default: custom benchmarks are disabled.

Enable this feature: both enforcer/controller deployments have the environment variable. 

           - name: ENABLE_CUSTOM_CHECK
              value: "1"

Note:  no custom benchmark, you can assign the value: "0"    

The enforcer part has been implemented.
The controller part: new variable: "ctrlEnv.customBenchmark".