### PR TITLE
NVSHAS-8406, only set service container's hasDatapath to true in istio case to avoid unexpected policy behavior

### DIFF
--- a/agent/system.go
+++ b/agent/system.go
@@ -813,7 +813,7 @@ func updateWorkloadDlpRuleConfig(DlpWlRules []*share.CLUSDlpWorkloadRule, dlprul
 					wlmacs.Add(pair.MAC.String())
 				}
 				//we need to detect traffic between sidecar and service container
-				if gInfo.tapProxymesh && c.info.ProxyMesh {
+				if gInfo.tapProxymesh && isProxyMesh(c) {
 					lomac_str := fmt.Sprintf(container.KubeProxyMeshLoMacStr, (c.pid>>8)&0xff, c.pid&0xff)
 					dlpWlRule.WorkloadMac = append(dlpWlRule.WorkloadMac, lomac_str)
 					wlmacs.Add(lomac_str)


### PR DESCRIPTION
In most recent cases reported by customer, they all involved with istio-enabled POD whose parent pid==0, this is verified in support log such as following
"network_mode": "/proc/29013/ns/net",//sidecar
"network_mode": "/proc/29013/ns/net",//app container
"network_mode": "/var/run/netns/cni-e4e558af-a3ed-fa0a-9790-926ab564bea3",//parent
runtime is containerd
in our current setup we have both child's hasDatapath=true, during policy depolyment this can cause unexpected behavior, so only let service container's hasDatapath=true