### PR TITLE
NVSHAS-8431 reduce log level for jwt cert manager

### DIFF
--- a/controller/kv/certmanager.go
+++ b/controller/kv/certmanager.go
@@ -221,12 +221,12 @@ func (c *CertManager) checkAndRotateCert(cn string, callback *CertManagerCallbac
 }
 
 func (c *CertManager) CheckAndRenewCerts() error {
-	log.Info("CheckAndRenewCerts() starts.")
+	log.Debug("CheckAndRenewCerts() starts.")
 	for cn, callback := range c.callbacks {
 		c.checkAndRotateCert(cn, callback)
 	}
 
-	log.Info("CheckAndRenewCerts() completes.")
+	log.Debug("CheckAndRenewCerts() completes.")
 
 	return nil
 }

--- a/controller/rest/rest.go
+++ b/controller/rest/rest.go
@@ -1270,7 +1270,7 @@ func getExpiryDate(certPEM []byte) (time.Time, error) {
 }
 
 func initJWTSignKey() error {
-	ExpiryCheckPeriod := time.Minute * 5
+	ExpiryCheckPeriod := time.Minute * 30
 	RenewThreshold := time.Hour * 24 * 30
 	JWTCertValidityPeriodDay := 90 // 90 days.
 


### PR DESCRIPTION
Change log level for `CheckAndRenewCerts() starts.` and `CheckAndRenewCerts() completes.` to debug.  
Also adjust cert recheck period to 30 minutes. 