### PR TITLE
NVSHAS-8304: Scans failing on one Node only

### DIFF
--- a/agent/grpc.go
+++ b/agent/grpc.go
@@ -54,7 +54,7 @@ func (ss *ScanService) ScanGetFiles(ctx context.Context, req *share.ScanRunningR
 	log.WithFields(log.Fields{"id": req.ID}).Info("")
 
 	if ss.setScanStart(req.ID) {
-		log.WithFields(log.Fields{"id": req.ID}).Info("scan in propress")
+		log.WithFields(log.Fields{"id": req.ID}).Info("scan in progress")
 		return &share.ScanData{Error: share.ScanErrorCode_ScanErrInProgress}, nil
 	}
 


### PR DESCRIPTION
(1) Deadlocked on the "docker cp" events. No engine's shared locks can be passed into the prober.
(2) Prevent the potential map access violations in the engine section.
(3) Fix a typo when the scanning file collection is in progress.