### PR TITLE
NVSHAS-8313 Fix node state shows 'un-managed' but enforcer shows 'connected'

### DIFF
--- a/controller/cache/node.go
+++ b/controller/cache/node.go
@@ -98,7 +98,7 @@ func (p *hostRemovalEvent) Expire() {
 		if cache.agents.Cardinality() != 0 {
 			log.WithFields(log.Fields{"count": cache.agents.Cardinality}).Info("host has agent")
 			cache.timerTask = ""
-			cache.state = ""
+			cache.state = api.StateOnline
 			cache.timerSched = time.Time{}
 			return
 		}


### PR DESCRIPTION
When scheduleHostRemoval() is called due to agent is deleted or new controller lead election, it will add a task to delete host from cluster, then set the timeout timer to 10 mins. During that period, host may have an agent added. After 10 mins timeout, controller will check if the host has an agent on it. If the host has an agent on it, it should set the state to 'connected'. (The current behaviour is setting the state to empty)