### PR TITLE
NVSHAS-8304: Scans failing on one Node only

### DIFF
--- a/controller/cache/scan.go
+++ b/controller/cache/scan.go
@@ -162,7 +162,7 @@ func (t *scanTask) rpcScanRunning(scanner string, info *scanInfo) {
 		cctx.k8sVersion, cctx.ocVersion = global.ORCH.GetVersion(false, false)
 		result, err = rpc.ScanPlatform(scanner, cctx.k8sVersion, cctx.ocVersion, scanReqTimeout)
 	}
-	if result == nil || result.Error == share.ScanErrorCode_ScanErrNetwork || err != nil {
+	if result == nil || result.Error == share.ScanErrorCode_ScanErrNetwork || result.Error == share.ScanErrorCode_ScanErrInProgress || err != nil {
 		// rpc request not made
 		cctx.ScanLog.WithFields(log.Fields{"id": t.id, "error": err}).Error()
 


### PR DESCRIPTION
Fix the nil results from the scanner side. Adding a positive scan-in-progress condition into the next scan queue.

`grpc: server failed to encode response: rpc error: code = Internal desc = grpc: error while marshaling: proto: Marshal called with nil`