### PR TITLE
NVSHAS-8275: [Enforcer] Creating about 800K files under monitored directory causes enforcer memory bloat to 5G

### DIFF
--- a/agent/probe/fsn.go
+++ b/agent/probe/fsn.go
@@ -18,7 +18,7 @@ import (
 )
 
 const hostRootMountPoint = "/proc/1/root"
-const waitFileActionCompleteSteps int = 32 // total: 1056 ms((528*2)
+const waitFileActionCompleteSteps int = 16
 
 const (
 	drv_overlayfs = iota
@@ -260,7 +260,7 @@ func (fsn *FileNotificationCtr) updateFileInfo(index string, file, path string) 
 		}
 		size = fi.Size()                            // wait for the next run
 		if i == (waitFileActionCompleteSteps - 1) { // still ongoing, give up, it reports anyway.
-			log.WithFields(log.Fields{"file": file, "id": root.id, "error": err, "size": size}).Error("FSN: incomplete file")
+			log.WithFields(log.Fields{"file": file, "id": root.id, "error": err, "size": size}).Debug("FSN: incomplete file")
 		}
 	}
 
@@ -347,6 +347,7 @@ func (fsn *FileNotificationCtr) handleEvent(event fsnotify.Event) {
 		} else if fi.Mode().IsRegular() {
 			go fsn.updateFileInfo(index, file, path)
 			// log.WithFields(log.Fields{"file": file, "path": path}).Debug("FSN: new file")
+			return
 		}
 	}
 
@@ -372,7 +373,7 @@ func (fsn *FileNotificationCtr) monitorEvents() {
 			if !ok {
 				return
 			}
-			go fsn.handleEvent(event)
+			fsn.handleEvent(event)
 		case err, ok := <-fsn.watcher.Errors:
 			if !ok && err == nil {
 				// exited

--- a/share/fsmon/fanotify_linux.go
+++ b/share/fsmon/fanotify_linux.go
@@ -207,6 +207,9 @@ func (fn *FaNotify) ContainerCleanup(rootPid int) {
 	defer fn.mux.Unlock()
 	if r, ok := fn.roots[rootPid]; ok {
 		fn.removeMarks(r)
+		r.paths = nil
+		r.dirs = nil
+		r.dirMonitorMap = nil
 		delete(fn.roots, rootPid)
 	}
 


### PR DESCRIPTION
Two improvements

(1) The rapid file creation causes a huge amount of goroutines and the enforcer can not near half millions of workers together. Remove goroutines from the container's upper layer file monitor. 

(2) When the test pod has been removed, the file monitor will keep reporting events and set up its notify paths.  Reducing the footprints of the allocated structures and the stop reports will help a faster memory usage decline.