### PR TITLE
NVSHAS-7704: show all deny rule violations during configuration assessment

### DIFF
--- a/controller/cache/interface.go
+++ b/controller/cache/interface.go
@@ -165,7 +165,7 @@ type CacheInterface interface {
 	WaitUntilApiPathReady() bool
 	IsImageScanned(c *nvsysadmission.AdmContainerInfo) (bool, int, int)
 	MatchK8sAdmissionRules(admType string, admResObject *nvsysadmission.AdmResObject, c *nvsysadmission.AdmContainerInfo,
-		matchData *nvsysadmission.AdmMatchData, stamps *api.AdmCtlTimeStamps, ar *admissionv1beta1.AdmissionReview) (*nvsysadmission.AdmResult, bool)
+		matchData *nvsysadmission.AdmMatchData, stamps *api.AdmCtlTimeStamps, ar *admissionv1beta1.AdmissionReview, forTesting bool) (*nvsysadmission.AdmResult, bool)
 	IsAdmControlEnabled(uri *string) (bool, string, int, string, string)
 	UpdateLocalAdmCtrlStats(category string, stats int) error
 	IncrementAdmCtrlProcessing()

--- a/controller/rest/admwebhook.go
+++ b/controller/rest/admwebhook.go
@@ -766,7 +766,7 @@ func parseAdmRequest(req *admissionv1beta1.AdmissionRequest, objectMeta *metav1.
 	return resObject, nil
 }
 
-func walkThruContainers(admType string, admResObject *nvsysadmission.AdmResObject, op int, stamps *api.AdmCtlTimeStamps, ar *admissionv1beta1.AdmissionReview) *nvsysadmission.AdmResult {
+func walkThruContainers(admType string, admResObject *nvsysadmission.AdmResObject, op int, stamps *api.AdmCtlTimeStamps, ar *admissionv1beta1.AdmissionReview, forTesting bool) *nvsysadmission.AdmResult {
 	matchData := &nvsysadmission.AdmMatchData{}
 	if len(admResObject.OwnerUIDs) > 0 {
 		// If there is owner for this resource, check if the root owner's cache is still available.
@@ -814,7 +814,7 @@ func walkThruContainers(admType string, admResObject *nvsysadmission.AdmResObjec
 	for _, c := range admResObject.Containers {
 		var thisStamp api.AdmCtlTimeStamps
 		perMatchData := &nvsysadmission.AdmMatchData{RootAvail: matchData.RootAvail}
-		result, licenseAllowed := cacher.MatchK8sAdmissionRules(admType, admResObject, c, perMatchData, &thisStamp, ar)
+		result, licenseAllowed := cacher.MatchK8sAdmissionRules(admType, admResObject, c, perMatchData, &thisStamp, ar, forTesting)
 		if !licenseAllowed {
 			continue
 		}
@@ -1177,7 +1177,7 @@ func (whsvr *WebhookServer) validate(ar *admissionv1beta1.AdmissionReview, mode 
 		}
 		var subMsg, ruleScope, msgHeader string
 		// check if the containers are allowed
-		admResult = walkThruContainers(admission.NvAdmValidateType, admResObject, op, stamps, ar)
+		admResult = walkThruContainers(admission.NvAdmValidateType, admResObject, op, stamps, ar, forTesting)
 		if req.DryRun != nil && *req.DryRun {
 			msgHeader = "<Server Dry Run> "
 		} else if forTesting {


### PR DESCRIPTION
This appends a list of each violated deny rule and the problematic images on a per rule basis.

It looks like this:
![image](https://github.com/neuvector/neuvector/assets/101584289/30ac2b5f-de69-4eab-a594-f28a91d5d3f5)
