### PR TITLE
NVSHAS-7060 - Patch so we can build neuvector post Ubuntu 20.04

### DIFF
--- a/dp/Makefile
+++ b/dp/Makefile
@@ -16,6 +16,6 @@ STATIC_LIBS += third-party/.objs/lib/timeout.a
 STATIC_LIBS += third-party/.objs/lib/libpcre2-8.a
 STATIC_LIBS += third-party/.objs/lib/x86_64-linux-gnu/libhs.a
 
-EXTRA_LDFLAGS = -pthread -lurcu -lurcu-cds -lrt -lstdc++ -lm -lnetfilter_queue -Wl,-rpath,'$$ORIGIN' -Wl,--disable-new-dtags
+EXTRA_LDFLAGS = -no-pie -pthread -lurcu -lurcu-cds -lrt -lstdc++ -lm -lnetfilter_queue -Wl,-rpath,'$$ORIGIN' -Wl,--disable-new-dtags
 
 include $(TOPDIR)/Makefile.rule


### PR DESCRIPTION
Does not seem to break 18.04 but I wouldn't merge this just yet 

The issue right now with Ubuntu 20.04 is that the included libraries are updated AND the version of GCC is upgraded from 7.x to 11.x. This introduces minor incompatibilities without small modifications.

There are two problems

We cannot link against bpf_dump.o (/usr/bin/ld: objects/libpcap/bpf_dump.o) Solution, I added `-PIE` to the linking args. This may already be known in the top level Makefile but it was commented out I think. GCC 11 includes static analysis for malloc/free operations and uses syntatic sugars to make those determinations. See https://developers.redhat.com/blog/2021/04/30/detecting-memory-management-bugs-with-gcc-11-part-1-understanding-dynamic-allocation#detecting_mismatched_deallocations Solved by making sure our open and close operations use matching prefixes (eg: popen is followed by pclose. Or fopen is followed by fclose).