### PR TITLE
Add rlock protection on the shared map, "activeContainers", access.

### DIFF
--- a/agent/bench.go
+++ b/agent/bench.go
@@ -286,9 +286,8 @@ func (b *Bench) BenchLoop() {
 
 			// Run custom checks
 			wls := make([]*share.CLUSWorkload, 0)
-			gInfoRLock()
 			for id, name := range containers {
-				if c, ok := gInfo.activeContainers[id]; ok {
+				if c, ok := gInfoReadActiveContainer(id); ok {
 					if Host.Platform == share.PlatformKubernetes && c.parentNS == "" {
 						continue // skip kubernetes pod
 					}
@@ -301,7 +300,6 @@ func (b *Bench) BenchLoop() {
 					}
 				}
 			}
-			gInfoRUnlock()
 
 			if agentEnv.customBenchmark {
 				b.doContainerCustomCheck(wls)

--- a/agent/group_profile.go
+++ b/agent/group_profile.go
@@ -389,10 +389,7 @@ func procMemberChanges(members utils.Set) {
 			continue
 		}
 
-		gInfoRLock()
-		c, ok := gInfo.activeContainers[id]
-		gInfoRUnlock()
-		if ok {
+		if c, ok := gInfoReadActiveContainer(id); ok {
 			go applyProcGroupProfile(c)
 		} else {
 			log.WithFields(log.Fields{"id": id}).Debug("GRP: left")
@@ -410,10 +407,7 @@ func fileMemberChanges(members utils.Set) {
 			continue
 		}
 
-		gInfoRLock()
-		c, ok := gInfo.activeContainers[id]
-		gInfoRUnlock()
-		if ok {
+		if c, ok := gInfoReadActiveContainer(id); ok {
 			applyFileGroupProfile(c)
 		} else {
 			log.WithFields(log.Fields{"id": id}).Debug("GRP: left")
@@ -1091,13 +1085,10 @@ func updateContainerFamilyTrees(name string) {
 
 	for _, cid := range cids {
 		bPrivileged := false
-		gInfoRLock()
-		c, ok := gInfo.activeContainers[cid]
-		if ok && c.info != nil {
-			bPrivileged = c.info.Privileged
-		}
-		gInfoRUnlock()
-		if ok {
+		if c, ok := gInfoReadActiveContainer(cid); ok {
+			if c.info != nil {
+				bPrivileged = c.info.Privileged
+			}
 			prober.BuildProcessFamilyGroups(c.id, c.pid, false, bPrivileged)
 		}
 	}

--- a/agent/sniffer.go
+++ b/agent/sniffer.go
@@ -316,11 +316,7 @@ func waitOnSniffer(key string, proc *procInfo) {
 func startSniffer(info *share.CLUSSnifferRequest) (string, error) {
 	var pid int
 
-	gInfoRLock()
-	c, ok := gInfo.activeContainers[info.WorkloadID]
-	gInfoRUnlock()
-
-	if ok {
+	if c, ok := gInfoReadActiveContainer(info.WorkloadID); ok {
 		if c.hostMode {
 			return "", grpc.Errorf(codes.InvalidArgument, "Container packet capture not supported")
 		}
@@ -329,7 +325,7 @@ func startSniffer(info *share.CLUSSnifferRequest) (string, error) {
 		//NVSHAS-6635 and NVSHAS-6682,ep is parent whose pid could be zero
 		if pid == 0 {
 			for podID := range c.pods.Iter() {
-				if pod, ok := gInfo.activeContainers[podID.(string)]; ok {
+				if pod, ok := gInfoReadActiveContainer(podID.(string)); ok {
 					if pod.pid != 0 && pod.hasDatapath {
 						pid = pod.pid
 						break

--- a/agent/system.go
+++ b/agent/system.go
@@ -53,13 +53,13 @@ func policyInit() {
 
 func updateContainerPolicyMode(id, policyMode string) {
 	cid := ""
-	if c, ok := gInfo.activeContainers[id]; ok {
+	if c, ok := gInfoReadActiveContainer(id); ok {
 		//NVSHAS-6719,sometimes the real traffic is pass even the action is block in oc 4.9+
 		//when parent's pid==0, we need to execute func with child first to make sure datapath
 		//is setup correctly
 		if c.pid == 0 {
 			for podID := range c.pods.Iter() {
-				if pod, ok := gInfo.activeContainers[podID.(string)]; ok {
+				if pod, ok := gInfoReadActiveContainer(podID.(string)); ok {
 					if pod.pid != 0 && pod.hasDatapath {
 						cid = podID.(string)
 						break
@@ -68,7 +68,7 @@ func updateContainerPolicyMode(id, policyMode string) {
 			}
 			//log.WithFields(log.Fields{"cid": cid}).Debug("")
 			if cid != "" {
-				if pc, exist := gInfo.activeContainers[cid]; exist {
+				if pc, exist := gInfoReadActiveContainer(cid); exist {
 					if pc.policyMode != policyMode {
 						pc.policyMode = policyMode
 						inline := isContainerInline(pc)
@@ -400,8 +400,6 @@ func hostPolicyLookup(conn *dp.Connection) (uint32, uint8, bool) {
 		return 0, C.DP_POLICY_ACTION_OPEN, false
 	}
 
-	gInfoRLock()
-
 	// Use parent's policy if the connection is reported on child
 	var wlID *string
 	if conn.Ingress {
@@ -414,20 +412,17 @@ func hostPolicyLookup(conn *dp.Connection) (uint32, uint8, bool) {
 		conn.ExternalPeer = !isIPInternal(conn.ServerIP)
 	}
 
-	c, ok := gInfo.activeContainers[*wlID]
+	c, ok := gInfoReadActiveContainer(*wlID)
 	if !ok {
-		gInfoRUnlock()
 		return 0, C.DP_POLICY_ACTION_OPEN, false
 	} else if c.parentNS != "" {
-		pc ,exist := gInfo.activeContainers[c.parentNS]
-		if exist {
+		if pc ,exist := gInfoReadActiveContainer(c.parentNS); exist {
 			if pc.pid != 0 {
 				wlID = &c.parentNS
-				c, _ = gInfo.activeContainers[*wlID]
+				c, _ = gInfoReadActiveContainer(*wlID)
 			}
 		} else {
 			if !c.hasDatapath {
-				gInfoRUnlock()
 				log.WithFields(log.Fields{
 					"wlID": *wlID,
 				}).Error("cannot find parent container")
@@ -435,8 +430,6 @@ func hostPolicyLookup(conn *dp.Connection) (uint32, uint8, bool) {
 			}
 		}
 	}
-
-	gInfoRUnlock()
 
 	if !c.hasDatapath {
 		return 0, C.DP_POLICY_ACTION_OPEN, false
@@ -790,7 +783,7 @@ func updateWorkloadDlpRuleConfig(DlpWlRules []*share.CLUSDlpWorkloadRule, dlprul
 		if dre == nil {
 			continue
 		}
-		if c, ok := gInfo.activeContainers[dre.WorkloadId]; ok {
+		if c, ok := gInfoReadActiveContainer(dre.WorkloadId); ok {
 			if c.hasDatapath {
 				dlpWlRule := dp.DPWorkloadDlpRule{
 					WlID:          dre.WorkloadId,


### PR DESCRIPTION
We need to have a "read" lock protection of shared map data in the "gInfo" structure to keep it tightly only during the map search. This PR's improvement is focused on the map of the "gInfo.activeContainers".
