### PR TITLE
NVSHAS-5703: add extra logs for certificate reload

### DIFF
--- a/controller/rest/rest.go
+++ b/controller/rest/rest.go
@@ -1361,6 +1361,12 @@ func initJWTSignKey() error {
 					jwtCertState.jwtOldPublicKeyNotAfter = &t
 				}
 			}
+
+			log.WithFields(log.Fields{
+				"cn":            "neuvector-jwt-signing",
+				"newExpiryDate": jwtCertState.jwtPublicKeyNotAfter,
+				"oldExpiryDate": jwtCertState.jwtOldPublicKeyNotAfter,
+			}).Info("new certificate is loaded")
 		},
 	})
 	// Create and setup certificate.


### PR DESCRIPTION
JWT certificate could be reloaded in a different time from when new cert is created.  Adding logs to indicate the cert reloading.