### PR TITLE
NVSHAS-7947 - Process violation is reported as Host.Suspicious instead Container.Suspicious

### DIFF
--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -1626,10 +1626,6 @@ func (p *Probe) addContainerCandidate(proc *procInternal, scanMode bool) (*procC
 		}
 		return nil, -1 // not ready
 	}
-	if err != nil {
-		log.WithFields(log.Fields{"id": id, "containerInContainer": containerInContainer,
-			"err": err}).Warning("Container ID by PID failed")
-	}
 
 	// In container-in-container enviroment, the id should be container-in-container type.
 	if p.containerInContainer && !containerInContainer {
@@ -1904,25 +1900,10 @@ func (p *Probe) evaluateApplication(proc *procInternal, id string, bKeepAlive bo
 			risky = false
 		}
 	}
+	mLog.WithFields(log.Fields{"name": proc.name, "pid": proc.pid, "path": proc.path, "action": action, "risky": risky}).Debug("PROC: Result")
 
 	// it has not been reported as a profile/risky event
 	riskyReported = (proc.reported & (suspicReported | profileReported)) != 0
-
-	mLog.WithFields(log.Fields{
-		"id": id,
-		"name": proc.name,
-		"pname": proc.pname,
-		"pid": proc.pid,
-		"ppid": proc.ppid,
-		"path": proc.path,
-		"action": action,
-		"risky": risky,
-		"riskyReported": riskyReported,
-		"bSkipReport": bSkipReport,
-		"proc.riskType": proc.riskType,
-		"suspicReported": proc.reported & suspicReported,
-		"profileReported": proc.reported & profileReported,
-	}).Debug("PROC: Result")
 	if risky && !riskyReported {
 
 		proc.user = p.getUpdatedUsername(proc.pid, proc.euid)

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -1928,7 +1928,7 @@ func (p *Probe) evaluateApplication(proc *procInternal, id string, bKeepAlive bo
 		proc.user = p.getUpdatedUsername(proc.pid, proc.euid)
 
 		// If the ID is empty, lets make sure it is not because we missed the info
-		if id == "" && !global.RT.IsRuntimeProcess(proc.pname, nil) {
+		if id == "" && global.RT.IsRuntimeProcess(proc.pname, nil) {
 			c, found := p.pidContainerMap[proc.pid]
 			if found && c.id != "" {
 				id = c.id

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -1932,7 +1932,7 @@ func (p *Probe) evaluateApplication(proc *procInternal, id string, bKeepAlive bo
 				id = c.id
 				mLog.WithFields(log.Fields{"id": id, "pid": proc.pid, "c": c}).Debug("PROC: Patched empty proc ID with updated container info")
 			} else {
-				if procID, _, err, found := global.SYS.GetContainerIDByPID(proc.pid); err != nil && found {
+				if procID, _, err, found := global.SYS.GetContainerIDByPID(proc.pid); err == nil && found {
 					id = procID
 					mLog.WithFields(log.Fields{"id": id, "pid": proc.pid, "procId": procID}).Debug("PROC: Patched empty proc ID with Container info thru PID")
 				} else {

--- a/controller/cache/log.go
+++ b/controller/cache/log.go
@@ -332,7 +332,7 @@ func recordEvent(rlog *api.Event) {
 }
 
 func recordIncident(rlog *api.Incident) {
-	log.WithFields(log.Fields{"name": rlog.Name}).Debug("")
+	log.WithFields(log.Fields{"name": rlog.Name, "id": rlog.ID, "proc": rlog.ProcName, "msg": rlog.Msg}).Debug("")
 
 	if curIncidentIndex == logCacheSize {
 		_, incidentCache = incidentCache[0], incidentCache[1:]

--- a/controller/cache/log.go
+++ b/controller/cache/log.go
@@ -332,7 +332,7 @@ func recordEvent(rlog *api.Event) {
 }
 
 func recordIncident(rlog *api.Incident) {
-	log.WithFields(log.Fields{"name": rlog.Name, "id": rlog.ID, "proc": rlog.ProcName, "msg": rlog.Msg}).Debug("")
+	log.WithFields(log.Fields{"name": rlog.Name}).Debug("")
 
 	if curIncidentIndex == logCacheSize {
 		_, incidentCache = incidentCache[0], incidentCache[1:]


### PR DESCRIPTION
I believe this is a race condition where the container map being updated at the same time we are evaluating a new process. The map data is not available so it assumes it is a host process.

I made a change in evaluateApplication() so when it detects a violation, it will make a last ditch attempt to confirm the process is not a host process by checking:
1. if pidContainerMap has the pid and has an updated information about the container
2. Make another attempt at GetContainerIDByPID() to determine the container ID from the PID.

I also added some extra information to recordIncident() because the log entry was not useful in debugging as is. Either we make it more useful or we remove it.