### PR TITLE
NVSHAS-5774: Assets > Containers: Show containers that were scanned in registry

### DIFF
--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -857,6 +857,7 @@ type RESTWorkloadBrief struct { // obsolete, use v2 instead
 	Image              string               `json:"image"`
 	ImageID            string               `json:"image_id"`
 	ImgCreateAt        string               `json:"image_created_at"`
+	ImgRegScand        bool                 `json:"image_reg_scanned"`
 	PlatformRole       string               `json:"platform_role"`
 	Domain             string               `json:"domain"`
 	State              string               `json:"state"`
@@ -920,6 +921,7 @@ type RESTWorkloadBriefV2 struct {
 	Image        string `json:"image"`
 	ImageID      string `json:"image_id"`
 	ImgCreateAt  string `json:"image_created_at"`
+	ImgRegScand  bool   `json:"image_reg_scanned"`
 	Domain       string `json:"domain"`
 	State        string `json:"state"`
 	Service      string `json:"service"`

--- a/controller/api/apis.yaml
+++ b/controller/api/apis.yaml
@@ -12083,6 +12083,9 @@ definitions:
         type: string
         format: date-time
         example: 2018-01-18T00:44:02Z
+      image_reg_scanned:
+        type: boolean
+        example: false
       platform_role:
         type: string
         example: core
@@ -12185,6 +12188,9 @@ definitions:
         type: string
         format: date-time
         example: 2018-01-18T00:44:02Z
+      image_reg_scanned:
+        type: boolean
+        example: false
       domain:
         type: string
         example: ""

--- a/controller/cache/learn_test.go
+++ b/controller/cache/learn_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/neuvector/neuvector/controller/access"
 	"github.com/neuvector/neuvector/controller/common"
 	"github.com/neuvector/neuvector/controller/graph"
+	"github.com/neuvector/neuvector/controller/scan"
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/utils"
 )
@@ -42,6 +43,12 @@ func preTest() {
 		MutexLog: mutexLog,
 		LocalDev: localDev,
 	}
+
+	sctx := scan.Context{
+		MutexLog:   mutexLog,
+		ScanLog:    mutexLog,
+	}
+	scan.InitContext(&sctx, true)
 }
 
 type caseParam struct {

--- a/controller/cache/object.go
+++ b/controller/cache/object.go
@@ -257,6 +257,7 @@ func workload2BriefREST(cache *workloadCache) *api.RESTWorkloadBrief {
 		Image:              wl.Image,
 		ImageID:            wl.ImageID,
 		ImgCreateAt:        api.RESTTimeString(wl.ImgCreateAt),
+		ImgRegScand:        scan.IsRegistryImageScanned(wl.ImageID),
 		PlatformRole:       cache.platformRole,
 		Domain:             wl.Domain,
 		Author:             wl.Author,

--- a/controller/rest/workload.go
+++ b/controller/rest/workload.go
@@ -170,6 +170,7 @@ func workloadV1ToV2(wlV1 *api.RESTWorkload) *api.RESTWorkloadV2 {
 			Image:        wlV1.Image,
 			ImageID:      wlV1.ImageID,
 			ImgCreateAt:  wlV1.ImgCreateAt,
+			ImgRegScand:  wlV1.ImgRegScand,
 			Domain:       wlV1.Domain,
 			State:        wlV1.State,
 			Service:      wlV1.Service,

--- a/controller/scan/registry.go
+++ b/controller/scan/registry.go
@@ -1846,3 +1846,25 @@ func (t *regScanTask) shouldRetry(result *share.ScanResult) bool {
 func (t *regScanTask) reachedMaxRetries() bool {
 	return t.retries == maxRetry
 }
+
+func IsRegistryImageScanned(id string) bool {
+	var scanned bool
+
+	regReadLock()
+	for _, rs := range regMap {
+		rs.stateLock()
+		if sum, ok := rs.summary[id]; ok {
+			// smd.scanLog.WithFields(log.Fields{"img": id, "summary": sum}).Debug("found")
+			scanned = (sum.Status == api.ScanStatusFinished)
+		}
+		rs.stateUnlock()
+
+		if scanned {
+			break
+		}
+	}
+	regReadUnlock()
+
+	// smd.scanLog.WithFields(log.Fields{"img": id, "scanned": scanned}).Debug()
+	return scanned
+}

--- a/controller/scan/scan.go
+++ b/controller/scan/scan.go
@@ -273,9 +273,7 @@ func ScannerDBChange(db *share.CLUSScannerDB) {
 	}
 }
 
-func Init(ctx *Context, leader bool) ScanInterface {
-	log.Info()
-
+func InitContext(ctx *Context, leader bool) {
 	if smd == nil {
 		smd = &scanMethod{
 			auditQueue: ctx.AuditQueue,
@@ -295,6 +293,12 @@ func Init(ctx *Context, leader bool) ScanInterface {
 		smd.isLeader = leader
 		smd.fedRole = ctx.FedRole
 	}
+}
+
+func Init(ctx *Context, leader bool) ScanInterface {
+	log.Info()
+
+	InitContext(ctx, leader)
 
 	clusHelper = kv.GetClusterHelper()
 


### PR DESCRIPTION
Add a flag which indicates the registry scan status of a workload.

api.RESTWorkloadBrief and api.RESTWorkloadBriefv2
      
      ImgRegScand          bool          `json:"image_reg_scanned"`