### PR TITLE
NVSHAS-5703: Improve update FQDN field in graph

### DIFF
--- a/controller/cache/learn.go
+++ b/controller/cache/learn.go
@@ -366,7 +366,11 @@ func addConnectToGraph(conn *share.CLUSConnection, ca, sa *nodeAttr, stip *serve
 		} else {
 			ge.toSidecar = 0
 		}
-		ge.fqdn = conn.FQDN
+		// No need to update the FQDN field if (ge.fqdn != "" && conn.FQDN == "") for the
+		// same connection. This may be due to the IP-FQDN record has timed out.
+		if ge.fqdn == "" || conn.FQDN != "" {
+			ge.fqdn = conn.FQDN
+		}
 	} else {
 		ge := &graphEntry{
 			bytes:    conn.Bytes,


### PR DESCRIPTION
No need to update FQDN field in graph if it has value but the updated connection's FQDN field is empty. This may be due to the IP-FQDN record has timed out.