### PR TITLE
NVSHAS-8368 goroutine crash

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -37,6 +37,9 @@ import (
 var Host share.CLUSHost = share.CLUSHost{
 	Platform: share.PlatformDocker,
 }
+
+// When accessing global Ctrler, Ctrler.OrchConnStatus and Ctrler.OrchConnLastError will be empty all the time.
+// Use GetOrchConnStatus() instead.
 var Ctrler, parentCtrler share.CLUSController
 
 type ctrlEnvInfo struct {


### PR DESCRIPTION
Fixed this goroutine crash, which happens when doing string comparison.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xda77b4]

goroutine 256 [running]:
main.(*orchConn).cbWatcherState(0xc00000f480, 0x2ce7b90, 0x9, 0x0, 0x0)
	/go/src/github.com/neuvector/neuvector/controller/orch.go:37 +0x423
github.com/neuvector/neuvector/controller/resource.(*kubernetes).startWatchResource.func1(0xc0000c6a10, 0x0, 0x0, 0xc0000aacf0, 0xc00098aeb0, 0x2ce81c0, 0x9, 0xc00098aea0)
	/go/src/github.com/neuvector/neuvector/controller/resource/kubernetes_resource.go:1479 +0x8cc
created by github.com/neuvector/neuvector/controller/resource.(*kubernetes).startWatchResource
	/go/src/github.com/neuvector/neuvector/controller/resource/kubernetes_resource.go:1465 +0x202
```

The root cause is a race condition between reader and writer on `OrchConnStatus` and `OrchConnLastError` of the global variable Ctrler.

It's easy to make these operation atomic by using a sync.Mutex when reader/writer are accessing the data, but the problem is that `Ctrler` is being accessed a lot, and these two volatile members would still cause random problem to its reader.  For example, this line that marshals `Ctrler` directly:

https://github.com/neuvector/neuvector/blob/6bf83a9471908772b85705769cbec63d536858df/controller/cluster.go#L368

When inserting into kv, the data is now reconstructed from `CLUSController`, `OrchConnStatus` and `OrchConnLastError` with proper lock.