### PR TITLE
NVSHAS-8327: FileMonitor: Many automation cases fail due to many fields missing in the event.

### DIFF
--- a/agent/probe/incident_reporter.go
+++ b/agent/probe/incident_reporter.go
@@ -286,7 +286,7 @@ func (p *Probe) processAggregateProbeReports() int {
 		pmsga.triggerCnt--
 		pmsga.expireCnt--
 		if pmsga.expireCnt == 0 {
-			if pmsga.count > 1 || (pmsga.bFsMonMsg && pmsga.count != 0) {
+			if pmsga.count > 1  || (pmsga.bFsMonMsg && pmsga.count != 0 && pmsga.fsMsg.Path != "") {
 				go p.sendReport(*pmsga)
 				cnt++
 			}


### PR DESCRIPTION
(1) the hash data was not initialized before the new file modified event.
(2) correct the file manipulation process slices. 
(3) filter out the reported file events with an empty file path.