### PR TITLE
NVSHAS-5999 AWS bottlerocket benchmark execution error

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -116,6 +116,7 @@ func getLocalInfo(selfID string, pid2ID map[int]string) error {
 	}
 
 	agentEnv.startsAt = time.Now().UTC()
+	Agent.Pid = os.Getpid()
 	if agentEnv.runInContainer {
 		dev, meta, err := global.RT.GetDevice(selfID)
 		if err != nil {
@@ -136,7 +137,6 @@ func getLocalInfo(selfID string, pid2ID map[int]string) error {
 		}
 	} else {
 		Agent.ID = Host.ID
-		Agent.Pid = os.Getpid()
 		Agent.NetworkMode = "host"
 		Agent.PidMode = "host"
 		Agent.SelfHostname = Host.Name

--- a/agent/nvbench/kube_master_1_0_0.tmpl
+++ b/agent/nvbench/kube_master_1_0_0.tmpl
@@ -40,6 +40,11 @@ yell "# ------------------------------------------------------------------------
 # security concerns slow down your CI/CD processes.
 # ------------------------------------------------------------------------------"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 #get a process command line from /proc
 get_command_line_args() {
     PROC="$1"
@@ -65,7 +70,7 @@ get_argument_value() {
         |
     grep "^${OPTION}" |
     sed \
-        -e "s/^${OPTION}=//g"
+        -E "s/^${OPTION}(=|\s+)//g"
 }
 
 #check whether an argument exist in command line
@@ -80,6 +85,19 @@ check_argument() {
     grep "^${OPTION}" 
 }
 
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}
 CIS_APISERVER_CMD="<<<.Replace_apiserver_cmd>>>"
 CIS_MANAGER_CMD="<<<.Replace_manager_cmd>>>"
 CIS_SCHEDULER_CMD="<<<.Replace_scheduler_cmd>>>"
@@ -320,6 +338,7 @@ fi
 check_1_1_26="1.1.26  - Ensure that the --service-account-key-file argument is set as appropriate"
 if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_APISERVER_CMD" '--service-account-key-file')
+    file=$(append_prefix "$CONFIG_PREFIX" "$file")
     pass "$check_1_1_26"
     pass "        * service-account-key-file: $file"
 else
@@ -331,6 +350,8 @@ if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--etcd-keyfile' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-certfile')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-keyfile')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_1_27"
         pass "        * etcd-certfile: $certfile"
         pass "        * etcd-keyfile: $keyfile"
@@ -366,6 +387,7 @@ fi
 check_1_1_30="1.1.30  - Ensure that the --client-ca-file argument is set as appropriate"
 if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_1_30"
     pass "        * client-ca-file: $cafile"
 else
@@ -375,6 +397,7 @@ fi
 check_1_1_31="1.1.31  - Ensure that the --etcd-cafile argument is set as appropriate"
 if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-cafile')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_1_31"
     pass "        * etcd-cafile: $cafile"
 else
@@ -450,6 +473,7 @@ fi
 check_1_3_5="1.3.5  - Ensure that the --service-account-private-key-file argument is set as appropriate"
 if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
     keyfile=$(get_argument_value "$CIS_MANAGER_CMD" '--service-account-private-key-file')
+    keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
     pass "$check_1_3_5"
     pass "       * service-account-private-key-file: $keyfile"
 else
@@ -459,6 +483,7 @@ fi
 check_1_3_6="1.3.6  - Ensure that the --root-ca-file argument is set as appropriate"
 if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_MANAGER_CMD" '--root-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_3_6"
     pass "       * root-ca-file: $cafile"
 else
@@ -467,11 +492,14 @@ fi
 info "1.4 - Configuration Files"
 
 check_1_4_1="1.4.1  - Ensure that the apiserver file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/manifests/kube-apiserver.json" ]; then
-    file="/etc/kubernetes/manifests/kube-apiserver.json"
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.json")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
+if [ -f $config_json ]; then
+    file=$config_json
 else
-    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_1"
@@ -485,11 +513,6 @@ else
 fi
 
 check_1_4_2="1.4.2  - Ensure that the apiserver file ownership is set to root:root"
-if [ -f "/etc/kubernetes/manifests/kube-apiserver.json" ]; then
-    file="/etc/kubernetes/manifests/kube-apiserver.json"
-else
-    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_2"
@@ -503,6 +526,8 @@ fi
 
 check_1_4_3="1.4.3  - Ensure that the config file permissions are set to 644 or more restrictive"
 file="/etc/kubernetes/admin.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_3"
@@ -517,6 +542,8 @@ fi
 
 check_1_4_4="1.4.4  - Ensure that the config file ownership is set to root:root"
 file="/etc/kubernetes/admin.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_4"
@@ -530,11 +557,14 @@ else
 fi
 
 check_1_4_5="1.4.5  - Ensure that the scheduler file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/manifests/kube-scheduler.json" ]; then
-    file="/etc/kubernetes/manifests/kube-scheduler.json"
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.json")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
+if [ -f $config_json ]; then
+    file=$config_json
 else
-    file="/etc/kubernetes/manifests/kube-scheduler.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_5"
@@ -548,11 +578,6 @@ else
 fi
 
 check_1_4_6="1.4.6  - Ensure that the scheduler file ownership is set to root:root"
-if [ -f "/etc/kubernetes/manifests/kube-scheduler.json" ]; then
-    file="/etc/kubernetes/manifests/kube-scheduler.json"
-else
-    file="/etc/kubernetes/manifests/kube-scheduler.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_6"
@@ -566,11 +591,14 @@ else
 fi
 
 check_1_4_7="1.4.7  - Ensure that the etcd.conf file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/manifests/etcd.json" ]; then
-    file="/etc/kubernetes/manifests/etcd.json"
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.json")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
+if [ -f $config_json ]; then
+    file=$config_json
 else
-    file="/etc/kubernetes/manifests/etcd.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_7"
@@ -584,11 +612,6 @@ else
 fi
 
 check_1_4_8="1.4.8  - Ensure that the etcd.conf file ownership is set to root:root"
-if [ -f "/etc/kubernetes/manifests/etcd.json" ]; then
-    file="/etc/kubernetes/manifests/etcd.json"
-else
-    file="/etc/kubernetes/manifests/etcd.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_8"
@@ -605,7 +628,7 @@ check_1_4_9="1.4.9  - Ensure that the flanneld file permissions are set to 644 o
 check_1_4_10="1.4.10  - Ensure that the flanneld file ownership is set to root:root"
 check_1_4_11="1.4.11  - Ensure that the etcd data directory permissions are set to 700 or more restrictive"
 directory=$(get_argument_value "$CIS_ETCD_CMD" '--data-dir')
-if [ -d $directory ]; then
+if [ -d "$directory" ]; then
   if [ "$(stat -c %a $directory)" -eq 700 ]; then
     pass "$check_1_4_11"
   else
@@ -620,7 +643,7 @@ fi
 
 check_1_4_12="1.4.12  - Ensure that the etcd data directory ownership is set to etcd:etcd"
 directory=$(get_argument_value "$CIS_ETCD_CMD" '--data-dir')
-if [ -d $directory ]; then
+if [ -d "$directory" ]; then
   if [ "$(stat -c %U:%G $directory)" = "etcd:etcd" ]; then
     pass "$check_1_4_12"
   else
@@ -639,6 +662,8 @@ if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_1_5_1"
         pass "       * cert-file: $cfile"
         pass "       * key-file: $kfile"
@@ -668,6 +693,8 @@ if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--peer-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_1_5_4"
         pass "       * peer-cert-file: $cfile"
         pass "       * peer-key-file: $kfile"

--- a/agent/nvbench/kube_master_1_2_0.tmpl
+++ b/agent/nvbench/kube_master_1_2_0.tmpl
@@ -40,6 +40,11 @@ yell "# ------------------------------------------------------------------------
 # security concerns slow down your CI/CD processes.
 # ------------------------------------------------------------------------------"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 #get a process command line from /proc
 get_command_line_args() {
     PROC="$1"
@@ -65,7 +70,7 @@ get_argument_value() {
         |
     grep "^${OPTION}" |
     sed \
-        -e "s/^${OPTION}=//g"
+        -E "s/^${OPTION}(=|\s+)//g"
 }
 
 #check whether an argument exist in command line
@@ -80,6 +85,19 @@ check_argument() {
     grep "^${OPTION}" 
 }
 
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}
 CIS_APISERVER_CMD="<<<.Replace_apiserver_cmd>>>"
 CIS_MANAGER_CMD="<<<.Replace_manager_cmd>>>"
 CIS_SCHEDULER_CMD="<<<.Replace_scheduler_cmd>>>"
@@ -313,6 +331,7 @@ fi
 check_1_1_25="1.1.25  - Ensure that the --service-account-key-file argument is set as appropriate"
 if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_APISERVER_CMD" '--service-account-key-file')
+    file=$(append_prefix "$CONFIG_PREFIX" "$file")
     pass "$check_1_1_25"
     pass "        * service-account-key-file: $file"
 else
@@ -324,6 +343,8 @@ if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--etcd-keyfile' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-certfile')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-keyfile')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_1_26"
         pass "        * etcd-certfile: $certfile"
         pass "        * etcd-keyfile: $keyfile"
@@ -346,6 +367,8 @@ if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-cert-file')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-private-key-file')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_1_28"
         pass "        * tls-cert-file: $certfile"
         pass "        * tls-private-key-file: $keyfile"
@@ -359,6 +382,7 @@ fi
 check_1_1_29="1.1.29  - Ensure that the --client-ca-file argument is set as appropriate"
 if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_1_29"
     pass "        * client-ca-file: $cafile"
 else
@@ -368,6 +392,7 @@ fi
 check_1_1_30="1.1.30  - Ensure that the --etcd-cafile argument is set as appropriate"
 if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-cafile')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_1_30"
     pass "        * etcd-cafile: $cafile"
 else
@@ -472,6 +497,7 @@ fi
 check_1_3_4="1.3.4  - Ensure that the --service-account-private-key-file argument is set as appropriate"
 if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
     keyfile=$(get_argument_value "$CIS_MANAGER_CMD" '--service-account-private-key-file')
+    keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
     pass "$check_1_3_4"
     pass "       * service-account-private-key-file: $keyfile"
 else
@@ -481,6 +507,7 @@ fi
 check_1_3_5="1.3.5  - Ensure that the --root-ca-file argument is set as appropriate"
 if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_MANAGER_CMD" '--root-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_3_5"
     pass "       * root-ca-file: $cafile"
 else
@@ -489,14 +516,19 @@ fi
 info "1.4 - Configuration Files"
 
 check_1_4_1="1.4.1  - Ensure that the API server pod specification file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/manifests/kube-apiserver.json" ]; then
-    file="/etc/kubernetes/manifests/kube-apiserver.json"
-elif [ -f "/etc/kubernetes/manifests/kube-apiserver.manifest" ]; then
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.json")
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
+if [ -f $config_json ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-apiserver.manifest"
+    file=$config_json
+elif [ -f $config_manifest ]; then
+    # kops
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_1"
@@ -510,14 +542,6 @@ else
 fi
 
 check_1_4_2="1.4.2  - Ensure that the API server pod specification file ownership is set to root:root"
-if [ -f "/etc/kubernetes/manifests/kube-apiserver.json" ]; then
-    file="/etc/kubernetes/manifests/kube-apiserver.json"
-elif [ -f "/etc/kubernetes/manifests/kube-apiserver.manifest" ]; then
-    # kops
-    file="/etc/kubernetes/manifests/kube-apiserver.manifest"
-else
-    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_2"
@@ -530,14 +554,18 @@ else
 fi
 
 check_1_4_3="1.4.3  - Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/manifests/kube-controller-manager.json" ]; then
-    file="/etc/kubernetes/manifests/kube-controller-manager.json"
-elif [ -f "/etc/kubernetes/manifests/kube-controller-manager.manifest" ]; then
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.json")
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
+if [ -f $config_json ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-controller-manager.manifest"
+    file=$config_json
+elif [ -f $config_manifest ]; then
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-controller-manager.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_3"
@@ -551,14 +579,6 @@ else
 fi
 
 check_1_4_4="1.4.4  - Ensure that the controller manager pod specification file ownership is set to root:root"
-if [ -f "/etc/kubernetes/manifests/kube-controller-manager.json" ]; then
-    file="/etc/kubernetes/manifests/kube-controller-manager.json"
-elif [ -f "/etc/kubernetes/manifests/kube-controller-manager.manifest" ]; then
-    # kops
-    file="/etc/kubernetes/manifests/kube-controller-manager.manifest"
-else
-    file="/etc/kubernetes/manifests/kube-controller-manager.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_4"
@@ -572,14 +592,18 @@ else
 fi
 
 check_1_4_5="1.4.5  - Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/manifests/kube-scheduler.json" ]; then
-    file="/etc/kubernetes/manifests/kube-scheduler.json"
-elif [ -f "/etc/kubernetes/manifests/kube-scheduler.manifest" ]; then
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.json")
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
+if [ -f $config_json ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-scheduler.manifest"
+    file=$config_json
+elif [ -f $config_manifest ]; then
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-scheduler.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_5"
@@ -593,14 +617,6 @@ else
 fi
 
 check_1_4_6="1.4.6  - Ensure that the scheduler pod specification file ownership is set to root:root"
-if [ -f "/etc/kubernetes/manifests/kube-scheduler.json" ]; then
-    file="/etc/kubernetes/manifests/kube-scheduler.json"
-elif [ -f "/etc/kubernetes/manifests/kube-scheduler.manifest" ]; then
-    # kops
-    file="/etc/kubernetes/manifests/kube-scheduler.manifest"
-else
-    file="/etc/kubernetes/manifests/kube-scheduler.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %U:%G $file)" = "root:root" ]; then
     pass "$check_1_4_6"
@@ -615,15 +631,20 @@ else
 fi
 
 check_1_4_7="1.4.7  - Ensure that the etcd pod specification file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/manifests/etcd.json" ]; then
-    file="/etc/kubernetes/manifests/etcd.json"
-elif [ -f "/etc/kubernetes/manifests/etcd.manifest" ]; then
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.json")
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
+if [ -f $config_json ]; then
+    # kops
+    file=$config_json
+elif [ -f $config_manifest ]; then
     # kops
     # Also this file is a symlink, hence 'stat -L' below.
-    file="/etc/kubernetes/manifests/etcd.manifest"
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/etcd.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -L -c %a $file)" -eq 644 -o "$(stat -L -c %a $file)" -eq 640 -o "$(stat -L -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_7"
@@ -637,14 +658,6 @@ else
 fi
 
 check_1_4_8="1.4.8  - Ensure that the etcd pod specification file ownership is set to root:root"
-if [ -f "/etc/kubernetes/manifests/etcd.json" ]; then
-    file="/etc/kubernetes/manifests/etcd.json"
-elif [ -f "/etc/kubernetes/manifests/etcd.manifest" ]; then
-    # kops
-    file="/etc/kubernetes/manifests/etcd.manifest"
-else
-    file="/etc/kubernetes/manifests/etcd.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %U:%G $file)" = "root:root" ]; then
     pass "$check_1_4_8"
@@ -692,6 +705,8 @@ fi
 
 check_1_4_13="1.4.13  - Ensure that the admin.conf file permissions are set to 644 or more restrictive"
 file="/etc/kubernetes/admin.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_13"
@@ -707,6 +722,8 @@ fi
 
 check_1_4_14="1.4.14  - Ensure that the admin.conf file ownership is set to root:root"
 file="/etc/kubernetes/admin.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_14"
@@ -722,6 +739,8 @@ fi
 
 check_1_4_15="1.4.15  - Ensure that the scheduler.conf file permissions are set to 644 or more restrictive"
 file="/etc/kubernetes/scheduler.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_15"
@@ -737,6 +756,8 @@ fi
 
 check_1_4_16="1.4.16  - Ensure that the scheduler.conf file ownership is set to root:root"
 file="/etc/kubernetes/scheduler.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_16"
@@ -752,6 +773,8 @@ fi
 
 check_1_4_17="1.4.17  - Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive"
 file="/etc/kubernetes/controller-manager.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_17"
@@ -767,6 +790,8 @@ fi
 
 check_1_4_18="1.4.18  - Ensure that the controller-manager.conf file ownership is set to root:root"
 file="/etc/kubernetes/controller-manager.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_18"
@@ -786,6 +811,8 @@ if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_1_5_1"
         pass "       * cert-file: $cfile"
         pass "       * key-file: $kfile"
@@ -815,6 +842,8 @@ if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--peer-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_1_5_4"
         pass "       * peer-cert-file: $cfile"
         pass "       * peer-key-file: $kfile"

--- a/agent/nvbench/kube_master_1_4_1.tmpl
+++ b/agent/nvbench/kube_master_1_4_1.tmpl
@@ -23,6 +23,11 @@ notScored="1.1.1, 1.1.12, 1.1.13, 1.1.31, 1.4.9, 1.4.10, 1.5.7, 1.6.1, 1.6.2, 1.
 level2="1.3.6, 1.5.7, 1.6.1, 1.6.4, 1.6.5, 1.6.6, 1.6.7, 1.6.8,
  1.7.6, 1.7.7"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 info () {
 
   s_txt=""
@@ -129,7 +134,7 @@ get_argument_value() {
         |
     grep "^${OPTION}" |
     sed \
-        -e "s/^${OPTION}=//g"
+        -E "s/^${OPTION}(=|\s+)//g"
 }
 
 #check whether an argument exist in command line
@@ -144,6 +149,20 @@ check_argument() {
     grep "^${OPTION}"
 }
 
+#get the pid that running the command
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}
 CIS_APISERVER_CMD="<<<.Replace_apiserver_cmd>>>"
 CIS_MANAGER_CMD="<<<.Replace_manager_cmd>>>"
 CIS_SCHEDULER_CMD="<<<.Replace_scheduler_cmd>>>"
@@ -374,6 +393,7 @@ fi
 check_1_1_25="1.1.25  - Ensure that the --service-account-key-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_APISERVER_CMD" '--service-account-key-file')
+    file=$(append_prefix "$CONFIG_PREFIX" "$file")
     pass "$check_1_1_25"
     pass "        * service-account-key-file: $file"
 else
@@ -385,6 +405,8 @@ if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--etcd-keyfile' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-certfile')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-keyfile')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_1_26"
         pass "        * etcd-certfile: $certfile"
         pass "        * etcd-keyfile: $keyfile"
@@ -407,6 +429,8 @@ if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-cert-file')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-private-key-file')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_1_28"
         pass "        * tls-cert-file: $certfile"
         pass "        * tls-private-key-file: $keyfile"
@@ -420,6 +444,7 @@ fi
 check_1_1_29="1.1.29  - Ensure that the --client-ca-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_1_29"
     pass "        * client-ca-file: $cafile"
 else
@@ -429,6 +454,7 @@ fi
 check_1_1_30="1.1.30  - Ensure that the --etcd-cafile argument is set as appropriate (Scored)"
 if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-cafile')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_1_30"
     pass "        * etcd-cafile: $cafile"
 else
@@ -558,6 +584,7 @@ fi
 check_1_3_4="1.3.4  - Ensure that the --service-account-private-key-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
     keyfile=$(get_argument_value "$CIS_MANAGER_CMD" '--service-account-private-key-file')
+    keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
     pass "$check_1_3_4"
     pass "       * service-account-private-key-file: $keyfile"
 else
@@ -567,6 +594,7 @@ fi
 check_1_3_5="1.3.5  - Ensure that the --root-ca-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_MANAGER_CMD" '--root-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_3_5"
     pass "       * root-ca-file: $cafile"
 else
@@ -595,14 +623,19 @@ fi
 info "1.4 - Configuration Files"
 
 check_1_4_1="1.4.1  - Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-apiserver.json" ]; then
-    file="/etc/kubernetes/manifests/kube-apiserver.json"
-elif [ -f "/etc/kubernetes/manifests/kube-apiserver.manifest" ]; then
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.json")
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
+if [ -f $config_json ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-apiserver.manifest"
+    file=$config_json
+elif [ -f $config_manifest ]; then
+    # kops
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_1"
@@ -616,14 +649,6 @@ else
 fi
 
 check_1_4_2="1.4.2  - Ensure that the API server pod specification file ownership is set to root:root (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-apiserver.json" ]; then
-    file="/etc/kubernetes/manifests/kube-apiserver.json"
-elif [ -f "/etc/kubernetes/manifests/kube-apiserver.manifest" ]; then
-    # kops
-    file="/etc/kubernetes/manifests/kube-apiserver.manifest"
-else
-    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_2"
@@ -636,14 +661,19 @@ else
 fi
 
 check_1_4_3="1.4.3  - Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-controller-manager.json" ]; then
-    file="/etc/kubernetes/manifests/kube-controller-manager.json"
-elif [ -f "/etc/kubernetes/manifests/kube-controller-manager.manifest" ]; then
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.json")
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
+if [ -f $config_json ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-controller-manager.manifest"
+    file=$config_json
+elif [ -f $config_manifest ]; then
+    # kops
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-controller-manager.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_3"
@@ -657,14 +687,6 @@ else
 fi
 
 check_1_4_4="1.4.4  - Ensure that the controller manager pod specification file ownership is set to root:root (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-controller-manager.json" ]; then
-    file="/etc/kubernetes/manifests/kube-controller-manager.json"
-elif [ -f "/etc/kubernetes/manifests/kube-controller-manager.manifest" ]; then
-    # kops
-    file="/etc/kubernetes/manifests/kube-controller-manager.manifest"
-else
-    file="/etc/kubernetes/manifests/kube-controller-manager.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_4"
@@ -678,14 +700,18 @@ else
 fi
 
 check_1_4_5="1.4.5  - Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-scheduler.json" ]; then
-    file="/etc/kubernetes/manifests/kube-scheduler.json"
-elif [ -f "/etc/kubernetes/manifests/kube-scheduler.manifest" ]; then
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.json")
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
+if [ -f $config_json ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-scheduler.manifest"
+    file=$config_json
+elif [ -f $config_manifest ]; then
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-scheduler.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_5"
@@ -699,14 +725,6 @@ else
 fi
 
 check_1_4_6="1.4.6  - Ensure that the scheduler pod specification file ownership is set to root:root (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-scheduler.json" ]; then
-    file="/etc/kubernetes/manifests/kube-scheduler.json"
-elif [ -f "/etc/kubernetes/manifests/kube-scheduler.manifest" ]; then
-    # kops
-    file="/etc/kubernetes/manifests/kube-scheduler.manifest"
-else
-    file="/etc/kubernetes/manifests/kube-scheduler.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %U:%G $file)" = "root:root" ]; then
     pass "$check_1_4_6"
@@ -721,15 +739,20 @@ else
 fi
 
 check_1_4_7="1.4.7  - Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/etc/kubernetes/manifests/etcd.json" ]; then
-    file="/etc/kubernetes/manifests/etcd.json"
-elif [ -f "/etc/kubernetes/manifests/etcd.manifest" ]; then
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.json")
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
+if [ -f $config_json ]; then
+    # kops
+    file=$config_json
+elif [ -f $config_manifest ]; then
     # kops
     # Also this file is a symlink, hence 'stat -L' below.
-    file="/etc/kubernetes/manifests/etcd.manifest"
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/etcd.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -L -c %a $file)" -eq 644 -o "$(stat -L -c %a $file)" -eq 640 -o "$(stat -L -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_7"
@@ -743,14 +766,6 @@ else
 fi
 
 check_1_4_8="1.4.8  - Ensure that the etcd pod specification file ownership is set to root:root (Scored)"
-if [ -f "/etc/kubernetes/manifests/etcd.json" ]; then
-    file="/etc/kubernetes/manifests/etcd.json"
-elif [ -f "/etc/kubernetes/manifests/etcd.manifest" ]; then
-    # kops
-    file="/etc/kubernetes/manifests/etcd.manifest"
-else
-    file="/etc/kubernetes/manifests/etcd.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %U:%G $file)" = "root:root" ]; then
     pass "$check_1_4_8"
@@ -802,6 +817,8 @@ fi
 
 check_1_4_13="1.4.13  - Ensure that the admin.conf file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/admin.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_13"
@@ -817,6 +834,8 @@ fi
 
 check_1_4_14="1.4.14  - Ensure that the admin.conf file ownership is set to root:root (Scored)"
 file="/etc/kubernetes/admin.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_14"
@@ -832,6 +851,8 @@ fi
 
 check_1_4_15="1.4.15  - Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/scheduler.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_15"
@@ -847,6 +868,8 @@ fi
 
 check_1_4_16="1.4.16  - Ensure that the scheduler.conf file ownership is set to root:root (Scored)"
 file="/etc/kubernetes/scheduler.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_16"
@@ -862,6 +885,8 @@ fi
 
 check_1_4_17="1.4.17  - Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/controller-manager.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_17"
@@ -877,6 +902,8 @@ fi
 
 check_1_4_18="1.4.18  - Ensure that the controller-manager.conf file ownership is set to root:root (Scored)"
 file="/etc/kubernetes/controller-manager.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_18"
@@ -892,6 +919,7 @@ fi
 
 check_1_4_19="1.4.19  - Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Scored)"
 file="/etc/kubernetes/pki/"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 files=$(find $file)
 pass=true
 for f in ${files}; do
@@ -945,6 +973,8 @@ if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_1_5_1"
         pass "       * cert-file: $cfile"
         pass "       * key-file: $kfile"
@@ -974,6 +1004,8 @@ if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--peer-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_1_5_4"
         pass "       * peer-cert-file: $cfile"
         pass "       * peer-key-file: $kfile"
@@ -1003,6 +1035,8 @@ if check_argument "$CIS_ETCD_CMD" '--trusted-ca-file' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
         tfile=$(get_argument_value "$CIS_ETCD_CMD" '--trusted-ca-file')
         cfile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+        tfile=$(append_prefix "$CONFIG_PREFIX" "$tfile")
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
         if [ "$tfile" = "$cfile" ]; then
             pass "$check_1_5_7"
             pass "       * trusted-ca-file: $tfile"

--- a/agent/nvbench/kube_master_1_5_1.tmpl
+++ b/agent/nvbench/kube_master_1_5_1.tmpl
@@ -20,6 +20,11 @@ fi
 
 level2="1.3.6, 2.7, 3.1.1, 3.2.2, 4.2.9, 5.2.9, 5.3.2, 5.4.2, 5.5.1, 5.7.2, 5.7.3, 5.7.4"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 info () {
 
   s_txt=""
@@ -126,7 +131,7 @@ get_argument_value() {
         |
     grep "^${OPTION}" |
     sed \
-        -e "s/^${OPTION}=//g"
+        -E "s/^${OPTION}(=|\s+)//g"
 }
 
 #check whether an argument exist in command line
@@ -141,6 +146,20 @@ check_argument() {
     grep "^${OPTION}"
 }
 
+#append prefix for the file
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}
 CIS_APISERVER_CMD="<<<.Replace_apiserver_cmd>>>"
 CIS_MANAGER_CMD="<<<.Replace_manager_cmd>>>"
 CIS_SCHEDULER_CMD="<<<.Replace_scheduler_cmd>>>"
@@ -159,12 +178,15 @@ info "1 - Control Plane Components"
 info "1.1 - Master Node Configuration Files"
 
 check_1_1_1="1.1.1  - Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-apiserver.manifest" ]; then
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
+if [ -f $config_manifest ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-apiserver.manifest"
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_1_1"
@@ -190,11 +212,13 @@ else
 fi
 
 check_1_1_3="1.1.3  - Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-controller-manager.manifest" ]; then
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
+if [ -f $config_manifest ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-controller-manager.manifest"
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-controller-manager.yaml"
+    file=$config_yaml
 fi
 
 if [ -f "$file" ]; then
@@ -222,11 +246,13 @@ else
 fi
 
 check_1_1_5="1.1.5  - Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-scheduler.yaml" ]; then
-    file="/etc/kubernetes/manifests/kube-scheduler.yaml"
-else
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
+if [ -f $config_yaml ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-scheduler.manifest"
+    file=$config_yaml
+else
+    file=$config_manifest
 fi
 
 if [ -f "$file" ]; then
@@ -254,11 +280,13 @@ else
 fi
 
 check_1_1_7="1.1.7  - Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/etc/kubernetes/manifests/etcd.yaml" ]; then
-    file="/etc/kubernetes/manifests/etcd.yaml"
-else
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
+if [ -f $config_yaml ]; then
     # kops
-    file="/etc/kubernetes/manifests/etcd.manifest"
+    file=$config_yaml
+else
+    file=$config_manifest
 fi
 
 if [ -f "$file" ]; then
@@ -305,6 +333,8 @@ file=""
 if check_argument "$CIS_ETCD_CMD" '--data-dir' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_ETCD_CMD" '--data-dir'|cut -d " " -f 1)
 fi
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 700 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_11"
@@ -332,6 +362,8 @@ fi
 
 check_1_1_13="1.1.13  - Ensure that the admin.conf file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/admin.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_13"
@@ -358,6 +390,8 @@ fi
 
 check_1_1_15="1.1.15  - Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/scheduler.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_15"
@@ -384,6 +418,8 @@ fi
 
 check_1_1_17="1.1.17  - Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/controller-manager.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_17"
@@ -410,6 +446,7 @@ fi
 
 check_1_1_19="1.1.19  - Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Scored)"
 file="/etc/kubernetes/pki/"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 files=$(find $file)
 pass=true
 for f in ${files}; do
@@ -698,6 +735,7 @@ fi
 check_1_2_28="1.2.28  - Ensure that the --service-account-key-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_APISERVER_CMD" '--service-account-key-file')
+    file=$(append_prefix "$CONFIG_PREFIX" "$file")
     pass "$check_1_2_28"
     pass "        * service-account-key-file: $file"
 else
@@ -709,6 +747,8 @@ if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--etcd-keyfile' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-certfile')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-keyfile')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_2_29"
         pass "        * etcd-certfile: $certfile"
         pass "        * etcd-keyfile: $keyfile"
@@ -724,6 +764,8 @@ if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-cert-file')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-private-key-file')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_2_30"
         pass "        * tls-cert-file: $certfile"
         pass "        * tls-private-key-file: $keyfile"
@@ -737,6 +779,7 @@ fi
 check_1_2_31="1.2.31  - Ensure that the --client-ca-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_2_31"
     pass "        * client-ca-file: $cafile"
 else
@@ -746,6 +789,7 @@ fi
 check_1_2_32="1.2.32  - Ensure that the --etcd-cafile argument is set as appropriate (Scored)"
 if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-cafile')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_2_32"
     pass "        * etcd-cafile: $cafile"
 else
@@ -828,6 +872,7 @@ fi
 check_1_3_4="1.3.4  - Ensure that the --service-account-private-key-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
     keyfile=$(get_argument_value "$CIS_MANAGER_CMD" '--service-account-private-key-file')
+    keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
     pass "$check_1_3_4"
     pass "       * service-account-private-key-file: $keyfile"
 else
@@ -837,6 +882,7 @@ fi
 check_1_3_5="1.3.5  - Ensure that the --root-ca-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_MANAGER_CMD" '--root-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_3_5"
     pass "       * root-ca-file: $cafile"
 else
@@ -885,6 +931,8 @@ if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_2_1"
         pass "       * cert-file: $cfile"
         pass "       * key-file: $kfile"
@@ -914,6 +962,8 @@ if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--peer-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_2_4"
         pass "       * peer-cert-file: $cfile"
         pass "       * peer-key-file: $kfile"
@@ -944,6 +994,8 @@ if check_argument "$CIS_ETCD_CMD" '--trusted-ca-file' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
         tfile=$(get_argument_value "$CIS_ETCD_CMD" '--trusted-ca-file')
         cfile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+        tfile=$(append_prefix "$CONFIG_PREFIX" "$tfile")
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
         if [ "$tfile" = "$cfile" ]; then
             pass "$check_2_7"
             pass "       * trusted-ca-file: $tfile"
@@ -972,6 +1024,7 @@ info "3.2 - Logging"
 check_3_2_1="3.2.1 - Ensure that a minimal audit policy is created (Scored)"
 if check_argument "$CIS_APISERVER_CMD" '--audit-policy-file' >/dev/null 2>&1; then
     auditPolicyFile=$(get_argument_value "$CIS_APISERVER_CMD" '--audit-policy-file')
+    auditPolicyFile=$(append_prefix "$CONFIG_PREFIX" "$auditPolicyFile")
     pass "$check_3_2_1"
     pass "        * audit-policy-file: $auditPolicyFile"
 else

--- a/agent/nvbench/kube_master_1_6_0.tmpl
+++ b/agent/nvbench/kube_master_1_6_0.tmpl
@@ -22,6 +22,11 @@ level2="1.3.6, 2.7, 3.1.1, 3.2.2, 4.2.9, 5.2.9, 5.3.2, 5.4.2, 5.5.1, 5.7.2, 5.7.
 not_scored="1.1.9, 1.1.10, 1.1.20, 1.1.21, 1.2.1, 1.2.10, 1.2.12, 1.2.13, 1.2.33, 1.2.34, 1.2.35, 1.3.1, 2.7, 3.1.1, 3.2.2, 4,2.8, 4.2.9, 4.2.13, 5.1.1, 5.1.2, 5.1.3, 5.1.4, 5.1.6, 5.2.1, 5.2.6, 5.2.7, 5.2.8, 5.2.9, 5.3.1, 5.4.1, 5.4.2, 5.5.1, 5.7.1, 5.7.2, 5.7.3"
 assessment_manual="1.1.9, 1.1.10, 1.1.20, 1.1.21, 1.2.1, 1.2.10, 1.2.12, 1.2.13, 1.2.33, 1.2.34, 1.2.35, 1.3.1, 2.7, 3.1.1, 3.2.1, 3.2.2, 4.1.3, 4.1.4, 4.1.6, 4.1.7, 4.1.8, 4.2.4, 4.2.5, 4.2.8, 4.2.9, 4.2.10, 4.2.11, 4.2.12, 4.2.13, 5.1.1, 5.1.2, 5.1.3, 5.1.4, 5.1.5, 5.1.6, 5.2.1, 5.2.2, 5.2.3, 5.2.4, 5.2.5, 5.2.6, 5.2.7, 5.2.8, 5.2.9, 5.3.1, 5.3.2, 5.4.1, 5.4.2, 5.5.1, 5.7.1, 5.7.2, 5.7.3, 5.7.4"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 info () {
 
   s_txt=""
@@ -146,7 +151,7 @@ get_argument_value() {
         |
     grep "^${OPTION}" |
     sed \
-        -e "s/^${OPTION}=//g"
+        -E "s/^${OPTION}(=|\s+)//g"
 }
 
 #check whether an argument exist in command line
@@ -161,6 +166,20 @@ check_argument() {
     grep "^${OPTION}"
 }
 
+#append prefix for the file
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}
 CIS_APISERVER_CMD="<<<.Replace_apiserver_cmd>>>"
 CIS_MANAGER_CMD="<<<.Replace_manager_cmd>>>"
 CIS_SCHEDULER_CMD="<<<.Replace_scheduler_cmd>>>"
@@ -179,12 +198,15 @@ info "1 - Control Plane Components"
 info "1.1 - Master Node Configuration Files"
 
 check_1_1_1="1.1.1  - Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
-if [ -f "/etc/kubernetes/manifests/kube-apiserver.manifest" ]; then
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
+if [ -f $config_manifest ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-apiserver.manifest"
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_1_1"
@@ -210,11 +232,13 @@ else
 fi
 
 check_1_1_3="1.1.3  - Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Automated)"
-if [ -f "/etc/kubernetes/manifests/kube-controller-manager.manifest" ]; then
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
+if [ -f $config_manifest ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-controller-manager.manifest"
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-controller-manager.yaml"
+    file=$config_yaml
 fi
 
 if [ -f "$file" ]; then
@@ -242,11 +266,13 @@ else
 fi
 
 check_1_1_5="1.1.5  - Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Automated)"
-if [ -f "/etc/kubernetes/manifests/kube-scheduler.yaml" ]; then
-    file="/etc/kubernetes/manifests/kube-scheduler.yaml"
-else
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
+if [ -f $config_yaml ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-scheduler.manifest"
+    file=$config_yaml
+else
+    file=$config_manifest
 fi
 
 if [ -f "$file" ]; then
@@ -274,11 +300,13 @@ else
 fi
 
 check_1_1_7="1.1.7  - Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"
-if [ -f "/etc/kubernetes/manifests/etcd.yaml" ]; then
-    file="/etc/kubernetes/manifests/etcd.yaml"
-else
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
+if [ -f $config_yaml ]; then
     # kops
-    file="/etc/kubernetes/manifests/etcd.manifest"
+    file=$config_yaml
+else
+    file=$config_manifest
 fi
 
 if [ -f "$file" ]; then
@@ -325,6 +353,8 @@ file=""
 if check_argument "$CIS_ETCD_CMD" '--data-dir' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_ETCD_CMD" '--data-dir'|cut -d " " -f 1)
 fi
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 700 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_11"
@@ -352,6 +382,8 @@ fi
 
 check_1_1_13="1.1.13  - Ensure that the admin.conf file permissions are set to 644 or more restrictive (Automated)"
 file="/etc/kubernetes/admin.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_13"
@@ -378,6 +410,8 @@ fi
 
 check_1_1_15="1.1.15  - Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
 file="/etc/kubernetes/scheduler.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_15"
@@ -404,6 +438,8 @@ fi
 
 check_1_1_17="1.1.17  - Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
 file="/etc/kubernetes/controller-manager.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_17"
@@ -430,6 +466,7 @@ fi
 
 check_1_1_19="1.1.19  - Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
 file="/etc/kubernetes/pki/"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 files=$(find $file)
 pass=true
 for f in ${files}; do
@@ -718,6 +755,7 @@ fi
 check_1_2_28="1.2.28  - Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
 if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_APISERVER_CMD" '--service-account-key-file')
+    file=$(append_prefix "$CONFIG_PREFIX" "$file")
     pass "$check_1_2_28"
     pass "        * service-account-key-file: $file"
 else
@@ -729,6 +767,8 @@ if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--etcd-keyfile' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-certfile')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-keyfile')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_2_29"
         pass "        * etcd-certfile: $certfile"
         pass "        * etcd-keyfile: $keyfile"
@@ -744,6 +784,8 @@ if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-cert-file')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-private-key-file')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_2_30"
         pass "        * tls-cert-file: $certfile"
         pass "        * tls-private-key-file: $keyfile"
@@ -757,6 +799,7 @@ fi
 check_1_2_31="1.2.31  - Ensure that the --client-ca-file argument is set as appropriate (Automated)"
 if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_2_31"
     pass "        * client-ca-file: $cafile"
 else
@@ -766,6 +809,7 @@ fi
 check_1_2_32="1.2.32  - Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
 if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-cafile')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_2_32"
     pass "        * etcd-cafile: $cafile"
 else
@@ -848,6 +892,7 @@ fi
 check_1_3_4="1.3.4  - Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
 if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
     keyfile=$(get_argument_value "$CIS_MANAGER_CMD" '--service-account-private-key-file')
+    keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
     pass "$check_1_3_4"
     pass "       * service-account-private-key-file: $keyfile"
 else
@@ -857,6 +902,7 @@ fi
 check_1_3_5="1.3.5  - Ensure that the --root-ca-file argument is set as appropriate (Automated)"
 if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_MANAGER_CMD" '--root-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_3_5"
     pass "       * root-ca-file: $cafile"
 else
@@ -905,6 +951,8 @@ if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_2_1"
         pass "       * cert-file: $cfile"
         pass "       * key-file: $kfile"
@@ -934,6 +982,8 @@ if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--peer-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_2_4"
         pass "       * peer-cert-file: $cfile"
         pass "       * peer-key-file: $kfile"
@@ -964,6 +1014,8 @@ if check_argument "$CIS_ETCD_CMD" '--trusted-ca-file' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
         tfile=$(get_argument_value "$CIS_ETCD_CMD" '--trusted-ca-file')
         cfile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+        tfile=$(append_prefix "$CONFIG_PREFIX" "$tfile")
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
         if [ "$tfile" = "$cfile" ]; then
             pass "$check_2_7"
             pass "       * trusted-ca-file: $tfile"
@@ -992,6 +1044,7 @@ info "3.2 - Logging"
 check_3_2_1="3.2.1 - Ensure that a minimal audit policy is created (Manual)"
 if check_argument "$CIS_APISERVER_CMD" '--audit-policy-file' >/dev/null 2>&1; then
     auditPolicyFile=$(get_argument_value "$CIS_APISERVER_CMD" '--audit-policy-file')
+    auditPolicyFile=$(append_prefix "$CONFIG_PREFIX" "$auditPolicyFile")
     pass "$check_3_2_1"
     pass "        * audit-policy-file: $auditPolicyFile"
 else

--- a/agent/nvbench/kube_master_gke_1_0_0.tmpl
+++ b/agent/nvbench/kube_master_gke_1_0_0.tmpl
@@ -21,6 +21,11 @@ fi
 level2="1.3.6, 2.7, 3.1.1, 3.2.2, 4.2.9, 5.2.6, 5.2.9, 5.3.2, 5.4.2, 5.6.2, 5.6.3, 5.6.4,
 6.1.4, 6.2.1, 6.4.2, 6.5.1, 6.5.7, 6.6.1, 6.6.4, 6.6.8, 6.7.2, 6.8.3, 6.10.4, 6.10.5"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 info () {
 
   s_txt=""

--- a/agent/nvbench/kube_master_ocp_4_3.tmpl
+++ b/agent/nvbench/kube_master_ocp_4_3.tmpl
@@ -158,6 +158,19 @@ check_argument() {
     grep "^${OPTION}"
 }
 
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}
 info "1 - Control Plane Components"
 
 info "1.1 - Master Node Configuration Files"

--- a/agent/nvbench/kube_master_ocp_4_3.tmpl
+++ b/agent/nvbench/kube_master_ocp_4_3.tmpl
@@ -113,6 +113,11 @@ yell "# ------------------------------------------------------------------------
 # security concerns slow down your CI/CD processes.
 # ------------------------------------------------------------------------------"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 #get a process command line from /proc
 get_command_line_args() {
     PROC="$1"
@@ -160,6 +165,7 @@ info "1.1 - Master Node Configuration Files"
 check_1_1_1="1.1.1  - Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Scored)"
 
 file="/etc/kubernetes/manifests/kube-apiserver-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_1_1"
@@ -175,6 +181,7 @@ fi
 check_1_1_2="1.1.2  - Ensure that the API server pod specification file ownership is set to root:root (Scored)"
 
 file="/etc/kubernetes/manifests/kube-apiserver-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_2"
@@ -189,6 +196,7 @@ fi
 check_1_1_3="1.1.3  - Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Scored)"
 
 file="/etc/kubernetes/manifests/kube-controller-manager-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_3"
@@ -204,6 +212,7 @@ fi
 check_1_1_4="1.1.4  - Ensure that the controller manager pod specification file ownership is set to root:root (Scored)"
 
 file="/etc/kubernetes/manifests/kube-controller-manager-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_4"
@@ -218,6 +227,7 @@ fi
 check_1_1_5="1.1.5  - Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Scored)"
 
 file="/etc/kubernetes/manifests/kube-scheduler-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_5"
@@ -233,6 +243,7 @@ fi
 check_1_1_6="1.1.6  - Ensure that the scheduler pod specification file ownership is set to root:root (Scored)"
 
 file="/etc/kubernetes/manifests/kube-scheduler-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_6"
@@ -247,6 +258,7 @@ fi
 check_1_1_7="1.1.7  - Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Scored)"
 
 file="/etc/kubernetes/manifests/etcd-member.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_7"
@@ -262,6 +274,7 @@ fi
 check_1_1_8="1.1.8  - Ensure that the etcd pod specification file ownership is set to root:root (Scored)"
 
 file="/etc/kubernetes/manifests/etcd-member.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_8"
@@ -277,15 +290,17 @@ fi
 check_1_1_9="1.1.9  - Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Not Scored)"
 
 valid_permission=true
-path_cni_netd="/etc/cni/net.d"
-path_cni_bin="/opt/cni/bin"
-path_sdn_lib_ocpsdn="/var/lib/cni/networks/openshift-sdn"
-path_sdn_run_ocpsdn="/var/run/openshift-sdn"
-path_ovs_openv="/var/run/openvswitch"
-path_ovs_k8s="/var/run/kubernetes"
-path_ovs_etc_openv="/etc/openvswitch"
-path_ovs_run_openv="/run/openvswitch"
-path_ovs_var_openv="/var/run/openvswitch"
+path_cni_netd=$(append_prefix "$CONFIG_PREFIX" "/etc/cni/net.d")
+path_cni_bin=$(append_prefix "$CONFIG_PREFIX" "/opt/cni/bin")
+
+path_sdn_lib_ocpsdn=$(append_prefix "$CONFIG_PREFIX" "/var/lib/cni/networks/openshift-sdn")
+path_sdn_run_ocpsdn=$(append_prefix "$CONFIG_PREFIX" "/var/run/openshift-sdn")
+
+path_ovs_openv=$(append_prefix "$CONFIG_PREFIX" "/var/run/openvswitch")
+path_ovs_k8s=$(append_prefix "$CONFIG_PREFIX" "/var/run/kubernetes")
+path_ovs_etc_openv=$(append_prefix "$CONFIG_PREFIX" "/etc/openvswitch")
+path_ovs_run_openv=$(append_prefix "$CONFIG_PREFIX" "/run/openvswitch")
+path_ovs_var_openv=$(append_prefix "$CONFIG_PREFIX" "/var/run/openvswitch")
 
 invalid_file_list=""
 
@@ -316,17 +331,17 @@ fi
 check_1_1_10="1.1.10  - Ensure that the Container Network Interface file ownership is set to root:root (Not Scored)"
 
 valid_ownership=true
-path_cni_netd="/etc/cni/net.d"
-path_cni_bin="/opt/cni/bin"
+path_cni_netd=$(append_prefix "$CONFIG_PREFIX" "/etc/cni/net.d")
+path_cni_bin=$(append_prefix "$CONFIG_PREFIX" "/opt/cni/bin")
 
-path_sdn_lib_ocpsdn="/var/lib/cni/networks/openshift-sdn"
-path_sdn_run_ocpsdn="/var/run/openshift-sdn"
+path_sdn_lib_ocpsdn=$(append_prefix "$CONFIG_PREFIX" "/var/lib/cni/networks/openshift-sdn")
+path_sdn_run_ocpsdn=$(append_prefix "$CONFIG_PREFIX" "/var/run/openshift-sdn")
 
-path_ovs_openv="/var/run/openvswitch"
-path_ovs_k8s="/var/run/kubernetes"
-path_ovs_etc_openv="/etc/openvswitch"
-path_ovs_run_openv="/run/openvswitch"
-path_ovs_var_openv="/var/run/openvswitch"
+path_ovs_openv=$(append_prefix "$CONFIG_PREFIX" "/var/run/openvswitch")
+path_ovs_k8s=$(append_prefix "$CONFIG_PREFIX" "/var/run/kubernetes")
+path_ovs_etc_openv=$(append_prefix "$CONFIG_PREFIX" "/etc/openvswitch")
+path_ovs_run_openv=$(append_prefix "$CONFIG_PREFIX" "/run/openvswitch")
+path_ovs_var_openv=$(append_prefix "$CONFIG_PREFIX" "/var/run/openvswitch")
 
 invalid_file_list=""
 
@@ -371,6 +386,7 @@ fi
 check_1_1_11="1.1.11  - Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
 
 file="/var/lib/etcd"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -d "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 700 ]; then
     pass "$check_1_1_11"
@@ -385,6 +401,7 @@ fi
 check_1_1_12="1.1.12  - Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
 
 file="/var/lib/etcd"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -d "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_12"
@@ -399,6 +416,7 @@ fi
 check_1_1_13="1.1.13  - Ensure that the admin.conf file permissions are set to 644 or more restrictive (Scored)"
 
 file="/etc/kubernetes/kubeconfig"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_13"
@@ -414,6 +432,7 @@ fi
 check_1_1_14="1.1.14  - Ensure that the admin.conf file ownership is set to root:root (Scored)"
 
 file="/etc/kubernetes/kubeconfig"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_14"
@@ -426,8 +445,7 @@ else
 fi
 
 check_1_1_15="1.1.15  - Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Scored)"
-
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
 
 valid_permission=false
 for i in $files
@@ -447,8 +465,7 @@ else
 fi
 
 check_1_1_16="1.1.16  - Ensure that the scheduler.conf file ownership is set to root:root (Scored)"
-
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
 
 valid_permission=false
 for i in $files
@@ -468,8 +485,7 @@ else
 fi
 
 check_1_1_17="1.1.17  - Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Scored)"
-
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
 
 valid_permission=false
 for i in $files
@@ -489,8 +505,7 @@ else
 fi
 
 check_1_1_18="1.1.18  - Ensure that the controller-manager.conf file ownership is set to root:root (Scored)"
-
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
 
 valid_permission=false
 for i in $files
@@ -510,9 +525,8 @@ else
 fi
 
 check_1_1_19="1.1.19  - Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Scored)"
-
-directories=$(find /etc/kubernetes/static-pod-resources -type d -wholename '*/secrets*')
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/secrets*')
+directories=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type d -wholename '*/secrets*')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/secrets*')
 
 valid_perm_dir=false
 for i in $directories
@@ -543,7 +557,7 @@ else
 fi
 
 check_1_1_20="1.1.20  - Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Not Scored)"
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/secrets/*.crt')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/secrets/*.crt')
 valid_perm_file=false
 for i in $files
 do
@@ -562,7 +576,7 @@ else
 fi
 
 check_1_1_21="1.1.21  - Ensure that the Kubernetes PKI key file permissions are set to 600 (Not Scored)"
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/secrets/*.key')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/secrets/*.key')
 valid_perm_file=false
 for i in $files
 do
@@ -1047,6 +1061,7 @@ info "2 - etcd"
 
 check_2_1="2.1  - Ensure that the --cert-file and --key-file arguments are set as appropriate (Scored)"
 file="/etc/kubernetes/manifests/etcd-member.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output_cert=$(grep "\(--cert-file=\)" $file)
 output_key=$(grep "\(--key-file=\)" $file)
 if [ -z "$output_cert" ] || [ -z "$output_key" ]; then
@@ -1057,6 +1072,7 @@ fi
 
 check_2_2="2.2  - Ensure that the --client-cert-auth argument is set to true (Scored)"
 file="/etc/kubernetes/manifests/etcd-member.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep "\(--client-cert-auth=true\)" $file)
 if [ -z "$output" ]; then
     warn "$check_2_2"
@@ -1066,6 +1082,7 @@ fi
 
 check_2_3="2.3  - Ensure that the --auto-tls argument is not set to true (Scored)"
 file="/etc/kubernetes/manifests/etcd-member.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep "\(--auto-tls=true\)" $file)
 if [ -z "$output" ]; then
     pass "$check_2_3"
@@ -1075,6 +1092,7 @@ fi
 
 check_2_4="2.4  - Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Scored)"
 file="/etc/kubernetes/manifests/etcd-member.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output_cert=$(grep "\(--peer-cert-file=\)" $file)
 output_key=$(grep "\(--peer-key-file=\)" $file)
 if [ -z "$output_cert" ] || [ -z "$output_key" ]; then
@@ -1085,6 +1103,7 @@ fi
 
 check_2_5="2.5  - Ensure that the --peer-client-cert-auth argument is set to true (Scored)"
 file="/etc/kubernetes/manifests/etcd-member.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep "\(--peer-client-cert-auth=true\)" $file)
 if [ -z "$output" ]; then
     warn "$check_2_5"
@@ -1094,6 +1113,7 @@ fi
 
 check_2_6="2.6  - Ensure that the --peer-auto-tls argument is not set to true (Scored)"
 file="/etc/kubernetes/manifests/etcd-member.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep "\(--peer-auto-tls=true\)" $file)
 if [ -z "$output" ]; then
     pass "$check_2_6"
@@ -1103,7 +1123,8 @@ fi
 
 check_2_7="2.7  - Ensure that a unique Certificate Authority is used for etcd (Not Scored)"
 file="/etc/kubernetes/manifests/etcd-member.yaml"
-output=$(grep "\(--trusted-ca-file=/etc/ssl/etcd/ca.crt\)" $file)
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+output=$(grep "$(append_prefix "$CONFIG_PREFIX" "/etc/ssl/etcd/ca.crt")" "$file")
 if [ -z "$output" ]; then
     warn "$check_2_7"
 else
@@ -1115,7 +1136,7 @@ info "3.1 - Authentication and Authorization"
 
 #todo review
 check_3_1_1="3.1.1  - Client certificate authentication should not be used for users (Not Scored)"
-output=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*configmaps/client-ca/ca-bundle.crt')
+output=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*configmaps/client-ca/ca-bundle.crt')
 if [ -z "$output" ]; then
   warn "$check_3_1_1"
 else

--- a/agent/nvbench/kube_master_ocp_4_5.tmpl
+++ b/agent/nvbench/kube_master_ocp_4_5.tmpl
@@ -158,6 +158,19 @@ check_argument() {
     grep "^${OPTION}"
 }
 
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}
 info "1 - Control Plane Components"
 
 info "1.1 - Master Node Configuration Files"

--- a/agent/nvbench/kube_master_ocp_4_5.tmpl
+++ b/agent/nvbench/kube_master_ocp_4_5.tmpl
@@ -113,6 +113,11 @@ yell "# ------------------------------------------------------------------------
 # security concerns slow down your CI/CD processes.
 # ------------------------------------------------------------------------------"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 #get a process command line from /proc
 get_command_line_args() {
     PROC="$1"
@@ -160,6 +165,7 @@ info "1.1 - Master Node Configuration Files"
 check_1_1_1="1.1.1  - Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Manual)"
 
 file="/etc/kubernetes/manifests/kube-apiserver-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_1_1"
@@ -175,6 +181,7 @@ fi
 check_1_1_2="1.1.2  - Ensure that the API server pod specification file ownership is set to root:root (Manual)"
 
 file="/etc/kubernetes/manifests/kube-apiserver-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_2"
@@ -189,6 +196,7 @@ fi
 check_1_1_3="1.1.3  - Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Manual)"
 
 file="/etc/kubernetes/manifests/kube-controller-manager-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_3"
@@ -204,6 +212,7 @@ fi
 check_1_1_4="1.1.4  - Ensure that the controller manager pod specification file ownership is set to root:root (Manual)"
 
 file="/etc/kubernetes/manifests/kube-controller-manager-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_4"
@@ -218,6 +227,7 @@ fi
 check_1_1_5="1.1.5  - Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Manual)"
 
 file="/etc/kubernetes/manifests/kube-scheduler-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_5"
@@ -233,6 +243,7 @@ fi
 check_1_1_6="1.1.6  - Ensure that the scheduler pod specification file ownership is set to root:root (Manual)"
 
 file="/etc/kubernetes/manifests/kube-scheduler-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_6"
@@ -248,6 +259,7 @@ fi
 check_1_1_7="1.1.7  - Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Manual)"
 
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_7"
@@ -263,6 +275,7 @@ fi
 check_1_1_8="1.1.8  - Ensure that the etcd pod specification file ownership is set to root:root (Manual)"
 
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_8"
@@ -277,16 +290,16 @@ fi
 check_1_1_9="1.1.9  - Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
 
 valid_permission=true
-path_cni_netd="/etc/cni/net.d"
-path_cni_bin="/opt/cni/bin"
-path_cni_multus="/var/run/multus/cni/net.d"
-path_sdn_lib_ocpsdn="/var/lib/cni/networks/openshift-sdn"
-path_sdn_run_ocpsdn="/var/run/openshift-sdn"
-path_ovs_openv="/var/run/openvswitch"
-path_ovs_k8s="/var/run/kubernetes"
-path_ovs_etc_openv="/etc/openvswitch"
-path_ovs_run_openv="/run/openvswitch"
-path_ovs_var_openv="/var/run/openvswitch"
+path_cni_netd=$(append_prefix "$CONFIG_PREFIX" "/etc/cni/net.d")
+path_cni_bin=$(append_prefix "$CONFIG_PREFIX" "/opt/cni/bin")
+path_cni_multus=$(append_prefix "$CONFIG_PREFIX" "/var/run/multus/cni/net.d")
+path_sdn_lib_ocpsdn=$(append_prefix "$CONFIG_PREFIX" "/var/lib/cni/networks/openshift-sdn")
+path_sdn_run_ocpsdn=$(append_prefix "$CONFIG_PREFIX" "/var/run/openshift-sdn")
+path_ovs_openv=$(append_prefix "$CONFIG_PREFIX" "/var/run/openvswitch")
+path_ovs_k8s=$(append_prefix "$CONFIG_PREFIX" "/var/run/kubernetes")
+path_ovs_etc_openv=$(append_prefix "$CONFIG_PREFIX" "/etc/openvswitch")
+path_ovs_run_openv=$(append_prefix "$CONFIG_PREFIX" "/run/openvswitch")
+path_ovs_var_openv=$(append_prefix "$CONFIG_PREFIX" "/var/run/openvswitch")
 
 invalid_file_list=""
 
@@ -317,18 +330,18 @@ fi
 check_1_1_10="1.1.10  - Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
 
 valid_ownership=true
-path_cni_netd="/etc/cni/net.d"
-path_cni_bin="/opt/cni/bin"
-path_cni_multus="/var/run/multus/cni/net.d"
+path_cni_netd=$(append_prefix "$CONFIG_PREFIX" "/etc/cni/net.d")
+path_cni_bin=$(append_prefix "$CONFIG_PREFIX" "/opt/cni/bin")
+path_cni_multus=$(append_prefix "$CONFIG_PREFIX" "/var/run/multus/cni/net.d")
 
-path_sdn_lib_ocpsdn="/var/lib/cni/networks/openshift-sdn"
-path_sdn_run_ocpsdn="/var/run/openshift-sdn"
+path_sdn_lib_ocpsdn=$(append_prefix "$CONFIG_PREFIX" "/var/lib/cni/networks/openshift-sdn")
+path_sdn_run_ocpsdn=$(append_prefix "$CONFIG_PREFIX" "/var/run/openshift-sdn")
 
-path_ovs_openv="/var/run/openvswitch"
-path_ovs_k8s="/var/run/kubernetes"
-path_ovs_etc_openv="/etc/openvswitch"
-path_ovs_run_openv="/run/openvswitch"
-path_ovs_var_openv="/var/run/openvswitch"
+path_ovs_openv=$(append_prefix "$CONFIG_PREFIX" "/var/run/openvswitch")
+path_ovs_k8s=$(append_prefix "$CONFIG_PREFIX" "/var/run/kubernetes")
+path_ovs_etc_openv=$(append_prefix "$CONFIG_PREFIX" "/etc/openvswitch")
+path_ovs_run_openv=$(append_prefix "$CONFIG_PREFIX" "/run/openvswitch")
+path_ovs_var_openv=$(append_prefix "$CONFIG_PREFIX" "/var/run/openvswitch")
 
 invalid_file_list=""
 
@@ -373,6 +386,7 @@ fi
 check_1_1_11="1.1.11  - Ensure that the etcd data directory permissions are set to 700 or more restrictive (Manual)"
 
 file="/var/lib/etcd"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -d "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 700 ]; then
     pass "$check_1_1_11"
@@ -388,6 +402,7 @@ fi
 check_1_1_12="1.1.12  - Ensure that the etcd data directory ownership is set to root:root (Manual)"
 
 file="/var/lib/etcd"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -d "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_12"
@@ -402,6 +417,7 @@ fi
 check_1_1_13="1.1.13  - Ensure that the admin.conf file permissions are set to 644 or more restrictive (Manual)"
 
 file="/etc/kubernetes/kubeconfig"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -le 644 ]; then
     pass "$check_1_1_13"
@@ -417,6 +433,7 @@ fi
 check_1_1_14="1.1.14  - Ensure that the admin.conf file ownership is set to root:root (Manual)"
 
 file="/etc/kubernetes/kubeconfig"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_14"
@@ -430,7 +447,7 @@ fi
 
 check_1_1_15="1.1.15  - Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Manual)"
 
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
 
 valid_permission=false
 for i in $files
@@ -451,7 +468,7 @@ fi
 
 check_1_1_16="1.1.16  - Ensure that the scheduler.conf file ownership is set to root:root (Manual)"
 
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
 
 valid_permission=false
 for i in $files
@@ -472,7 +489,7 @@ fi
 
 check_1_1_17="1.1.17  - Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Manual)"
 
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
 
 valid_permission=false
 for i in $files
@@ -493,7 +510,7 @@ fi
 
 check_1_1_18="1.1.18  - Ensure that the controller-manager.conf file ownership is set to root:root (Manual)"
 
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
 
 valid_permission=false
 for i in $files
@@ -515,6 +532,7 @@ fi
 check_1_1_19="1.1.19  - Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Manual)"
 
 cert_path="/etc/kubernetes/static-pod-certs"
+cert_path=$(append_prefix "$CONFIG_PREFIX" "$cert_path")
 valid_perm_dir=false
 valid_perm_file=false
 
@@ -556,6 +574,7 @@ fi
 check_1_1_20="1.1.20  - Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
 
 cert_path="/etc/kubernetes/static-pod-certs"
+cert_path=$(append_prefix "$CONFIG_PREFIX" "$cert_path")
 if [ -f "$cert_path" ]; then
   files=$(find $cert_path -type f -wholename '*/secrets/*.crt')
   valid_perm_file=false
@@ -582,6 +601,7 @@ fi
 check_1_1_21="1.1.21  - Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
 
 cert_path="/etc/kubernetes/static-pod-certs"
+cert_path=$(append_prefix "$CONFIG_PREFIX" "$cert_path")
 
 if [ -f "$cert_path" ]; then
   files=$(find $cert_path -type f -wholename '*/secrets/*.key')
@@ -1071,6 +1091,7 @@ fi
 
 check_2_1="2.1  - Ensure that the --cert-file and --key-file arguments are set as appropriate (Manual)"
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output_cert=$(grep "\(--cert-file=\)" $file)
 output_key=$(grep "\(--key-file=\)" $file)
 if [ -z "$output_cert" ] || [ -z "$output_key" ]; then
@@ -1081,6 +1102,7 @@ fi
 
 check_2_2="2.2  - Ensure that the --client-cert-auth argument is set to true (Manual)"
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep "\(--client-cert-auth=true\)" $file)
 if [ -z "$output" ]; then
     warn "$check_2_2"
@@ -1091,6 +1113,7 @@ fi
 #todo review with Andson (OCP doesn't use auto-tls)
 check_2_3="2.3  - Ensure that the --auto-tls argument is not set to true (Manual)"
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep "\(--auto-tls=true\)" $file)
 if [ -z "$output" ]; then
     pass "$check_2_3"
@@ -1100,6 +1123,7 @@ fi
 
 check_2_4="2.4  - Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Manual)"
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output_cert=$(grep "\(--peer-cert-file=\)" $file)
 output_key=$(grep "\(--peer-key-file=\)" $file)
 if [ -z "$output_cert" ] || [ -z "$output_key" ]; then
@@ -1110,6 +1134,7 @@ fi
 
 check_2_5="2.5  - Ensure that the --peer-client-cert-auth argument is set to true (Manual)"
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep "\(--peer-client-cert-auth=true\)" $file)
 if [ -z "$output" ]; then
     warn "$check_2_5"
@@ -1119,6 +1144,7 @@ fi
 
 check_2_6="2.6  - Ensure that the --peer-auto-tls argument is not set to true (Manual)"
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep "\(--peer-auto-tls=true\)" $file)
 if [ -z "$output" ]; then
     pass "$check_2_6"
@@ -1128,6 +1154,7 @@ fi
 
 check_2_7="2.7  - Ensure that a unique Certificate Authority is used for etcd (Manual)"
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output_1=$(grep "\(--trusted-ca-file=\)" $file)
 output_2=$(grep "\(--peer-trusted-ca-file=\)" $file)
 if [ -z "$output_1" ] || [ -z "$output_2" ]; then
@@ -1141,7 +1168,7 @@ info "3.1 - Authentication and Authorization"
 
 #todo review
 check_3_1_1="3.1.1  - Client certificate authentication should not be used for users (Manual)"
-output=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*configmaps/client-ca/ca-bundle.crt')
+output=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*configmaps/client-ca/ca-bundle.crt')
 if [ -z "$output" ]; then
   warn "$check_3_1_1"
 else

--- a/agent/nvbench/kube_worker_1_0_0.tmpl
+++ b/agent/nvbench/kube_worker_1_0_0.tmpl
@@ -40,6 +40,11 @@ yell "# ------------------------------------------------------------------------
 # security concerns slow down your CI/CD processes.
 # ------------------------------------------------------------------------------"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 #get a process command line from /proc
 get_command_line_args() {
     PROC="$1"
@@ -65,7 +70,7 @@ get_argument_value() {
         |
     grep "^${OPTION}" |
     sed \
-        -e "s/^${OPTION}=//g"
+        -E "s/^${OPTION}(=|\s+)//g"
 }
 
 #check whether an argument exist in command line
@@ -80,6 +85,19 @@ check_argument() {
     grep "^${OPTION}" 
 }
 
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}
 CIS_KUBELET_CMD="<<<.Replace_kubelet_cmd>>>"
 
 if ps -ef | grep "$CIS_KUBELET_CMD" 2>/dev/null | grep -v "grep" >/dev/null 2>&1; then
@@ -115,6 +133,7 @@ fi
 check_2_1_4="2.1.4  - Ensure that the --client-ca-file argument is set as appropriate"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_2_1_4"
     pass "       * client-ca-file: $cafile"
 else
@@ -189,6 +208,8 @@ if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_KUBELET_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-cert-file')
         kfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-private-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_2_1_12"
         pass "        * tls-cert-file: $cfile"
         pass "        * tls-private-key-file: $kfile"
@@ -215,10 +236,12 @@ fi
 info "2.2 - Configuration Files"
 
 check_2_2_1="2.2.1  - Ensure that the config file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/config" ]; then
-    file="/etc/kubernetes/config"
+config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/config")
+kubelet_config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet.conf")
+if [ -f $config ]; then
+    file=$config
 else
-    file="/etc/kubernetes/kubelet.conf"
+    file=$kubelet_config
 fi
 
 if [ -f "$file" ]; then
@@ -246,10 +269,12 @@ else
 fi
 
 check_2_2_3="2.2.3  - Ensure that the kubelet file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/kubelet" ]; then
-    file="/etc/kubernetes/kubelet"
+config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubele")
+kubelet_config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet.conf")
+if [ -f $config ]; then
+    file=$config
 else
-    file="/etc/kubernetes/kubelet.conf"
+    file=$kubelet_config
 fi
 
 if [ -f "$file" ]; then
@@ -278,7 +303,7 @@ fi
 
 check_2_2_5="2.2.5  - Ensure that the proxy file permissions are set to 644 or more restrictive"
 file="/etc/kubernetes/proxy"
-
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_2_2_5"

--- a/agent/nvbench/kube_worker_1_2_0.tmpl
+++ b/agent/nvbench/kube_worker_1_2_0.tmpl
@@ -40,6 +40,11 @@ yell "# ------------------------------------------------------------------------
 # security concerns slow down your CI/CD processes.
 # ------------------------------------------------------------------------------"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 #get a process command line from /proc
 get_command_line_args() {
     PROC="$1"
@@ -65,7 +70,7 @@ get_argument_value() {
         |
     grep "^${OPTION}" |
     sed \
-        -e "s/^${OPTION}=//g"
+        -E "s/^${OPTION}(=|\s+)//g"
 }
 
 #check whether an argument exist in command line
@@ -80,6 +85,19 @@ check_argument() {
     grep "^${OPTION}" 
 }
 
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}
 CIS_KUBELET_CMD="<<<.Replace_kubelet_cmd>>>"
 
 if ps -ef | grep "$CIS_KUBELET_CMD" 2>/dev/null | grep -v "grep" >/dev/null 2>&1; then
@@ -115,6 +133,7 @@ fi
 check_2_1_4="2.1.4  - Ensure that the --client-ca-file argument is set as appropriate"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_2_1_4"
     pass "       * client-ca-file: $cafile"
 else
@@ -189,6 +208,8 @@ if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_KUBELET_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-cert-file')
         kfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-private-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_2_1_12"
         pass "        * tls-cert-file: $cfile"
         pass "        * tls-private-key-file: $kfile"
@@ -215,13 +236,15 @@ fi
 info "2.2 - Configuration Files"
 
 check_2_2_1="2.2.1  - Ensure that the config file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/config" ]; then
-    file="/etc/kubernetes/config"
-elif [ -f "/var/lib/kubelet/kubeconfig" ]; then
-    # kops
-    file="/var/lib/kubelet/kubeconfig"
+config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/config")
+kubeletconfig=$(append_prefix "$CONFIG_PREFIX" "/var/lib/kubelet/kubeconfig")
+kubelet_config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet.conf")
+if [ -f $config ]; then
+    file=$config
+elif [ -f $kubeletconfig ]; then
+    file=$kubeletconfig
 else
-    file="/etc/kubernetes/kubelet.conf"
+    file=$kubelet_config
 fi
 
 if [ -f "$file" ]; then
@@ -249,13 +272,15 @@ else
 fi
 
 check_2_2_3="2.2.3  - Ensure that the kubelet file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/kubelet" ]; then
-    file="/etc/kubernetes/kubelet"
-elif [ -f "/etc/sysconfig/kubelet" ]; then
-    # kops
-    file="/etc/sysconfig/kubelet"
+config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet")
+kubelet_sysconfig=$(append_prefix "$CONFIG_PREFIX" "/etc/sysconfig/kubelet")
+kubelet_config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet.conf")
+if [ -f $config ]; then
+    file=$config
+elif [ -f $kubelet_sysconfig ]; then
+    file=$kubelet_sysconfig
 else
-    file="/etc/kubernetes/kubelet.conf"
+    file=$kubelet_config
 fi
 
 if [ -f "$file" ]; then
@@ -283,11 +308,12 @@ else
 fi
 
 check_2_2_5="2.2.5  - Ensure that the proxy file permissions are set to 644 or more restrictive"
-if [ -f "/var/lib/kube-proxy/kubeconfig" ]; then
-    # kops
-    file="/var/lib/kube-proxy/kubeconfig"
+config=$(append_prefix "$CONFIG_PREFIX" "/var/lib/kube-proxy/kubeconfig")
+proxy_config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/proxy")
+if [ -f $config ]; then
+    file=$config
 else
-    file="/etc/kubernetes/proxy"
+    file=$proxy_config
 fi
 
 if [ -f "$file" ]; then
@@ -317,6 +343,7 @@ fi
 check_2_2_7="2.2.7  - Ensure that the certificate authorities file permissions are set to 644 or more restrictive"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_2_2_7"
     pass "       * client-ca-file: $file"
@@ -332,6 +359,7 @@ fi
 check_2_2_8="2.2.8  - Ensure that the client certificate authorities file ownership is set to root:root"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_2_2_8"
     pass "       * client-ca-file: $file"

--- a/agent/nvbench/kube_worker_1_4_1.tmpl
+++ b/agent/nvbench/kube_worker_1_4_1.tmpl
@@ -23,6 +23,11 @@ notScored="1.1.1, 1.1.12, 1.1.13, 1.1.31, 1.4.9, 1.4.10, 1.5.7, 1.6.1, 1.6.2, 1.
 level2="1.3.6, 1.5.7, 1.6.1, 1.6.4, 1.6.5, 1.6.6, 1.6.7, 1.6.8,
  1.7.6, 1.7.7"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 info () {
 
   s_txt=""
@@ -129,7 +134,7 @@ get_argument_value() {
         |
     grep "^${OPTION}" |
     sed \
-        -e "s/^${OPTION}=//g"
+        -E "s/^${OPTION}(=|\s+)//g"
 }
 
 #check whether an argument exist in command line
@@ -144,6 +149,20 @@ check_argument() {
     grep "^${OPTION}"
 }
 
+#get the pid that running the command
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}
 CIS_KUBELET_CMD="<<<.Replace_kubelet_cmd>>>"
 CIS_PROXY_CMD="<<<.Replace_proxy_cmd>>>"
 
@@ -173,6 +192,7 @@ fi
 check_2_1_3="2.1.3  - Ensure that the --client-ca-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_2_1_3"
     pass "       * client-ca-file: $cafile"
 else
@@ -240,6 +260,8 @@ if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_KUBELET_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-cert-file')
         kfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-private-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_2_1_10"
         pass "        * tls-cert-file: $cfile"
         pass "        * tls-private-key-file: $kfile"
@@ -262,6 +284,7 @@ fi
 
 check_2_1_13="2.1.13  - Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
 file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 found=$(sed -rn '/--feature-gates=RotateKubeletServerCertificate=true/p' $file)
 if [ -z "$found" ]; then
     warn "$check_2_1_13"
@@ -285,7 +308,7 @@ info "2.2 - Configuration Files"
 
 check_2_2_1="2.2.1  - Ensure that the kubelet service file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
-
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_2_2_1"
@@ -300,6 +323,7 @@ fi
 
 check_2_2_2="2.2.2  - Ensure that the kubelet.conf file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_2_2_2"
@@ -315,6 +339,7 @@ fi
 
 check_2_2_3="2.2.3  - Ensure that the kubelet.conf file ownership is set to root:root (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_2_2_3"
@@ -328,6 +353,7 @@ fi
 
 check_2_2_4="2.2.4  - Ensure that the kubelet service file ownership is set to root:root (Scored)"
 file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_2_2_4"
@@ -344,6 +370,7 @@ file=""
 if check_argument "$CIS_PROXY_CMD" '--kubeconfig' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
 fi
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
@@ -362,6 +389,8 @@ file=""
 if check_argument "$CIS_PROXY_CMD" '--kubeconfig' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
 fi
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_2_2_6"
@@ -377,6 +406,7 @@ fi
 check_2_2_7="2.2.7  - Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_2_2_7"
     pass "       * client-ca-file: $file"
@@ -392,6 +422,7 @@ fi
 check_2_2_8="2.2.8  - Ensure that the client certificate authorities file ownership is set to root:root (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_2_2_8"
     pass "       * client-ca-file: $file"
@@ -407,6 +438,7 @@ fi
 check_2_2_9="2.2.9  - Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_2_2_9"
     pass "       * config: $file"
@@ -422,6 +454,7 @@ fi
 check_2_2_10="2.2.10  - Ensure that the kubelet configuration file ownership is set to root:root (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_2_2_10"
     pass "       * client: $file"

--- a/agent/nvbench/kube_worker_1_5_1.tmpl
+++ b/agent/nvbench/kube_worker_1_5_1.tmpl
@@ -20,6 +20,11 @@ fi
 
 level2="1.3.6, 2.7, 3.1.1, 3.2.2, 4.2.9, 5.2.9, 5.3.2, 5.4.2, 5.5.1, 5.7.2, 5.7.3, 5.7.4"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 info () {
 
   s_txt=""
@@ -126,7 +131,7 @@ get_argument_value() {
         |
     grep "^${OPTION}" |
     sed \
-        -e "s/^${OPTION}=//g"
+        -E "s/^${OPTION}(=|\s+)//g"
 }
 
 #check whether an argument exist in command line
@@ -141,6 +146,20 @@ check_argument() {
     grep "^${OPTION}"
 }
 
+#append prefix for the file
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}
 CIS_KUBELET_CMD="<<<.Replace_kubelet_cmd>>>"
 CIS_PROXY_CMD="<<<.Replace_proxy_cmd>>>"
 
@@ -155,6 +174,8 @@ info "4.1 - Worker Node Configuration Files"
 
 check_4_1_1="4.1.1  - Ensure that the kubelet service file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_1"
@@ -184,6 +205,7 @@ file=""
 if check_argument "$CIS_PROXY_CMD" '--kubeconfig' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
 fi
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
@@ -211,11 +233,13 @@ else
 fi
 
 check_4_1_5="4.1.5  - Ensure that the kubelet.conf file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/var/lib/kube-proxy/kubeconfig" ]; then
+kube_proxy_config=$(append_prefix "$CONFIG_PREFIX" "/var/lib/kube-proxy/kubeconfig")
+kubernetes_proxy=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/proxy")
+if [ -f $kube_proxy_config ]; then
     # kops
-    file="/var/lib/kube-proxy/kubeconfig"
+    file=$kube_proxy_config
 else
-    file="/etc/kubernetes/proxy"
+    file=$kubernetes_proxy
 fi
 
 if [ -f "$file" ]; then
@@ -245,6 +269,8 @@ fi
 check_4_1_7="4.1.7  - Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_7"
     pass "       * client-ca-file: $file"
@@ -260,6 +286,8 @@ fi
 check_4_1_8="4.1.8  - Ensure that the client certificate authorities file ownership is set to root:root (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_8"
     pass "       * client-ca-file: $file"
@@ -275,6 +303,7 @@ fi
 check_4_1_9="4.1.9  - Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_9"
     pass "       * kubelet configuration file: $file"
@@ -290,6 +319,7 @@ fi
 check_4_1_10="4.1.10  - Ensure that the kubelet configuration file ownership is set to root:root (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_10"
     pass "       * kubelet configuration file: $file"
@@ -322,6 +352,7 @@ fi
 check_4_2_3="4.2.3  - Ensure that the --client-ca-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_4_2_3"
     pass "       * client-ca-file: $cafile"
 else
@@ -383,6 +414,8 @@ if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_KUBELET_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-cert-file')
         kfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-private-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_4_2_10"
         pass "        * tls-cert-file: $cfile"
         pass "        * tls-private-key-file: $kfile"
@@ -408,6 +441,7 @@ fi
 
 check_4_2_12="4.2.12  - Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
 file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 found=$(sed -rn '/--feature-gates=RotateKubeletServerCertificate=true/p' $file)
 if [ -z "$found" ]; then
     warn "$check_4_2_12"

--- a/agent/nvbench/kube_worker_1_6_0.tmpl
+++ b/agent/nvbench/kube_worker_1_6_0.tmpl
@@ -22,6 +22,11 @@ level2="1.3.6, 2.7, 3.1.1, 3.2.2, 4.2.9, 5.2.9, 5.3.2, 5.4.2, 5.5.1, 5.7.2, 5.7.
 not_scored="1.1.9, 1.1.10, 1.1.20, 1.1.21, 1.2.1, 1.2.10, 1.2.12, 1.2.13, 1.2.33, 1.2.34, 1.2.35, 1.3.1, 2.7, 3.1.1, 3.2.2, 4,2.8, 4.2.9, 4.2.13, 5.1.1, 5.1.2, 5.1.3, 5.1.4, 5.1.6, 5.2.1, 5.2.6, 5.2.7, 5.2.8, 5.2.9, 5.3.1, 5.4.1, 5.4.2, 5.5.1, 5.7.1, 5.7.2, 5.7.3"
 assessment_manual="1.1.9, 1.1.10, 1.1.20, 1.1.21, 1.2.1, 1.2.10, 1.2.12, 1.2.13, 1.2.33, 1.2.34, 1.2.35, 1.3.1, 2.7, 3.1.1, 3.2.1, 3.2.2, 4.1.3, 4.1.4, 4.1.6, 4.1.7, 4.1.8, 4.2.4, 4.2.5, 4.2.8, 4.2.9, 4.2.10, 4.2.11, 4.2.12, 4.2.13, 5.1.1, 5.1.2, 5.1.3, 5.1.4, 5.1.5, 5.1.6, 5.2.1, 5.2.2, 5.2.3, 5.2.4, 5.2.5, 5.2.6, 5.2.7, 5.2.8, 5.2.9, 5.3.1, 5.3.2, 5.4.1, 5.4.2, 5.5.1, 5.7.1, 5.7.2, 5.7.3, 5.7.4"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 info () {
 
   s_txt=""
@@ -146,7 +151,7 @@ get_argument_value() {
         |
     grep "^${OPTION}" |
     sed \
-        -e "s/^${OPTION}=//g"
+        -E "s/^${OPTION}(=|\s+)//g"
 }
 
 #check whether an argument exist in command line
@@ -161,6 +166,20 @@ check_argument() {
     grep "^${OPTION}"
 }
 
+#append prefix for the file
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}
 CIS_KUBELET_CMD="<<<.Replace_kubelet_cmd>>>"
 CIS_PROXY_CMD="<<<.Replace_proxy_cmd>>>"
 
@@ -175,6 +194,8 @@ info "4.1 - Worker Node Configuration Files"
 
 check_4_1_1="4.1.1  - Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
 file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_1"
@@ -205,6 +226,7 @@ if check_argument "$CIS_PROXY_CMD" '--kubeconfig' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
 fi
 
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_3"
@@ -231,11 +253,14 @@ else
 fi
 
 check_4_1_5="4.1.5  - Ensure that the kubelet.conf file permissions are set to 644 or more restrictive (Automated)"
-if [ -f "/var/lib/kube-proxy/kubeconfig" ]; then
+kube_proxy_config=$(append_prefix "$CONFIG_PREFIX" "/var/lib/kube-proxy/kubeconfig")
+kubernetes_proxy=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/proxy")
+
+if [ -f $kube_proxy_config ]; then
     # kops
-    file="/var/lib/kube-proxy/kubeconfig"
+    file=$kube_proxy_config
 else
-    file="/etc/kubernetes/proxy"
+    file=$kubernetes_proxy
 fi
 
 if [ -f "$file" ]; then
@@ -265,6 +290,7 @@ fi
 check_4_1_7="4.1.7  - Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_7"
     pass "       * client-ca-file: $file"
@@ -280,6 +306,7 @@ fi
 check_4_1_8="4.1.8  - Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_8"
     pass "       * client-ca-file: $file"
@@ -295,6 +322,7 @@ fi
 check_4_1_9="4.1.9  - Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Automated)"
 if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_9"
     pass "       * kubelet configuration file: $file"
@@ -310,6 +338,7 @@ fi
 check_4_1_10="4.1.10  - Ensure that the kubelet configuration file ownership is set to root:root (Automated)"
 if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_10"
     pass "       * kubelet configuration file: $file"
@@ -342,6 +371,7 @@ fi
 check_4_2_3="4.2.3  - Ensure that the --client-ca-file argument is set as appropriate (Automated)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_4_2_3"
     pass "       * client-ca-file: $cafile"
 else
@@ -403,6 +433,8 @@ if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_KUBELET_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-cert-file')
         kfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-private-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_4_2_10"
         pass "        * tls-cert-file: $cfile"
         pass "        * tls-private-key-file: $kfile"
@@ -428,6 +460,7 @@ fi
 
 check_4_2_12="4.2.12  - Ensure that the RotateKubeletServerCertificate argument is set to true (Manual)"
 file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 found=$(sed -rn '/--feature-gates=RotateKubeletServerCertificate=true/p' $file)
 if [ -z "$found" ]; then
     warn "$check_4_2_12"

--- a/agent/nvbench/kube_worker_gke_1_0_0.tmpl
+++ b/agent/nvbench/kube_worker_gke_1_0_0.tmpl
@@ -21,6 +21,11 @@ fi
 level2="1.3.6, 2.7, 3.1.1, 3.2.2, 4.2.9, 5.2.6, 5.2.9, 5.3.2, 5.4.2, 5.6.2, 5.6.3, 5.6.4,
 6.1.4, 6.2.1, 6.4.2, 6.5.1, 6.5.7, 6.6.1, 6.6.4, 6.6.8, 6.7.2, 6.8.3, 6.10.4, 6.10.5"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 info () {
 
   s_txt=""
@@ -165,6 +170,7 @@ file=""
 if check_argument "$CIS_PROXY_CMD" '--kubeconfig' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
 fi
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
@@ -206,6 +212,7 @@ info "$check_4_1_8"
 check_4_1_9="4.1.9  - Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_9"
     pass "       * kubelet configuration file: $file"
@@ -221,6 +228,7 @@ fi
 check_4_1_10="4.1.10  - Ensure that the kubelet configuration file ownership is set to root:root (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_10"
     pass "       * kubelet configuration file: $file"
@@ -253,6 +261,7 @@ fi
 check_4_2_3="4.2.3  - Ensure that the --client-ca-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_4_2_3"
     pass "       * client-ca-file: $cafile"
 else
@@ -314,6 +323,8 @@ if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_KUBELET_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-cert-file')
         kfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-private-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_4_2_10"
         pass "        * tls-cert-file: $cfile"
         pass "        * tls-private-key-file: $kfile"
@@ -333,6 +344,7 @@ fi
 
 check_4_2_12="4.2.12  - Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
 file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 found=$(sed -rn '/--feature-gates=RotateKubeletServerCertificate=true/p' $file 2>/dev/null)
 if [ -z "$found" ]; then
     warn "$check_4_2_12"

--- a/agent/nvbench/kube_worker_ocp_4_3.tmpl
+++ b/agent/nvbench/kube_worker_ocp_4_3.tmpl
@@ -158,6 +158,19 @@ check_argument() {
     grep "^${OPTION}"
 }
 
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}
 info "4.1 - Worker Node Configuration Files"
 
 check_4_1_1="4.1.1  - Ensure that the kubelet service file permissions are set to 644 or more restrictive (Scored)"

--- a/agent/nvbench/kube_worker_ocp_4_3.tmpl
+++ b/agent/nvbench/kube_worker_ocp_4_3.tmpl
@@ -113,6 +113,11 @@ yell "# ------------------------------------------------------------------------
 # security concerns slow down your CI/CD processes.
 # ------------------------------------------------------------------------------"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 #get a process command line from /proc
 get_command_line_args() {
     PROC="$1"
@@ -157,6 +162,7 @@ info "4.1 - Worker Node Configuration Files"
 
 check_4_1_1="4.1.1  - Ensure that the kubelet service file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/systemd/system/kubelet.service"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_1"
@@ -171,6 +177,7 @@ fi
 
 check_4_1_2="4.1.2  - Ensure that the kubelet service file ownership is set to root:root (Scored)"
 file="/etc/systemd/system/kubelet.service"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_2"
@@ -188,6 +195,7 @@ fi
 
 check_4_1_5="4.1.5  - Ensure that the kubelet.conf file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_5"
@@ -202,6 +210,7 @@ fi
 
 check_4_1_6="4.1.6  - Ensure that the kubelet.conf file ownership is set to root:root (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_6"
@@ -215,6 +224,7 @@ fi
 
 check_4_1_7="4.1.7  - Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/kubelet-ca.crt"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_7"
@@ -229,6 +239,7 @@ fi
 
 check_4_1_8="4.1.8  - Ensure that the client certificate authorities file ownership is set to root:root (Scored)"
 file="/etc/kubernetes/kubelet-ca.crt"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_8"
@@ -242,6 +253,7 @@ fi
 
 check_4_1_9="4.1.9  - Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Scored)"
 file="/var/lib/kubelet/kubeconfig"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_4_1_9"
@@ -256,6 +268,7 @@ fi
 
 check_4_1_10="4.1.10  - Ensure that the kubelet configuration file ownership is set to root:root (Scored)"
 file="/var/lib/kubelet/kubeconfig"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_10"
@@ -272,7 +285,9 @@ info "4.2 - Kubelet"
 #todo review all audits
 check_4_2_1="4.2.1  - Ensure that the anonymous-auth argument is set to false (Scored)"
 file="/etc/kubernetes/kubelet.conf"
-output_ca=$(grep '\(clientCAFile: /etc/kubernetes/kubelet-ca.crt\)' $file)
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+ca_cert=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet-ca.crt")
+output_ca=$(grep "clientCAFile: $ca_cert" $file)
 output_auth=$(grep '\(enabled: false\)' $file)
 if [ -z "$output_ca" ] || [ -z "$output_auth" ] ; then
     warn "$check_4_2_1"
@@ -282,6 +297,7 @@ fi
 
 check_4_2_2="4.2.2  - Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(authorization-mode\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_2"
@@ -291,7 +307,9 @@ fi
 
 check_4_2_3="4.2.3  - Ensure that the --client-ca-file argument is set as appropriate (Scored)"
 file="/etc/kubernetes/kubelet.conf"
-output_ca=$(grep '\(clientCAFile: /etc/kubernetes/kubelet-ca.crt\)' $file)
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+ca_cert=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet-ca.crt")
+output_ca=$(grep "clientCAFile: $ca_cert" $file)
 if [ -z "$output_ca" ]; then
     warn "$check_4_2_3"
 else
@@ -301,6 +319,7 @@ fi
 #todo review (ocp by default setting)
 check_4_2_4="4.2.4  - Ensure that the --read-only-port argument is set to 0 (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(read-only-port\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_4"
@@ -310,6 +329,7 @@ fi
 
 check_4_2_5="4.2.5  - Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(streaming-connection-idle-timeout\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_5"
@@ -319,6 +339,7 @@ fi
 
 check_4_2_7="4.2.7  - Ensure that the --make-iptables-util-chains argument is set to true (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(make-iptables-util-chains\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_7"
@@ -331,6 +352,7 @@ info "$check_4_2_9"
 
 check_4_2_10="4.2.10  - Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output_cert=$(grep '\(tls-cert-file\)' $file)
 output_key=$(grep '\(tls-private-key-file\)' $file)
 if [ -z "$output_cert" ] && [ -z "$output_key" ]; then
@@ -354,6 +376,7 @@ fi
 
 check_4_2_11="4.2.11  - Ensure that the RotateKubeletClientCertificate argument is not set to false (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(RotateKubeletClientCertificate\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_11"
@@ -374,6 +397,7 @@ fi
 
 check_4_2_12="4.2.12  - Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(RotateKubeletServerCertificate: true\)' $file)
 if [ -z "$output" ]; then
     warn "$check_4_2_12"

--- a/agent/nvbench/kube_worker_ocp_4_5.tmpl
+++ b/agent/nvbench/kube_worker_ocp_4_5.tmpl
@@ -113,6 +113,11 @@ yell "# ------------------------------------------------------------------------
 # security concerns slow down your CI/CD processes.
 # ------------------------------------------------------------------------------"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 #get a process command line from /proc
 get_command_line_args() {
     PROC="$1"
@@ -157,6 +162,7 @@ info "4.1 - Worker Node Configuration Files"
 
 check_4_1_1="4.1.1  - Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
 file="/etc/systemd/system/kubelet.service"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_1"
@@ -171,6 +177,7 @@ fi
 
 check_4_1_2="4.1.2  - Ensure that the kubelet service file ownership is set to root:root (Automated)"
 file="/etc/systemd/system/kubelet.service"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_2"
@@ -191,6 +198,7 @@ info "$check_4_1_4"
 
 check_4_1_5="4.1.5  - Ensure that the kubelet.conf file permissions are set to 644 or more restrictive (Manual)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_5"
@@ -205,6 +213,7 @@ fi
 
 check_4_1_6="4.1.6  - Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Manual)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_6"
@@ -218,6 +227,7 @@ fi
 
 check_4_1_7="4.1.7  - Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Automated)"
 file="/etc/kubernetes/kubelet-ca.crt"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_7"
@@ -232,6 +242,7 @@ fi
 
 check_4_1_8="4.1.8  - Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
 file="/etc/kubernetes/kubelet-ca.crt"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_8"
@@ -245,6 +256,7 @@ fi
 
 check_4_1_9="4.1.9  - Ensure that the kubelet --config configuration file has permissions set to 644 or more restrictive (Automated)"
 file="/var/lib/kubelet/kubeconfig"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_4_1_9"
@@ -259,6 +271,7 @@ fi
 
 check_4_1_10="4.1.10  - Ensure that the kubelet configuration file ownership is set to root:root (Automated)"
 file="/var/lib/kubelet/kubeconfig"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_10"
@@ -275,7 +288,9 @@ info "4.2 - Kubelet"
 #todo review all audits
 check_4_2_1="4.2.1  - Ensure that the anonymous-auth argument is set to false (Automated)"
 file="/etc/kubernetes/kubelet.conf"
-output_ca=$(grep '\(clientCAFile: /etc/kubernetes/kubelet-ca.crt\)' $file)
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+ca_cert=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet-ca.crt")
+output_ca=$(grep "clientCAFile: $ca_cert" $file)
 output_auth=$(grep '\(enabled: false\)' $file)
 if [ -z "$output_ca" ] || [ -z "$output_auth" ] ; then
     warn "$check_4_2_1"
@@ -285,6 +300,7 @@ fi
 
 check_4_2_2="4.2.2  - Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(authorization-mode\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_2"
@@ -294,7 +310,9 @@ fi
 
 check_4_2_3="4.2.3  - Ensure that the --client-ca-file argument is set as appropriate (Automated)"
 file="/etc/kubernetes/kubelet.conf"
-output_ca=$(grep '\(clientCAFile: /etc/kubernetes/kubelet-ca.crt\)' $file)
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+ca_cert=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet-ca.crt")
+output_ca=$(grep "clientCAFile: $ca_cert" $file)
 if [ -z "$output_ca" ]; then
     warn "$check_4_2_3"
 else
@@ -304,6 +322,7 @@ fi
 #todo review (ocp by default setting)
 check_4_2_4="4.2.4  - Verify that the read only port is not used or is set to 0 (Automated)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(read-only-port\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_4"
@@ -313,6 +332,7 @@ fi
 
 check_4_2_5="4.2.5  - Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Automated)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(streaming-connection-idle-timeout\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_5"
@@ -322,6 +342,7 @@ fi
 
 check_4_2_6="4.2.6  - Ensure that the --protect-kernel-defaults argument is not set (Manual)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(protectKernelDefaults\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_5"
@@ -331,6 +352,7 @@ fi
 
 check_4_2_7="4.2.7  - Ensure that the --make-iptables-util-chains argument is set to true (Manual)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(make-iptables-util-chains\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_7"
@@ -340,6 +362,7 @@ fi
 
 check_4_2_8="4.2.8  - Ensure that the --hostname-override argument is not set (Manual)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(hostname-override\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_7"
@@ -349,6 +372,7 @@ fi
 
 check_4_2_9="4.2.9  - Ensure that the kubeAPIQPS [--event-qps] argument is set to 0 or a level which ensures appropriate event capture (Automated)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(kubeAPIQPS: 50\)' $file)
 if [ -z "$output" ]; then
     warn "$check_4_2_9"
@@ -358,6 +382,7 @@ fi
 
 check_4_2_10="4.2.10  - Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output_cert=$(grep '\(tls-cert-file\)' $file)
 output_key=$(grep '\(tls-private-key-file\)' $file)
 if [ -z "$output_cert" ] && [ -z "$output_key" ]; then
@@ -381,6 +406,7 @@ fi
 
 check_4_2_11="4.2.11  - Ensure that the --rotate-certificates argument is not set to false (Manual)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output1=$(grep '\(rotateKubeletClientCertificates: false\)' $file)
 output2=$(grep '\(rotateCertificates: true\)' $file)
 if [ -z "$output1"] && [ -n "$output2" ]; then
@@ -402,6 +428,7 @@ fi
 
 check_4_2_12="4.2.12  - Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output1=$(grep '\(RotateKubeletServerCertificate: true\)' $file)
 output2=$(grep '\(rotateCertificates: true\)' $file)
 if [ -n "$output1" ] && [ -n "$output2" ] ; then

--- a/agent/nvbench/kube_worker_ocp_4_5.tmpl
+++ b/agent/nvbench/kube_worker_ocp_4_5.tmpl
@@ -158,6 +158,19 @@ check_argument() {
     grep "^${OPTION}"
 }
 
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}
 info "4.1 - Worker Node Configuration Files"
 
 check_4_1_1="4.1.1  - Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"

--- a/agent/nvbench/kubernetes-cis-benchmark/1.0.0/master/master_1_api_server.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.0.0/master/master_1_api_server.sh
@@ -226,6 +226,7 @@ fi
 check_1_1_26="1.1.26  - Ensure that the --service-account-key-file argument is set as appropriate"
 if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_APISERVER_CMD" '--service-account-key-file')
+    file=$(append_prefix "$CONFIG_PREFIX" "$file")
     pass "$check_1_1_26"
     pass "        * service-account-key-file: $file"
 else
@@ -237,6 +238,8 @@ if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--etcd-keyfile' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-certfile')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-keyfile')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_1_27"
         pass "        * etcd-certfile: $certfile"
         pass "        * etcd-keyfile: $keyfile"
@@ -272,6 +275,7 @@ fi
 check_1_1_30="1.1.30  - Ensure that the --client-ca-file argument is set as appropriate"
 if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_1_30"
     pass "        * client-ca-file: $cafile"
 else
@@ -281,6 +285,7 @@ fi
 check_1_1_31="1.1.31  - Ensure that the --etcd-cafile argument is set as appropriate"
 if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-cafile')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_1_31"
     pass "        * etcd-cafile: $cafile"
 else

--- a/agent/nvbench/kubernetes-cis-benchmark/1.0.0/master/master_3_contoller_manager.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.0.0/master/master_3_contoller_manager.sh
@@ -33,6 +33,7 @@ fi
 check_1_3_5="1.3.5  - Ensure that the --service-account-private-key-file argument is set as appropriate"
 if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
     keyfile=$(get_argument_value "$CIS_MANAGER_CMD" '--service-account-private-key-file')
+    keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
     pass "$check_1_3_5"
     pass "       * service-account-private-key-file: $keyfile"
 else
@@ -42,6 +43,7 @@ fi
 check_1_3_6="1.3.6  - Ensure that the --root-ca-file argument is set as appropriate"
 if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_MANAGER_CMD" '--root-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_3_6"
     pass "       * root-ca-file: $cafile"
 else

--- a/agent/nvbench/kubernetes-cis-benchmark/1.0.0/master/master_4_configuration_files.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.0.0/master/master_4_configuration_files.sh
@@ -1,11 +1,14 @@
 info "1.4 - Configuration Files"
 
 check_1_4_1="1.4.1  - Ensure that the apiserver file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/manifests/kube-apiserver.json" ]; then
-    file="/etc/kubernetes/manifests/kube-apiserver.json"
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.json")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
+if [ -f $config_json ]; then
+    file=$config_json
 else
-    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_1"
@@ -19,11 +22,6 @@ else
 fi
 
 check_1_4_2="1.4.2  - Ensure that the apiserver file ownership is set to root:root"
-if [ -f "/etc/kubernetes/manifests/kube-apiserver.json" ]; then
-    file="/etc/kubernetes/manifests/kube-apiserver.json"
-else
-    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_2"
@@ -37,6 +35,8 @@ fi
 
 check_1_4_3="1.4.3  - Ensure that the config file permissions are set to 644 or more restrictive"
 file="/etc/kubernetes/admin.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_3"
@@ -51,6 +51,8 @@ fi
 
 check_1_4_4="1.4.4  - Ensure that the config file ownership is set to root:root"
 file="/etc/kubernetes/admin.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_4"
@@ -64,11 +66,14 @@ else
 fi
 
 check_1_4_5="1.4.5  - Ensure that the scheduler file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/manifests/kube-scheduler.json" ]; then
-    file="/etc/kubernetes/manifests/kube-scheduler.json"
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.json")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
+if [ -f $config_json ]; then
+    file=$config_json
 else
-    file="/etc/kubernetes/manifests/kube-scheduler.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_5"
@@ -82,11 +87,6 @@ else
 fi
 
 check_1_4_6="1.4.6  - Ensure that the scheduler file ownership is set to root:root"
-if [ -f "/etc/kubernetes/manifests/kube-scheduler.json" ]; then
-    file="/etc/kubernetes/manifests/kube-scheduler.json"
-else
-    file="/etc/kubernetes/manifests/kube-scheduler.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_6"
@@ -100,11 +100,14 @@ else
 fi
 
 check_1_4_7="1.4.7  - Ensure that the etcd.conf file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/manifests/etcd.json" ]; then
-    file="/etc/kubernetes/manifests/etcd.json"
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.json")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
+if [ -f $config_json ]; then
+    file=$config_json
 else
-    file="/etc/kubernetes/manifests/etcd.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_7"
@@ -118,11 +121,6 @@ else
 fi
 
 check_1_4_8="1.4.8  - Ensure that the etcd.conf file ownership is set to root:root"
-if [ -f "/etc/kubernetes/manifests/etcd.json" ]; then
-    file="/etc/kubernetes/manifests/etcd.json"
-else
-    file="/etc/kubernetes/manifests/etcd.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_8"
@@ -139,7 +137,7 @@ check_1_4_9="1.4.9  - Ensure that the flanneld file permissions are set to 644 o
 check_1_4_10="1.4.10  - Ensure that the flanneld file ownership is set to root:root"
 check_1_4_11="1.4.11  - Ensure that the etcd data directory permissions are set to 700 or more restrictive"
 directory=$(get_argument_value "$CIS_ETCD_CMD" '--data-dir')
-if [ -d $directory ]; then
+if [ -d "$directory" ]; then
   if [ "$(stat -c %a $directory)" -eq 700 ]; then
     pass "$check_1_4_11"
   else
@@ -154,7 +152,7 @@ fi
 
 check_1_4_12="1.4.12  - Ensure that the etcd data directory ownership is set to etcd:etcd"
 directory=$(get_argument_value "$CIS_ETCD_CMD" '--data-dir')
-if [ -d $directory ]; then
+if [ -d "$directory" ]; then
   if [ "$(stat -c %U:%G $directory)" = "etcd:etcd" ]; then
     pass "$check_1_4_12"
   else

--- a/agent/nvbench/kubernetes-cis-benchmark/1.0.0/master/master_5_etcd.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.0.0/master/master_5_etcd.sh
@@ -5,6 +5,8 @@ if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_1_5_1"
         pass "       * cert-file: $cfile"
         pass "       * key-file: $kfile"
@@ -34,6 +36,8 @@ if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--peer-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_1_5_4"
         pass "       * peer-cert-file: $cfile"
         pass "       * peer-key-file: $kfile"

--- a/agent/nvbench/kubernetes-cis-benchmark/1.0.0/worker/worker_1_kubelet.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.0.0/worker/worker_1_kubelet.sh
@@ -24,6 +24,7 @@ fi
 check_2_1_4="2.1.4  - Ensure that the --client-ca-file argument is set as appropriate"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_2_1_4"
     pass "       * client-ca-file: $cafile"
 else
@@ -98,6 +99,8 @@ if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_KUBELET_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-cert-file')
         kfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-private-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_2_1_12"
         pass "        * tls-cert-file: $cfile"
         pass "        * tls-private-key-file: $kfile"

--- a/agent/nvbench/kubernetes-cis-benchmark/1.0.0/worker/worker_2_configure_files.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.0.0/worker/worker_2_configure_files.sh
@@ -1,10 +1,12 @@
 info "2.2 - Configuration Files"
 
 check_2_2_1="2.2.1  - Ensure that the config file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/config" ]; then
-    file="/etc/kubernetes/config"
+config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/config")
+kubelet_config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet.conf")
+if [ -f $config ]; then
+    file=$config
 else
-    file="/etc/kubernetes/kubelet.conf"
+    file=$kubelet_config
 fi
 
 if [ -f "$file" ]; then
@@ -32,10 +34,12 @@ else
 fi
 
 check_2_2_3="2.2.3  - Ensure that the kubelet file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/kubelet" ]; then
-    file="/etc/kubernetes/kubelet"
+config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubele")
+kubelet_config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet.conf")
+if [ -f $config ]; then
+    file=$config
 else
-    file="/etc/kubernetes/kubelet.conf"
+    file=$kubelet_config
 fi
 
 if [ -f "$file" ]; then
@@ -64,7 +68,7 @@ fi
 
 check_2_2_5="2.2.5  - Ensure that the proxy file permissions are set to 644 or more restrictive"
 file="/etc/kubernetes/proxy"
-
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_2_2_5"

--- a/agent/nvbench/kubernetes-cis-benchmark/1.2.0/master/master_1_api_server.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.2.0/master/master_1_api_server.sh
@@ -219,6 +219,7 @@ fi
 check_1_1_25="1.1.25  - Ensure that the --service-account-key-file argument is set as appropriate"
 if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_APISERVER_CMD" '--service-account-key-file')
+    file=$(append_prefix "$CONFIG_PREFIX" "$file")
     pass "$check_1_1_25"
     pass "        * service-account-key-file: $file"
 else
@@ -230,6 +231,8 @@ if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--etcd-keyfile' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-certfile')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-keyfile')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_1_26"
         pass "        * etcd-certfile: $certfile"
         pass "        * etcd-keyfile: $keyfile"
@@ -252,6 +255,8 @@ if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-cert-file')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-private-key-file')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_1_28"
         pass "        * tls-cert-file: $certfile"
         pass "        * tls-private-key-file: $keyfile"
@@ -265,6 +270,7 @@ fi
 check_1_1_29="1.1.29  - Ensure that the --client-ca-file argument is set as appropriate"
 if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_1_29"
     pass "        * client-ca-file: $cafile"
 else
@@ -274,6 +280,7 @@ fi
 check_1_1_30="1.1.30  - Ensure that the --etcd-cafile argument is set as appropriate"
 if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-cafile')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_1_30"
     pass "        * etcd-cafile: $cafile"
 else

--- a/agent/nvbench/kubernetes-cis-benchmark/1.2.0/master/master_3_contoller_manager.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.2.0/master/master_3_contoller_manager.sh
@@ -29,6 +29,7 @@ fi
 check_1_3_4="1.3.4  - Ensure that the --service-account-private-key-file argument is set as appropriate"
 if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
     keyfile=$(get_argument_value "$CIS_MANAGER_CMD" '--service-account-private-key-file')
+    keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
     pass "$check_1_3_4"
     pass "       * service-account-private-key-file: $keyfile"
 else
@@ -38,6 +39,7 @@ fi
 check_1_3_5="1.3.5  - Ensure that the --root-ca-file argument is set as appropriate"
 if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_MANAGER_CMD" '--root-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_3_5"
     pass "       * root-ca-file: $cafile"
 else

--- a/agent/nvbench/kubernetes-cis-benchmark/1.2.0/master/master_4_configuration_files.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.2.0/master/master_4_configuration_files.sh
@@ -1,14 +1,19 @@
 info "1.4 - Configuration Files"
 
 check_1_4_1="1.4.1  - Ensure that the API server pod specification file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/manifests/kube-apiserver.json" ]; then
-    file="/etc/kubernetes/manifests/kube-apiserver.json"
-elif [ -f "/etc/kubernetes/manifests/kube-apiserver.manifest" ]; then
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.json")
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
+if [ -f $config_json ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-apiserver.manifest"
+    file=$config_json
+elif [ -f $config_manifest ]; then
+    # kops
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_1"
@@ -22,14 +27,6 @@ else
 fi
 
 check_1_4_2="1.4.2  - Ensure that the API server pod specification file ownership is set to root:root"
-if [ -f "/etc/kubernetes/manifests/kube-apiserver.json" ]; then
-    file="/etc/kubernetes/manifests/kube-apiserver.json"
-elif [ -f "/etc/kubernetes/manifests/kube-apiserver.manifest" ]; then
-    # kops
-    file="/etc/kubernetes/manifests/kube-apiserver.manifest"
-else
-    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_2"
@@ -42,14 +39,18 @@ else
 fi
 
 check_1_4_3="1.4.3  - Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/manifests/kube-controller-manager.json" ]; then
-    file="/etc/kubernetes/manifests/kube-controller-manager.json"
-elif [ -f "/etc/kubernetes/manifests/kube-controller-manager.manifest" ]; then
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.json")
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
+if [ -f $config_json ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-controller-manager.manifest"
+    file=$config_json
+elif [ -f $config_manifest ]; then
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-controller-manager.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_3"
@@ -63,14 +64,6 @@ else
 fi
 
 check_1_4_4="1.4.4  - Ensure that the controller manager pod specification file ownership is set to root:root"
-if [ -f "/etc/kubernetes/manifests/kube-controller-manager.json" ]; then
-    file="/etc/kubernetes/manifests/kube-controller-manager.json"
-elif [ -f "/etc/kubernetes/manifests/kube-controller-manager.manifest" ]; then
-    # kops
-    file="/etc/kubernetes/manifests/kube-controller-manager.manifest"
-else
-    file="/etc/kubernetes/manifests/kube-controller-manager.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_4"
@@ -84,14 +77,18 @@ else
 fi
 
 check_1_4_5="1.4.5  - Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/manifests/kube-scheduler.json" ]; then
-    file="/etc/kubernetes/manifests/kube-scheduler.json"
-elif [ -f "/etc/kubernetes/manifests/kube-scheduler.manifest" ]; then
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.json")
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
+if [ -f $config_json ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-scheduler.manifest"
+    file=$config_json
+elif [ -f $config_manifest ]; then
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-scheduler.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_5"
@@ -105,14 +102,6 @@ else
 fi
 
 check_1_4_6="1.4.6  - Ensure that the scheduler pod specification file ownership is set to root:root"
-if [ -f "/etc/kubernetes/manifests/kube-scheduler.json" ]; then
-    file="/etc/kubernetes/manifests/kube-scheduler.json"
-elif [ -f "/etc/kubernetes/manifests/kube-scheduler.manifest" ]; then
-    # kops
-    file="/etc/kubernetes/manifests/kube-scheduler.manifest"
-else
-    file="/etc/kubernetes/manifests/kube-scheduler.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %U:%G $file)" = "root:root" ]; then
     pass "$check_1_4_6"
@@ -127,15 +116,20 @@ else
 fi
 
 check_1_4_7="1.4.7  - Ensure that the etcd pod specification file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/manifests/etcd.json" ]; then
-    file="/etc/kubernetes/manifests/etcd.json"
-elif [ -f "/etc/kubernetes/manifests/etcd.manifest" ]; then
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.json")
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
+if [ -f $config_json ]; then
+    # kops
+    file=$config_json
+elif [ -f $config_manifest ]; then
     # kops
     # Also this file is a symlink, hence 'stat -L' below.
-    file="/etc/kubernetes/manifests/etcd.manifest"
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/etcd.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -L -c %a $file)" -eq 644 -o "$(stat -L -c %a $file)" -eq 640 -o "$(stat -L -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_7"
@@ -149,14 +143,6 @@ else
 fi
 
 check_1_4_8="1.4.8  - Ensure that the etcd pod specification file ownership is set to root:root"
-if [ -f "/etc/kubernetes/manifests/etcd.json" ]; then
-    file="/etc/kubernetes/manifests/etcd.json"
-elif [ -f "/etc/kubernetes/manifests/etcd.manifest" ]; then
-    # kops
-    file="/etc/kubernetes/manifests/etcd.manifest"
-else
-    file="/etc/kubernetes/manifests/etcd.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %U:%G $file)" = "root:root" ]; then
     pass "$check_1_4_8"
@@ -204,6 +190,8 @@ fi
 
 check_1_4_13="1.4.13  - Ensure that the admin.conf file permissions are set to 644 or more restrictive"
 file="/etc/kubernetes/admin.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_13"
@@ -219,6 +207,8 @@ fi
 
 check_1_4_14="1.4.14  - Ensure that the admin.conf file ownership is set to root:root"
 file="/etc/kubernetes/admin.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_14"
@@ -234,6 +224,8 @@ fi
 
 check_1_4_15="1.4.15  - Ensure that the scheduler.conf file permissions are set to 644 or more restrictive"
 file="/etc/kubernetes/scheduler.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_15"
@@ -249,6 +241,8 @@ fi
 
 check_1_4_16="1.4.16  - Ensure that the scheduler.conf file ownership is set to root:root"
 file="/etc/kubernetes/scheduler.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_16"
@@ -264,6 +258,8 @@ fi
 
 check_1_4_17="1.4.17  - Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive"
 file="/etc/kubernetes/controller-manager.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_17"
@@ -279,6 +275,8 @@ fi
 
 check_1_4_18="1.4.18  - Ensure that the controller-manager.conf file ownership is set to root:root"
 file="/etc/kubernetes/controller-manager.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_18"

--- a/agent/nvbench/kubernetes-cis-benchmark/1.2.0/master/master_5_etcd.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.2.0/master/master_5_etcd.sh
@@ -5,6 +5,8 @@ if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_1_5_1"
         pass "       * cert-file: $cfile"
         pass "       * key-file: $kfile"
@@ -34,6 +36,8 @@ if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--peer-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_1_5_4"
         pass "       * peer-cert-file: $cfile"
         pass "       * peer-key-file: $kfile"

--- a/agent/nvbench/kubernetes-cis-benchmark/1.2.0/worker/worker_1_kubelet.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.2.0/worker/worker_1_kubelet.sh
@@ -24,6 +24,7 @@ fi
 check_2_1_4="2.1.4  - Ensure that the --client-ca-file argument is set as appropriate"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_2_1_4"
     pass "       * client-ca-file: $cafile"
 else
@@ -98,6 +99,8 @@ if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_KUBELET_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-cert-file')
         kfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-private-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_2_1_12"
         pass "        * tls-cert-file: $cfile"
         pass "        * tls-private-key-file: $kfile"

--- a/agent/nvbench/kubernetes-cis-benchmark/1.2.0/worker/worker_2_configure_files.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.2.0/worker/worker_2_configure_files.sh
@@ -1,13 +1,15 @@
 info "2.2 - Configuration Files"
 
 check_2_2_1="2.2.1  - Ensure that the config file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/config" ]; then
-    file="/etc/kubernetes/config"
-elif [ -f "/var/lib/kubelet/kubeconfig" ]; then
-    # kops
-    file="/var/lib/kubelet/kubeconfig"
+config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/config")
+kubeletconfig=$(append_prefix "$CONFIG_PREFIX" "/var/lib/kubelet/kubeconfig")
+kubelet_config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet.conf")
+if [ -f $config ]; then
+    file=$config
+elif [ -f $kubeletconfig ]; then
+    file=$kubeletconfig
 else
-    file="/etc/kubernetes/kubelet.conf"
+    file=$kubelet_config
 fi
 
 if [ -f "$file" ]; then
@@ -35,13 +37,15 @@ else
 fi
 
 check_2_2_3="2.2.3  - Ensure that the kubelet file permissions are set to 644 or more restrictive"
-if [ -f "/etc/kubernetes/kubelet" ]; then
-    file="/etc/kubernetes/kubelet"
-elif [ -f "/etc/sysconfig/kubelet" ]; then
-    # kops
-    file="/etc/sysconfig/kubelet"
+config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet")
+kubelet_sysconfig=$(append_prefix "$CONFIG_PREFIX" "/etc/sysconfig/kubelet")
+kubelet_config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet.conf")
+if [ -f $config ]; then
+    file=$config
+elif [ -f $kubelet_sysconfig ]; then
+    file=$kubelet_sysconfig
 else
-    file="/etc/kubernetes/kubelet.conf"
+    file=$kubelet_config
 fi
 
 if [ -f "$file" ]; then
@@ -69,11 +73,12 @@ else
 fi
 
 check_2_2_5="2.2.5  - Ensure that the proxy file permissions are set to 644 or more restrictive"
-if [ -f "/var/lib/kube-proxy/kubeconfig" ]; then
-    # kops
-    file="/var/lib/kube-proxy/kubeconfig"
+config=$(append_prefix "$CONFIG_PREFIX" "/var/lib/kube-proxy/kubeconfig")
+proxy_config=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/proxy")
+if [ -f $config ]; then
+    file=$config
 else
-    file="/etc/kubernetes/proxy"
+    file=$proxy_config
 fi
 
 if [ -f "$file" ]; then
@@ -103,6 +108,7 @@ fi
 check_2_2_7="2.2.7  - Ensure that the certificate authorities file permissions are set to 644 or more restrictive"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_2_2_7"
     pass "       * client-ca-file: $file"
@@ -118,6 +124,7 @@ fi
 check_2_2_8="2.2.8  - Ensure that the client certificate authorities file ownership is set to root:root"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_2_2_8"
     pass "       * client-ca-file: $file"

--- a/agent/nvbench/kubernetes-cis-benchmark/1.4.1/master/master_1_api_server.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.4.1/master/master_1_api_server.sh
@@ -215,6 +215,7 @@ fi
 check_1_1_25="1.1.25  - Ensure that the --service-account-key-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_APISERVER_CMD" '--service-account-key-file')
+    file=$(append_prefix "$CONFIG_PREFIX" "$file")
     pass "$check_1_1_25"
     pass "        * service-account-key-file: $file"
 else
@@ -226,6 +227,8 @@ if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--etcd-keyfile' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-certfile')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-keyfile')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_1_26"
         pass "        * etcd-certfile: $certfile"
         pass "        * etcd-keyfile: $keyfile"
@@ -248,6 +251,8 @@ if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-cert-file')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-private-key-file')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_1_28"
         pass "        * tls-cert-file: $certfile"
         pass "        * tls-private-key-file: $keyfile"
@@ -261,6 +266,7 @@ fi
 check_1_1_29="1.1.29  - Ensure that the --client-ca-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_1_29"
     pass "        * client-ca-file: $cafile"
 else
@@ -270,6 +276,7 @@ fi
 check_1_1_30="1.1.30  - Ensure that the --etcd-cafile argument is set as appropriate (Scored)"
 if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-cafile')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_1_30"
     pass "        * etcd-cafile: $cafile"
 else

--- a/agent/nvbench/kubernetes-cis-benchmark/1.4.1/master/master_3_contoller_manager.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.4.1/master/master_3_contoller_manager.sh
@@ -28,6 +28,7 @@ fi
 check_1_3_4="1.3.4  - Ensure that the --service-account-private-key-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
     keyfile=$(get_argument_value "$CIS_MANAGER_CMD" '--service-account-private-key-file')
+    keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
     pass "$check_1_3_4"
     pass "       * service-account-private-key-file: $keyfile"
 else
@@ -37,6 +38,7 @@ fi
 check_1_3_5="1.3.5  - Ensure that the --root-ca-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_MANAGER_CMD" '--root-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_3_5"
     pass "       * root-ca-file: $cafile"
 else

--- a/agent/nvbench/kubernetes-cis-benchmark/1.4.1/master/master_4_configuration_files.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.4.1/master/master_4_configuration_files.sh
@@ -1,14 +1,19 @@
 info "1.4 - Configuration Files"
 
 check_1_4_1="1.4.1  - Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-apiserver.json" ]; then
-    file="/etc/kubernetes/manifests/kube-apiserver.json"
-elif [ -f "/etc/kubernetes/manifests/kube-apiserver.manifest" ]; then
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.json")
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
+if [ -f $config_json ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-apiserver.manifest"
+    file=$config_json
+elif [ -f $config_manifest ]; then
+    # kops
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_1"
@@ -22,14 +27,6 @@ else
 fi
 
 check_1_4_2="1.4.2  - Ensure that the API server pod specification file ownership is set to root:root (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-apiserver.json" ]; then
-    file="/etc/kubernetes/manifests/kube-apiserver.json"
-elif [ -f "/etc/kubernetes/manifests/kube-apiserver.manifest" ]; then
-    # kops
-    file="/etc/kubernetes/manifests/kube-apiserver.manifest"
-else
-    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_2"
@@ -42,14 +39,19 @@ else
 fi
 
 check_1_4_3="1.4.3  - Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-controller-manager.json" ]; then
-    file="/etc/kubernetes/manifests/kube-controller-manager.json"
-elif [ -f "/etc/kubernetes/manifests/kube-controller-manager.manifest" ]; then
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.json")
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
+if [ -f $config_json ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-controller-manager.manifest"
+    file=$config_json
+elif [ -f $config_manifest ]; then
+    # kops
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-controller-manager.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_3"
@@ -63,14 +65,6 @@ else
 fi
 
 check_1_4_4="1.4.4  - Ensure that the controller manager pod specification file ownership is set to root:root (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-controller-manager.json" ]; then
-    file="/etc/kubernetes/manifests/kube-controller-manager.json"
-elif [ -f "/etc/kubernetes/manifests/kube-controller-manager.manifest" ]; then
-    # kops
-    file="/etc/kubernetes/manifests/kube-controller-manager.manifest"
-else
-    file="/etc/kubernetes/manifests/kube-controller-manager.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_4"
@@ -84,14 +78,18 @@ else
 fi
 
 check_1_4_5="1.4.5  - Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-scheduler.json" ]; then
-    file="/etc/kubernetes/manifests/kube-scheduler.json"
-elif [ -f "/etc/kubernetes/manifests/kube-scheduler.manifest" ]; then
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.json")
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
+if [ -f $config_json ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-scheduler.manifest"
+    file=$config_json
+elif [ -f $config_manifest ]; then
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-scheduler.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_5"
@@ -105,14 +103,6 @@ else
 fi
 
 check_1_4_6="1.4.6  - Ensure that the scheduler pod specification file ownership is set to root:root (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-scheduler.json" ]; then
-    file="/etc/kubernetes/manifests/kube-scheduler.json"
-elif [ -f "/etc/kubernetes/manifests/kube-scheduler.manifest" ]; then
-    # kops
-    file="/etc/kubernetes/manifests/kube-scheduler.manifest"
-else
-    file="/etc/kubernetes/manifests/kube-scheduler.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %U:%G $file)" = "root:root" ]; then
     pass "$check_1_4_6"
@@ -127,15 +117,20 @@ else
 fi
 
 check_1_4_7="1.4.7  - Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/etc/kubernetes/manifests/etcd.json" ]; then
-    file="/etc/kubernetes/manifests/etcd.json"
-elif [ -f "/etc/kubernetes/manifests/etcd.manifest" ]; then
+config_json=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.json")
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
+if [ -f $config_json ]; then
+    # kops
+    file=$config_json
+elif [ -f $config_manifest ]; then
     # kops
     # Also this file is a symlink, hence 'stat -L' below.
-    file="/etc/kubernetes/manifests/etcd.manifest"
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/etcd.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -L -c %a $file)" -eq 644 -o "$(stat -L -c %a $file)" -eq 640 -o "$(stat -L -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_7"
@@ -149,14 +144,6 @@ else
 fi
 
 check_1_4_8="1.4.8  - Ensure that the etcd pod specification file ownership is set to root:root (Scored)"
-if [ -f "/etc/kubernetes/manifests/etcd.json" ]; then
-    file="/etc/kubernetes/manifests/etcd.json"
-elif [ -f "/etc/kubernetes/manifests/etcd.manifest" ]; then
-    # kops
-    file="/etc/kubernetes/manifests/etcd.manifest"
-else
-    file="/etc/kubernetes/manifests/etcd.yaml"
-fi
 if [ -f $file ]; then
   if [ "$(stat -c %U:%G $file)" = "root:root" ]; then
     pass "$check_1_4_8"
@@ -208,6 +195,8 @@ fi
 
 check_1_4_13="1.4.13  - Ensure that the admin.conf file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/admin.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_13"
@@ -223,6 +212,8 @@ fi
 
 check_1_4_14="1.4.14  - Ensure that the admin.conf file ownership is set to root:root (Scored)"
 file="/etc/kubernetes/admin.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_14"
@@ -238,6 +229,8 @@ fi
 
 check_1_4_15="1.4.15  - Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/scheduler.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_15"
@@ -253,6 +246,8 @@ fi
 
 check_1_4_16="1.4.16  - Ensure that the scheduler.conf file ownership is set to root:root (Scored)"
 file="/etc/kubernetes/scheduler.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_16"
@@ -268,6 +263,8 @@ fi
 
 check_1_4_17="1.4.17  - Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/controller-manager.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_4_17"
@@ -283,6 +280,8 @@ fi
 
 check_1_4_18="1.4.18  - Ensure that the controller-manager.conf file ownership is set to root:root (Scored)"
 file="/etc/kubernetes/controller-manager.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f $file ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_4_18"
@@ -298,6 +297,7 @@ fi
 
 check_1_4_19="1.4.19  - Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Scored)"
 file="/etc/kubernetes/pki/"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 files=$(find $file)
 pass=true
 for f in ${files}; do

--- a/agent/nvbench/kubernetes-cis-benchmark/1.4.1/master/master_5_etcd.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.4.1/master/master_5_etcd.sh
@@ -5,6 +5,8 @@ if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_1_5_1"
         pass "       * cert-file: $cfile"
         pass "       * key-file: $kfile"
@@ -34,6 +36,8 @@ if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--peer-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_1_5_4"
         pass "       * peer-cert-file: $cfile"
         pass "       * peer-key-file: $kfile"
@@ -63,6 +67,8 @@ if check_argument "$CIS_ETCD_CMD" '--trusted-ca-file' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
         tfile=$(get_argument_value "$CIS_ETCD_CMD" '--trusted-ca-file')
         cfile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+        tfile=$(append_prefix "$CONFIG_PREFIX" "$tfile")
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
         if [ "$tfile" = "$cfile" ]; then
             pass "$check_1_5_7"
             pass "       * trusted-ca-file: $tfile"

--- a/agent/nvbench/kubernetes-cis-benchmark/1.4.1/worker/worker_1_kubelet.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.4.1/worker/worker_1_kubelet.sh
@@ -17,6 +17,7 @@ fi
 check_2_1_3="2.1.3  - Ensure that the --client-ca-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_2_1_3"
     pass "       * client-ca-file: $cafile"
 else
@@ -84,6 +85,8 @@ if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_KUBELET_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-cert-file')
         kfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-private-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_2_1_10"
         pass "        * tls-cert-file: $cfile"
         pass "        * tls-private-key-file: $kfile"
@@ -106,6 +109,7 @@ fi
 
 check_2_1_13="2.1.13  - Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
 file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 found=$(sed -rn '/--feature-gates=RotateKubeletServerCertificate=true/p' $file)
 if [ -z "$found" ]; then
     warn "$check_2_1_13"

--- a/agent/nvbench/kubernetes-cis-benchmark/1.4.1/worker/worker_2_configure_files.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.4.1/worker/worker_2_configure_files.sh
@@ -2,7 +2,7 @@ info "2.2 - Configuration Files"
 
 check_2_2_1="2.2.1  - Ensure that the kubelet service file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
-
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_2_2_1"
@@ -17,6 +17,7 @@ fi
 
 check_2_2_2="2.2.2  - Ensure that the kubelet.conf file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_2_2_2"
@@ -32,6 +33,7 @@ fi
 
 check_2_2_3="2.2.3  - Ensure that the kubelet.conf file ownership is set to root:root (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_2_2_3"
@@ -45,6 +47,7 @@ fi
 
 check_2_2_4="2.2.4  - Ensure that the kubelet service file ownership is set to root:root (Scored)"
 file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_2_2_4"
@@ -61,6 +64,7 @@ file=""
 if check_argument "$CIS_PROXY_CMD" '--kubeconfig' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
 fi
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
@@ -79,6 +83,8 @@ file=""
 if check_argument "$CIS_PROXY_CMD" '--kubeconfig' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
 fi
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_2_2_6"
@@ -94,6 +100,7 @@ fi
 check_2_2_7="2.2.7  - Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_2_2_7"
     pass "       * client-ca-file: $file"
@@ -109,6 +116,7 @@ fi
 check_2_2_8="2.2.8  - Ensure that the client certificate authorities file ownership is set to root:root (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_2_2_8"
     pass "       * client-ca-file: $file"
@@ -124,6 +132,7 @@ fi
 check_2_2_9="2.2.9  - Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_2_2_9"
     pass "       * config: $file"
@@ -139,6 +148,7 @@ fi
 check_2_2_10="2.2.10  - Ensure that the kubelet configuration file ownership is set to root:root (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_2_2_10"
     pass "       * client: $file"

--- a/agent/nvbench/kubernetes-cis-benchmark/1.5.1/master/1_control_plane_components.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.5.1/master/1_control_plane_components.sh
@@ -3,12 +3,15 @@ info "1 - Control Plane Components"
 info "1.1 - Master Node Configuration Files"
 
 check_1_1_1="1.1.1  - Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-apiserver.manifest" ]; then
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
+if [ -f $config_manifest ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-apiserver.manifest"
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_1_1"
@@ -34,11 +37,13 @@ else
 fi
 
 check_1_1_3="1.1.3  - Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-controller-manager.manifest" ]; then
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
+if [ -f $config_manifest ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-controller-manager.manifest"
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-controller-manager.yaml"
+    file=$config_yaml
 fi
 
 if [ -f "$file" ]; then
@@ -66,11 +71,13 @@ else
 fi
 
 check_1_1_5="1.1.5  - Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/etc/kubernetes/manifests/kube-scheduler.yaml" ]; then
-    file="/etc/kubernetes/manifests/kube-scheduler.yaml"
-else
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
+if [ -f $config_yaml ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-scheduler.manifest"
+    file=$config_yaml
+else
+    file=$config_manifest
 fi
 
 if [ -f "$file" ]; then
@@ -98,11 +105,13 @@ else
 fi
 
 check_1_1_7="1.1.7  - Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/etc/kubernetes/manifests/etcd.yaml" ]; then
-    file="/etc/kubernetes/manifests/etcd.yaml"
-else
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
+if [ -f $config_yaml ]; then
     # kops
-    file="/etc/kubernetes/manifests/etcd.manifest"
+    file=$config_yaml
+else
+    file=$config_manifest
 fi
 
 if [ -f "$file" ]; then
@@ -149,6 +158,8 @@ file=""
 if check_argument "$CIS_ETCD_CMD" '--data-dir' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_ETCD_CMD" '--data-dir'|cut -d " " -f 1)
 fi
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 700 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_11"
@@ -176,6 +187,8 @@ fi
 
 check_1_1_13="1.1.13  - Ensure that the admin.conf file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/admin.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_13"
@@ -202,6 +215,8 @@ fi
 
 check_1_1_15="1.1.15  - Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/scheduler.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_15"
@@ -228,6 +243,8 @@ fi
 
 check_1_1_17="1.1.17  - Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/controller-manager.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_17"
@@ -254,6 +271,7 @@ fi
 
 check_1_1_19="1.1.19  - Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Scored)"
 file="/etc/kubernetes/pki/"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 files=$(find $file)
 pass=true
 for f in ${files}; do
@@ -542,6 +560,7 @@ fi
 check_1_2_28="1.2.28  - Ensure that the --service-account-key-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_APISERVER_CMD" '--service-account-key-file')
+    file=$(append_prefix "$CONFIG_PREFIX" "$file")
     pass "$check_1_2_28"
     pass "        * service-account-key-file: $file"
 else
@@ -553,6 +572,8 @@ if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--etcd-keyfile' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-certfile')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-keyfile')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_2_29"
         pass "        * etcd-certfile: $certfile"
         pass "        * etcd-keyfile: $keyfile"
@@ -568,6 +589,8 @@ if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-cert-file')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-private-key-file')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_2_30"
         pass "        * tls-cert-file: $certfile"
         pass "        * tls-private-key-file: $keyfile"
@@ -581,6 +604,7 @@ fi
 check_1_2_31="1.2.31  - Ensure that the --client-ca-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_2_31"
     pass "        * client-ca-file: $cafile"
 else
@@ -590,6 +614,7 @@ fi
 check_1_2_32="1.2.32  - Ensure that the --etcd-cafile argument is set as appropriate (Scored)"
 if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-cafile')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_2_32"
     pass "        * etcd-cafile: $cafile"
 else
@@ -672,6 +697,7 @@ fi
 check_1_3_4="1.3.4  - Ensure that the --service-account-private-key-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
     keyfile=$(get_argument_value "$CIS_MANAGER_CMD" '--service-account-private-key-file')
+    keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
     pass "$check_1_3_4"
     pass "       * service-account-private-key-file: $keyfile"
 else
@@ -681,6 +707,7 @@ fi
 check_1_3_5="1.3.5  - Ensure that the --root-ca-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_MANAGER_CMD" '--root-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_3_5"
     pass "       * root-ca-file: $cafile"
 else

--- a/agent/nvbench/kubernetes-cis-benchmark/1.5.1/master/2_etcd.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.5.1/master/2_etcd.sh
@@ -5,6 +5,8 @@ if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_2_1"
         pass "       * cert-file: $cfile"
         pass "       * key-file: $kfile"
@@ -34,6 +36,8 @@ if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--peer-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_2_4"
         pass "       * peer-cert-file: $cfile"
         pass "       * peer-key-file: $kfile"
@@ -64,6 +68,8 @@ if check_argument "$CIS_ETCD_CMD" '--trusted-ca-file' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
         tfile=$(get_argument_value "$CIS_ETCD_CMD" '--trusted-ca-file')
         cfile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+        tfile=$(append_prefix "$CONFIG_PREFIX" "$tfile")
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
         if [ "$tfile" = "$cfile" ]; then
             pass "$check_2_7"
             pass "       * trusted-ca-file: $tfile"

--- a/agent/nvbench/kubernetes-cis-benchmark/1.5.1/master/3_control_plane_configuration.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.5.1/master/3_control_plane_configuration.sh
@@ -11,6 +11,7 @@ info "3.2 - Logging"
 check_3_2_1="3.2.1 - Ensure that a minimal audit policy is created (Scored)"
 if check_argument "$CIS_APISERVER_CMD" '--audit-policy-file' >/dev/null 2>&1; then
     auditPolicyFile=$(get_argument_value "$CIS_APISERVER_CMD" '--audit-policy-file')
+    auditPolicyFile=$(append_prefix "$CONFIG_PREFIX" "$auditPolicyFile")
     pass "$check_3_2_1"
     pass "        * audit-policy-file: $auditPolicyFile"
 else

--- a/agent/nvbench/kubernetes-cis-benchmark/1.5.1/worker/4_worker_nodes.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.5.1/worker/4_worker_nodes.sh
@@ -2,6 +2,8 @@ info "4.1 - Worker Node Configuration Files"
 
 check_4_1_1="4.1.1  - Ensure that the kubelet service file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_1"
@@ -31,6 +33,7 @@ file=""
 if check_argument "$CIS_PROXY_CMD" '--kubeconfig' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
 fi
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
@@ -58,11 +61,13 @@ else
 fi
 
 check_4_1_5="4.1.5  - Ensure that the kubelet.conf file permissions are set to 644 or more restrictive (Scored)"
-if [ -f "/var/lib/kube-proxy/kubeconfig" ]; then
+kube_proxy_config=$(append_prefix "$CONFIG_PREFIX" "/var/lib/kube-proxy/kubeconfig")
+kubernetes_proxy=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/proxy")
+if [ -f $kube_proxy_config ]; then
     # kops
-    file="/var/lib/kube-proxy/kubeconfig"
+    file=$kube_proxy_config
 else
-    file="/etc/kubernetes/proxy"
+    file=$kubernetes_proxy
 fi
 
 if [ -f "$file" ]; then
@@ -92,6 +97,8 @@ fi
 check_4_1_7="4.1.7  - Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_7"
     pass "       * client-ca-file: $file"
@@ -107,6 +114,8 @@ fi
 check_4_1_8="4.1.8  - Ensure that the client certificate authorities file ownership is set to root:root (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_8"
     pass "       * client-ca-file: $file"
@@ -122,6 +131,7 @@ fi
 check_4_1_9="4.1.9  - Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_9"
     pass "       * kubelet configuration file: $file"
@@ -137,6 +147,7 @@ fi
 check_4_1_10="4.1.10  - Ensure that the kubelet configuration file ownership is set to root:root (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_10"
     pass "       * kubelet configuration file: $file"
@@ -169,6 +180,7 @@ fi
 check_4_2_3="4.2.3  - Ensure that the --client-ca-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_4_2_3"
     pass "       * client-ca-file: $cafile"
 else
@@ -230,6 +242,8 @@ if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_KUBELET_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-cert-file')
         kfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-private-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_4_2_10"
         pass "        * tls-cert-file: $cfile"
         pass "        * tls-private-key-file: $kfile"
@@ -255,6 +269,7 @@ fi
 
 check_4_2_12="4.2.12  - Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
 file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 found=$(sed -rn '/--feature-gates=RotateKubeletServerCertificate=true/p' $file)
 if [ -z "$found" ]; then
     warn "$check_4_2_12"

--- a/agent/nvbench/kubernetes-cis-benchmark/1.6.0/master/1_control_plane_components.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.6.0/master/1_control_plane_components.sh
@@ -3,12 +3,15 @@ info "1 - Control Plane Components"
 info "1.1 - Master Node Configuration Files"
 
 check_1_1_1="1.1.1  - Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
-if [ -f "/etc/kubernetes/manifests/kube-apiserver.manifest" ]; then
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
+if [ -f $config_manifest ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-apiserver.manifest"
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-apiserver.yaml"
+    file=$config_yaml
 fi
+
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_1_1"
@@ -34,11 +37,13 @@ else
 fi
 
 check_1_1_3="1.1.3  - Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Automated)"
-if [ -f "/etc/kubernetes/manifests/kube-controller-manager.manifest" ]; then
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
+if [ -f $config_manifest ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-controller-manager.manifest"
+    file=$config_manifest
 else
-    file="/etc/kubernetes/manifests/kube-controller-manager.yaml"
+    file=$config_yaml
 fi
 
 if [ -f "$file" ]; then
@@ -66,11 +71,13 @@ else
 fi
 
 check_1_1_5="1.1.5  - Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Automated)"
-if [ -f "/etc/kubernetes/manifests/kube-scheduler.yaml" ]; then
-    file="/etc/kubernetes/manifests/kube-scheduler.yaml"
-else
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
+if [ -f $config_yaml ]; then
     # kops
-    file="/etc/kubernetes/manifests/kube-scheduler.manifest"
+    file=$config_yaml
+else
+    file=$config_manifest
 fi
 
 if [ -f "$file" ]; then
@@ -98,11 +105,13 @@ else
 fi
 
 check_1_1_7="1.1.7  - Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"
-if [ -f "/etc/kubernetes/manifests/etcd.yaml" ]; then
-    file="/etc/kubernetes/manifests/etcd.yaml"
-else
+config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.manifest")
+config_yaml=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
+if [ -f $config_yaml ]; then
     # kops
-    file="/etc/kubernetes/manifests/etcd.manifest"
+    file=$config_yaml
+else
+    file=$config_manifest
 fi
 
 if [ -f "$file" ]; then
@@ -149,6 +158,8 @@ file=""
 if check_argument "$CIS_ETCD_CMD" '--data-dir' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_ETCD_CMD" '--data-dir'|cut -d " " -f 1)
 fi
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 700 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_11"
@@ -176,6 +187,8 @@ fi
 
 check_1_1_13="1.1.13  - Ensure that the admin.conf file permissions are set to 644 or more restrictive (Automated)"
 file="/etc/kubernetes/admin.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_13"
@@ -202,6 +215,8 @@ fi
 
 check_1_1_15="1.1.15  - Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
 file="/etc/kubernetes/scheduler.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_15"
@@ -228,6 +243,8 @@ fi
 
 check_1_1_17="1.1.17  - Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
 file="/etc/kubernetes/controller-manager.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_17"
@@ -254,6 +271,7 @@ fi
 
 check_1_1_19="1.1.19  - Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
 file="/etc/kubernetes/pki/"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 files=$(find $file)
 pass=true
 for f in ${files}; do
@@ -542,6 +560,7 @@ fi
 check_1_2_28="1.2.28  - Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
 if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_APISERVER_CMD" '--service-account-key-file')
+    file=$(append_prefix "$CONFIG_PREFIX" "$file")
     pass "$check_1_2_28"
     pass "        * service-account-key-file: $file"
 else
@@ -553,6 +572,8 @@ if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--etcd-keyfile' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-certfile')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-keyfile')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_2_29"
         pass "        * etcd-certfile: $certfile"
         pass "        * etcd-keyfile: $keyfile"
@@ -568,6 +589,8 @@ if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-cert-file')
         keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-private-key-file')
+        certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
+        keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
         pass "$check_1_2_30"
         pass "        * tls-cert-file: $certfile"
         pass "        * tls-private-key-file: $keyfile"
@@ -581,6 +604,7 @@ fi
 check_1_2_31="1.2.31  - Ensure that the --client-ca-file argument is set as appropriate (Automated)"
 if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_2_31"
     pass "        * client-ca-file: $cafile"
 else
@@ -590,6 +614,7 @@ fi
 check_1_2_32="1.2.32  - Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
 if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-cafile')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_2_32"
     pass "        * etcd-cafile: $cafile"
 else
@@ -672,6 +697,7 @@ fi
 check_1_3_4="1.3.4  - Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
 if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
     keyfile=$(get_argument_value "$CIS_MANAGER_CMD" '--service-account-private-key-file')
+    keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
     pass "$check_1_3_4"
     pass "       * service-account-private-key-file: $keyfile"
 else
@@ -681,6 +707,7 @@ fi
 check_1_3_5="1.3.5  - Ensure that the --root-ca-file argument is set as appropriate (Automated)"
 if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_MANAGER_CMD" '--root-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_1_3_5"
     pass "       * root-ca-file: $cafile"
 else

--- a/agent/nvbench/kubernetes-cis-benchmark/1.6.0/master/2_etcd.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.6.0/master/2_etcd.sh
@@ -5,6 +5,8 @@ if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_2_1"
         pass "       * cert-file: $cfile"
         pass "       * key-file: $kfile"
@@ -34,6 +36,8 @@ if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_ETCD_CMD" '--peer-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-cert-file')
         kfile=$(get_argument_value "$CIS_ETCD_CMD" '--peer-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_2_4"
         pass "       * peer-cert-file: $cfile"
         pass "       * peer-key-file: $kfile"
@@ -64,6 +68,8 @@ if check_argument "$CIS_ETCD_CMD" '--trusted-ca-file' >/dev/null 2>&1; then
     if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
         tfile=$(get_argument_value "$CIS_ETCD_CMD" '--trusted-ca-file')
         cfile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+        tfile=$(append_prefix "$CONFIG_PREFIX" "$tfile")
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
         if [ "$tfile" = "$cfile" ]; then
             pass "$check_2_7"
             pass "       * trusted-ca-file: $tfile"

--- a/agent/nvbench/kubernetes-cis-benchmark/1.6.0/master/3_control_plane_configuration.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.6.0/master/3_control_plane_configuration.sh
@@ -11,6 +11,7 @@ info "3.2 - Logging"
 check_3_2_1="3.2.1 - Ensure that a minimal audit policy is created (Manual)"
 if check_argument "$CIS_APISERVER_CMD" '--audit-policy-file' >/dev/null 2>&1; then
     auditPolicyFile=$(get_argument_value "$CIS_APISERVER_CMD" '--audit-policy-file')
+    auditPolicyFile=$(append_prefix "$CONFIG_PREFIX" "$auditPolicyFile")
     pass "$check_3_2_1"
     pass "        * audit-policy-file: $auditPolicyFile"
 else

--- a/agent/nvbench/kubernetes-cis-benchmark/1.6.0/worker/4_worker_nodes.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/1.6.0/worker/4_worker_nodes.sh
@@ -2,6 +2,8 @@ info "4.1 - Worker Node Configuration Files"
 
 check_4_1_1="4.1.1  - Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
 file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_1"
@@ -32,6 +34,7 @@ if check_argument "$CIS_PROXY_CMD" '--kubeconfig' >/dev/null 2>&1; then
     file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
 fi
 
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_3"
@@ -58,11 +61,14 @@ else
 fi
 
 check_4_1_5="4.1.5  - Ensure that the kubelet.conf file permissions are set to 644 or more restrictive (Automated)"
-if [ -f "/var/lib/kube-proxy/kubeconfig" ]; then
+kube_proxy_config=$(append_prefix "$CONFIG_PREFIX" "/var/lib/kube-proxy/kubeconfig")
+kubernetes_proxy=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/proxy")
+
+if [ -f $kube_proxy_config ]; then
     # kops
-    file="/var/lib/kube-proxy/kubeconfig"
+    file=$kube_proxy_config
 else
-    file="/etc/kubernetes/proxy"
+    file=$kubernetes_proxy
 fi
 
 if [ -f "$file" ]; then
@@ -92,6 +98,7 @@ fi
 check_4_1_7="4.1.7  - Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_7"
     pass "       * client-ca-file: $file"
@@ -107,6 +114,7 @@ fi
 check_4_1_8="4.1.8  - Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_8"
     pass "       * client-ca-file: $file"
@@ -122,6 +130,7 @@ fi
 check_4_1_9="4.1.9  - Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Automated)"
 if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_9"
     pass "       * kubelet configuration file: $file"
@@ -137,6 +146,7 @@ fi
 check_4_1_10="4.1.10  - Ensure that the kubelet configuration file ownership is set to root:root (Automated)"
 if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_10"
     pass "       * kubelet configuration file: $file"
@@ -169,6 +179,7 @@ fi
 check_4_2_3="4.2.3  - Ensure that the --client-ca-file argument is set as appropriate (Automated)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_4_2_3"
     pass "       * client-ca-file: $cafile"
 else
@@ -230,6 +241,8 @@ if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_KUBELET_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-cert-file')
         kfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-private-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_4_2_10"
         pass "        * tls-cert-file: $cfile"
         pass "        * tls-private-key-file: $kfile"
@@ -255,6 +268,7 @@ fi
 
 check_4_2_12="4.2.12  - Ensure that the RotateKubeletServerCertificate argument is set to true (Manual)"
 file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 found=$(sed -rn '/--feature-gates=RotateKubeletServerCertificate=true/p' $file)
 if [ -z "$found" ]; then
     warn "$check_4_2_12"

--- a/agent/nvbench/kubernetes-cis-benchmark/gke/worker/4_worker_nodes.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/gke/worker/4_worker_nodes.sh
@@ -11,6 +11,7 @@ file=""
 if check_argument "$CIS_PROXY_CMD" '--kubeconfig' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
 fi
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
@@ -52,6 +53,7 @@ info "$check_4_1_8"
 check_4_1_9="4.1.9  - Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_9"
     pass "       * kubelet configuration file: $file"
@@ -67,6 +69,7 @@ fi
 check_4_1_10="4.1.10  - Ensure that the kubelet configuration file ownership is set to root:root (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
   file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
+  file=$(append_prefix "$CONFIG_PREFIX" "$file")
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_10"
     pass "       * kubelet configuration file: $file"
@@ -99,6 +102,7 @@ fi
 check_4_2_3="4.2.3  - Ensure that the --client-ca-file argument is set as appropriate (Scored)"
 if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
     cafile=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
+    cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
     pass "$check_4_2_3"
     pass "       * client-ca-file: $cafile"
 else
@@ -160,6 +164,8 @@ if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
     if check_argument "$CIS_KUBELET_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
         cfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-cert-file')
         kfile=$(get_argument_value "$CIS_KUBELET_CMD" '--tls-private-key-file')
+        cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+        kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
         pass "$check_4_2_10"
         pass "        * tls-cert-file: $cfile"
         pass "        * tls-private-key-file: $kfile"
@@ -179,6 +185,7 @@ fi
 
 check_4_2_12="4.2.12  - Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
 file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 found=$(sed -rn '/--feature-gates=RotateKubeletServerCertificate=true/p' $file 2>/dev/null)
 if [ -z "$found" ]; then
     warn "$check_4_2_12"

--- a/agent/nvbench/kubernetes-cis-benchmark/helper.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/helper.sh
@@ -40,6 +40,11 @@ yell "# ------------------------------------------------------------------------
 # security concerns slow down your CI/CD processes.
 # ------------------------------------------------------------------------------"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 #get a process command line from /proc
 get_command_line_args() {
     PROC="$1"
@@ -65,7 +70,7 @@ get_argument_value() {
         |
     grep "^${OPTION}" |
     sed \
-        -e "s/^${OPTION}=//g"
+        -E "s/^${OPTION}(=|\s+)//g"
 }
 
 #check whether an argument exist in command line
@@ -80,3 +85,16 @@ check_argument() {
     grep "^${OPTION}" 
 }
 
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}

--- a/agent/nvbench/kubernetes-cis-benchmark/helper1_4_1.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/helper1_4_1.sh
@@ -23,6 +23,11 @@ notScored="1.1.1, 1.1.12, 1.1.13, 1.1.31, 1.4.9, 1.4.10, 1.5.7, 1.6.1, 1.6.2, 1.
 level2="1.3.6, 1.5.7, 1.6.1, 1.6.4, 1.6.5, 1.6.6, 1.6.7, 1.6.8,
  1.7.6, 1.7.7"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 info () {
 
   s_txt=""
@@ -129,7 +134,7 @@ get_argument_value() {
         |
     grep "^${OPTION}" |
     sed \
-        -e "s/^${OPTION}=//g"
+        -E "s/^${OPTION}(=|\s+)//g"
 }
 
 #check whether an argument exist in command line
@@ -144,3 +149,17 @@ check_argument() {
     grep "^${OPTION}"
 }
 
+#get the pid that running the command
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}

--- a/agent/nvbench/kubernetes-cis-benchmark/helper1_5_1.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/helper1_5_1.sh
@@ -20,6 +20,11 @@ fi
 
 level2="1.3.6, 2.7, 3.1.1, 3.2.2, 4.2.9, 5.2.9, 5.3.2, 5.4.2, 5.5.1, 5.7.2, 5.7.3, 5.7.4"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 info () {
 
   s_txt=""
@@ -126,7 +131,7 @@ get_argument_value() {
         |
     grep "^${OPTION}" |
     sed \
-        -e "s/^${OPTION}=//g"
+        -E "s/^${OPTION}(=|\s+)//g"
 }
 
 #check whether an argument exist in command line
@@ -141,3 +146,17 @@ check_argument() {
     grep "^${OPTION}"
 }
 
+#append prefix for the file
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}

--- a/agent/nvbench/kubernetes-cis-benchmark/helper1_6_0.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/helper1_6_0.sh
@@ -22,6 +22,11 @@ level2="1.3.6, 2.7, 3.1.1, 3.2.2, 4.2.9, 5.2.9, 5.3.2, 5.4.2, 5.5.1, 5.7.2, 5.7.
 not_scored="1.1.9, 1.1.10, 1.1.20, 1.1.21, 1.2.1, 1.2.10, 1.2.12, 1.2.13, 1.2.33, 1.2.34, 1.2.35, 1.3.1, 2.7, 3.1.1, 3.2.2, 4,2.8, 4.2.9, 4.2.13, 5.1.1, 5.1.2, 5.1.3, 5.1.4, 5.1.6, 5.2.1, 5.2.6, 5.2.7, 5.2.8, 5.2.9, 5.3.1, 5.4.1, 5.4.2, 5.5.1, 5.7.1, 5.7.2, 5.7.3"
 assessment_manual="1.1.9, 1.1.10, 1.1.20, 1.1.21, 1.2.1, 1.2.10, 1.2.12, 1.2.13, 1.2.33, 1.2.34, 1.2.35, 1.3.1, 2.7, 3.1.1, 3.2.1, 3.2.2, 4.1.3, 4.1.4, 4.1.6, 4.1.7, 4.1.8, 4.2.4, 4.2.5, 4.2.8, 4.2.9, 4.2.10, 4.2.11, 4.2.12, 4.2.13, 5.1.1, 5.1.2, 5.1.3, 5.1.4, 5.1.5, 5.1.6, 5.2.1, 5.2.2, 5.2.3, 5.2.4, 5.2.5, 5.2.6, 5.2.7, 5.2.8, 5.2.9, 5.3.1, 5.3.2, 5.4.1, 5.4.2, 5.5.1, 5.7.1, 5.7.2, 5.7.3, 5.7.4"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 info () {
 
   s_txt=""
@@ -146,7 +151,7 @@ get_argument_value() {
         |
     grep "^${OPTION}" |
     sed \
-        -e "s/^${OPTION}=//g"
+        -E "s/^${OPTION}(=|\s+)//g"
 }
 
 #check whether an argument exist in command line
@@ -161,3 +166,17 @@ check_argument() {
     grep "^${OPTION}"
 }
 
+#append prefix for the file
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}

--- a/agent/nvbench/kubernetes-cis-benchmark/helper_gke.sh
+++ b/agent/nvbench/kubernetes-cis-benchmark/helper_gke.sh
@@ -21,6 +21,11 @@ fi
 level2="1.3.6, 2.7, 3.1.1, 3.2.2, 4.2.9, 5.2.6, 5.2.9, 5.3.2, 5.4.2, 5.6.2, 5.6.3, 5.6.4,
 6.1.4, 6.2.1, 6.4.2, 6.5.1, 6.5.7, 6.6.1, 6.6.4, 6.6.8, 6.7.2, 6.8.3, 6.10.4, 6.10.5"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 info () {
 
   s_txt=""

--- a/agent/nvbench/ocp/4.3/enforcer/master/1_control_plane_components.sh
+++ b/agent/nvbench/ocp/4.3/enforcer/master/1_control_plane_components.sh
@@ -5,6 +5,7 @@ info "1.1 - Master Node Configuration Files"
 check_1_1_1="1.1.1  - Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Scored)"
 
 file="/etc/kubernetes/manifests/kube-apiserver-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_1_1"
@@ -20,6 +21,7 @@ fi
 check_1_1_2="1.1.2  - Ensure that the API server pod specification file ownership is set to root:root (Scored)"
 
 file="/etc/kubernetes/manifests/kube-apiserver-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_2"
@@ -34,6 +36,7 @@ fi
 check_1_1_3="1.1.3  - Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Scored)"
 
 file="/etc/kubernetes/manifests/kube-controller-manager-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_3"
@@ -49,6 +52,7 @@ fi
 check_1_1_4="1.1.4  - Ensure that the controller manager pod specification file ownership is set to root:root (Scored)"
 
 file="/etc/kubernetes/manifests/kube-controller-manager-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_4"
@@ -63,6 +67,7 @@ fi
 check_1_1_5="1.1.5  - Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Scored)"
 
 file="/etc/kubernetes/manifests/kube-scheduler-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_5"
@@ -78,6 +83,7 @@ fi
 check_1_1_6="1.1.6  - Ensure that the scheduler pod specification file ownership is set to root:root (Scored)"
 
 file="/etc/kubernetes/manifests/kube-scheduler-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_6"
@@ -92,6 +98,7 @@ fi
 check_1_1_7="1.1.7  - Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Scored)"
 
 file="/etc/kubernetes/manifests/etcd-member.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_7"
@@ -107,6 +114,7 @@ fi
 check_1_1_8="1.1.8  - Ensure that the etcd pod specification file ownership is set to root:root (Scored)"
 
 file="/etc/kubernetes/manifests/etcd-member.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_8"
@@ -122,15 +130,17 @@ fi
 check_1_1_9="1.1.9  - Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Not Scored)"
 
 valid_permission=true
-path_cni_netd="/etc/cni/net.d"
-path_cni_bin="/opt/cni/bin"
-path_sdn_lib_ocpsdn="/var/lib/cni/networks/openshift-sdn"
-path_sdn_run_ocpsdn="/var/run/openshift-sdn"
-path_ovs_openv="/var/run/openvswitch"
-path_ovs_k8s="/var/run/kubernetes"
-path_ovs_etc_openv="/etc/openvswitch"
-path_ovs_run_openv="/run/openvswitch"
-path_ovs_var_openv="/var/run/openvswitch"
+path_cni_netd=$(append_prefix "$CONFIG_PREFIX" "/etc/cni/net.d")
+path_cni_bin=$(append_prefix "$CONFIG_PREFIX" "/opt/cni/bin")
+
+path_sdn_lib_ocpsdn=$(append_prefix "$CONFIG_PREFIX" "/var/lib/cni/networks/openshift-sdn")
+path_sdn_run_ocpsdn=$(append_prefix "$CONFIG_PREFIX" "/var/run/openshift-sdn")
+
+path_ovs_openv=$(append_prefix "$CONFIG_PREFIX" "/var/run/openvswitch")
+path_ovs_k8s=$(append_prefix "$CONFIG_PREFIX" "/var/run/kubernetes")
+path_ovs_etc_openv=$(append_prefix "$CONFIG_PREFIX" "/etc/openvswitch")
+path_ovs_run_openv=$(append_prefix "$CONFIG_PREFIX" "/run/openvswitch")
+path_ovs_var_openv=$(append_prefix "$CONFIG_PREFIX" "/var/run/openvswitch")
 
 invalid_file_list=""
 
@@ -161,17 +171,17 @@ fi
 check_1_1_10="1.1.10  - Ensure that the Container Network Interface file ownership is set to root:root (Not Scored)"
 
 valid_ownership=true
-path_cni_netd="/etc/cni/net.d"
-path_cni_bin="/opt/cni/bin"
+path_cni_netd=$(append_prefix "$CONFIG_PREFIX" "/etc/cni/net.d")
+path_cni_bin=$(append_prefix "$CONFIG_PREFIX" "/opt/cni/bin")
 
-path_sdn_lib_ocpsdn="/var/lib/cni/networks/openshift-sdn"
-path_sdn_run_ocpsdn="/var/run/openshift-sdn"
+path_sdn_lib_ocpsdn=$(append_prefix "$CONFIG_PREFIX" "/var/lib/cni/networks/openshift-sdn")
+path_sdn_run_ocpsdn=$(append_prefix "$CONFIG_PREFIX" "/var/run/openshift-sdn")
 
-path_ovs_openv="/var/run/openvswitch"
-path_ovs_k8s="/var/run/kubernetes"
-path_ovs_etc_openv="/etc/openvswitch"
-path_ovs_run_openv="/run/openvswitch"
-path_ovs_var_openv="/var/run/openvswitch"
+path_ovs_openv=$(append_prefix "$CONFIG_PREFIX" "/var/run/openvswitch")
+path_ovs_k8s=$(append_prefix "$CONFIG_PREFIX" "/var/run/kubernetes")
+path_ovs_etc_openv=$(append_prefix "$CONFIG_PREFIX" "/etc/openvswitch")
+path_ovs_run_openv=$(append_prefix "$CONFIG_PREFIX" "/run/openvswitch")
+path_ovs_var_openv=$(append_prefix "$CONFIG_PREFIX" "/var/run/openvswitch")
 
 invalid_file_list=""
 
@@ -216,6 +226,7 @@ fi
 check_1_1_11="1.1.11  - Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
 
 file="/var/lib/etcd"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -d "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 700 ]; then
     pass "$check_1_1_11"
@@ -230,6 +241,7 @@ fi
 check_1_1_12="1.1.12  - Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
 
 file="/var/lib/etcd"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -d "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_12"
@@ -244,6 +256,7 @@ fi
 check_1_1_13="1.1.13  - Ensure that the admin.conf file permissions are set to 644 or more restrictive (Scored)"
 
 file="/etc/kubernetes/kubeconfig"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_13"
@@ -259,6 +272,7 @@ fi
 check_1_1_14="1.1.14  - Ensure that the admin.conf file ownership is set to root:root (Scored)"
 
 file="/etc/kubernetes/kubeconfig"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_14"
@@ -271,8 +285,7 @@ else
 fi
 
 check_1_1_15="1.1.15  - Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Scored)"
-
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
 
 valid_permission=false
 for i in $files
@@ -292,8 +305,7 @@ else
 fi
 
 check_1_1_16="1.1.16  - Ensure that the scheduler.conf file ownership is set to root:root (Scored)"
-
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
 
 valid_permission=false
 for i in $files
@@ -313,8 +325,7 @@ else
 fi
 
 check_1_1_17="1.1.17  - Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Scored)"
-
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
 
 valid_permission=false
 for i in $files
@@ -334,8 +345,7 @@ else
 fi
 
 check_1_1_18="1.1.18  - Ensure that the controller-manager.conf file ownership is set to root:root (Scored)"
-
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
 
 valid_permission=false
 for i in $files
@@ -355,9 +365,8 @@ else
 fi
 
 check_1_1_19="1.1.19  - Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Scored)"
-
-directories=$(find /etc/kubernetes/static-pod-resources -type d -wholename '*/secrets*')
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/secrets*')
+directories=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type d -wholename '*/secrets*')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/secrets*')
 
 valid_perm_dir=false
 for i in $directories
@@ -388,7 +397,7 @@ else
 fi
 
 check_1_1_20="1.1.20  - Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Not Scored)"
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/secrets/*.crt')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/secrets/*.crt')
 valid_perm_file=false
 for i in $files
 do
@@ -407,7 +416,7 @@ else
 fi
 
 check_1_1_21="1.1.21  - Ensure that the Kubernetes PKI key file permissions are set to 600 (Not Scored)"
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/secrets/*.key')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/secrets/*.key')
 valid_perm_file=false
 for i in $files
 do

--- a/agent/nvbench/ocp/4.3/enforcer/master/2_etcd.sh
+++ b/agent/nvbench/ocp/4.3/enforcer/master/2_etcd.sh
@@ -2,6 +2,7 @@ info "2 - etcd"
 
 check_2_1="2.1  - Ensure that the --cert-file and --key-file arguments are set as appropriate (Scored)"
 file="/etc/kubernetes/manifests/etcd-member.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output_cert=$(grep "\(--cert-file=\)" $file)
 output_key=$(grep "\(--key-file=\)" $file)
 if [ -z "$output_cert" ] || [ -z "$output_key" ]; then
@@ -12,6 +13,7 @@ fi
 
 check_2_2="2.2  - Ensure that the --client-cert-auth argument is set to true (Scored)"
 file="/etc/kubernetes/manifests/etcd-member.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep "\(--client-cert-auth=true\)" $file)
 if [ -z "$output" ]; then
     warn "$check_2_2"
@@ -21,6 +23,7 @@ fi
 
 check_2_3="2.3  - Ensure that the --auto-tls argument is not set to true (Scored)"
 file="/etc/kubernetes/manifests/etcd-member.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep "\(--auto-tls=true\)" $file)
 if [ -z "$output" ]; then
     pass "$check_2_3"
@@ -30,6 +33,7 @@ fi
 
 check_2_4="2.4  - Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Scored)"
 file="/etc/kubernetes/manifests/etcd-member.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output_cert=$(grep "\(--peer-cert-file=\)" $file)
 output_key=$(grep "\(--peer-key-file=\)" $file)
 if [ -z "$output_cert" ] || [ -z "$output_key" ]; then
@@ -40,6 +44,7 @@ fi
 
 check_2_5="2.5  - Ensure that the --peer-client-cert-auth argument is set to true (Scored)"
 file="/etc/kubernetes/manifests/etcd-member.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep "\(--peer-client-cert-auth=true\)" $file)
 if [ -z "$output" ]; then
     warn "$check_2_5"
@@ -49,6 +54,7 @@ fi
 
 check_2_6="2.6  - Ensure that the --peer-auto-tls argument is not set to true (Scored)"
 file="/etc/kubernetes/manifests/etcd-member.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep "\(--peer-auto-tls=true\)" $file)
 if [ -z "$output" ]; then
     pass "$check_2_6"
@@ -58,7 +64,8 @@ fi
 
 check_2_7="2.7  - Ensure that a unique Certificate Authority is used for etcd (Not Scored)"
 file="/etc/kubernetes/manifests/etcd-member.yaml"
-output=$(grep "\(--trusted-ca-file=/etc/ssl/etcd/ca.crt\)" $file)
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+output=$(grep "$(append_prefix "$CONFIG_PREFIX" "/etc/ssl/etcd/ca.crt")" "$file")
 if [ -z "$output" ]; then
     warn "$check_2_7"
 else

--- a/agent/nvbench/ocp/4.3/enforcer/master/3_control_plane_configuration.sh
+++ b/agent/nvbench/ocp/4.3/enforcer/master/3_control_plane_configuration.sh
@@ -4,7 +4,7 @@ info "3.1 - Authentication and Authorization"
 
 #todo review
 check_3_1_1="3.1.1  - Client certificate authentication should not be used for users (Not Scored)"
-output=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*configmaps/client-ca/ca-bundle.crt')
+output=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*configmaps/client-ca/ca-bundle.crt')
 if [ -z "$output" ]; then
   warn "$check_3_1_1"
 else

--- a/agent/nvbench/ocp/4.3/enforcer/worker/4_worker_nodes.sh
+++ b/agent/nvbench/ocp/4.3/enforcer/worker/4_worker_nodes.sh
@@ -2,6 +2,7 @@ info "4.1 - Worker Node Configuration Files"
 
 check_4_1_1="4.1.1  - Ensure that the kubelet service file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/systemd/system/kubelet.service"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_1"
@@ -16,6 +17,7 @@ fi
 
 check_4_1_2="4.1.2  - Ensure that the kubelet service file ownership is set to root:root (Scored)"
 file="/etc/systemd/system/kubelet.service"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_2"
@@ -33,6 +35,7 @@ fi
 
 check_4_1_5="4.1.5  - Ensure that the kubelet.conf file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_5"
@@ -47,6 +50,7 @@ fi
 
 check_4_1_6="4.1.6  - Ensure that the kubelet.conf file ownership is set to root:root (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_6"
@@ -60,6 +64,7 @@ fi
 
 check_4_1_7="4.1.7  - Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Scored)"
 file="/etc/kubernetes/kubelet-ca.crt"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_7"
@@ -74,6 +79,7 @@ fi
 
 check_4_1_8="4.1.8  - Ensure that the client certificate authorities file ownership is set to root:root (Scored)"
 file="/etc/kubernetes/kubelet-ca.crt"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_8"
@@ -87,6 +93,7 @@ fi
 
 check_4_1_9="4.1.9  - Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Scored)"
 file="/var/lib/kubelet/kubeconfig"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_4_1_9"
@@ -101,6 +108,7 @@ fi
 
 check_4_1_10="4.1.10  - Ensure that the kubelet configuration file ownership is set to root:root (Scored)"
 file="/var/lib/kubelet/kubeconfig"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_10"
@@ -117,7 +125,9 @@ info "4.2 - Kubelet"
 #todo review all audits
 check_4_2_1="4.2.1  - Ensure that the anonymous-auth argument is set to false (Scored)"
 file="/etc/kubernetes/kubelet.conf"
-output_ca=$(grep '\(clientCAFile: /etc/kubernetes/kubelet-ca.crt\)' $file)
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+ca_cert=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet-ca.crt")
+output_ca=$(grep "clientCAFile: $ca_cert" $file)
 output_auth=$(grep '\(enabled: false\)' $file)
 if [ -z "$output_ca" ] || [ -z "$output_auth" ] ; then
     warn "$check_4_2_1"
@@ -127,6 +137,7 @@ fi
 
 check_4_2_2="4.2.2  - Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(authorization-mode\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_2"
@@ -136,7 +147,9 @@ fi
 
 check_4_2_3="4.2.3  - Ensure that the --client-ca-file argument is set as appropriate (Scored)"
 file="/etc/kubernetes/kubelet.conf"
-output_ca=$(grep '\(clientCAFile: /etc/kubernetes/kubelet-ca.crt\)' $file)
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+ca_cert=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet-ca.crt")
+output_ca=$(grep "clientCAFile: $ca_cert" $file)
 if [ -z "$output_ca" ]; then
     warn "$check_4_2_3"
 else
@@ -146,6 +159,7 @@ fi
 #todo review (ocp by default setting)
 check_4_2_4="4.2.4  - Ensure that the --read-only-port argument is set to 0 (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(read-only-port\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_4"
@@ -155,6 +169,7 @@ fi
 
 check_4_2_5="4.2.5  - Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(streaming-connection-idle-timeout\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_5"
@@ -164,6 +179,7 @@ fi
 
 check_4_2_7="4.2.7  - Ensure that the --make-iptables-util-chains argument is set to true (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(make-iptables-util-chains\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_7"
@@ -176,6 +192,7 @@ info "$check_4_2_9"
 
 check_4_2_10="4.2.10  - Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output_cert=$(grep '\(tls-cert-file\)' $file)
 output_key=$(grep '\(tls-private-key-file\)' $file)
 if [ -z "$output_cert" ] && [ -z "$output_key" ]; then
@@ -199,6 +216,7 @@ fi
 
 check_4_2_11="4.2.11  - Ensure that the RotateKubeletClientCertificate argument is not set to false (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(RotateKubeletClientCertificate\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_11"
@@ -219,6 +237,7 @@ fi
 
 check_4_2_12="4.2.12  - Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(RotateKubeletServerCertificate: true\)' $file)
 if [ -z "$output" ]; then
     warn "$check_4_2_12"

--- a/agent/nvbench/ocp/4.5/enforcer/master/1_control_plane_components.sh
+++ b/agent/nvbench/ocp/4.5/enforcer/master/1_control_plane_components.sh
@@ -5,6 +5,7 @@ info "1.1 - Master Node Configuration Files"
 check_1_1_1="1.1.1  - Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Manual)"
 
 file="/etc/kubernetes/manifests/kube-apiserver-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f $file ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 640 -o "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_1_1_1"
@@ -20,6 +21,7 @@ fi
 check_1_1_2="1.1.2  - Ensure that the API server pod specification file ownership is set to root:root (Manual)"
 
 file="/etc/kubernetes/manifests/kube-apiserver-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_2"
@@ -34,6 +36,7 @@ fi
 check_1_1_3="1.1.3  - Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Manual)"
 
 file="/etc/kubernetes/manifests/kube-controller-manager-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_3"
@@ -49,6 +52,7 @@ fi
 check_1_1_4="1.1.4  - Ensure that the controller manager pod specification file ownership is set to root:root (Manual)"
 
 file="/etc/kubernetes/manifests/kube-controller-manager-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_4"
@@ -63,6 +67,7 @@ fi
 check_1_1_5="1.1.5  - Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Manual)"
 
 file="/etc/kubernetes/manifests/kube-scheduler-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_5"
@@ -78,6 +83,7 @@ fi
 check_1_1_6="1.1.6  - Ensure that the scheduler pod specification file ownership is set to root:root (Manual)"
 
 file="/etc/kubernetes/manifests/kube-scheduler-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_6"
@@ -93,6 +99,7 @@ fi
 check_1_1_7="1.1.7  - Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Manual)"
 
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_1_1_7"
@@ -108,6 +115,7 @@ fi
 check_1_1_8="1.1.8  - Ensure that the etcd pod specification file ownership is set to root:root (Manual)"
 
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_8"
@@ -122,16 +130,16 @@ fi
 check_1_1_9="1.1.9  - Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
 
 valid_permission=true
-path_cni_netd="/etc/cni/net.d"
-path_cni_bin="/opt/cni/bin"
-path_cni_multus="/var/run/multus/cni/net.d"
-path_sdn_lib_ocpsdn="/var/lib/cni/networks/openshift-sdn"
-path_sdn_run_ocpsdn="/var/run/openshift-sdn"
-path_ovs_openv="/var/run/openvswitch"
-path_ovs_k8s="/var/run/kubernetes"
-path_ovs_etc_openv="/etc/openvswitch"
-path_ovs_run_openv="/run/openvswitch"
-path_ovs_var_openv="/var/run/openvswitch"
+path_cni_netd=$(append_prefix "$CONFIG_PREFIX" "/etc/cni/net.d")
+path_cni_bin=$(append_prefix "$CONFIG_PREFIX" "/opt/cni/bin")
+path_cni_multus=$(append_prefix "$CONFIG_PREFIX" "/var/run/multus/cni/net.d")
+path_sdn_lib_ocpsdn=$(append_prefix "$CONFIG_PREFIX" "/var/lib/cni/networks/openshift-sdn")
+path_sdn_run_ocpsdn=$(append_prefix "$CONFIG_PREFIX" "/var/run/openshift-sdn")
+path_ovs_openv=$(append_prefix "$CONFIG_PREFIX" "/var/run/openvswitch")
+path_ovs_k8s=$(append_prefix "$CONFIG_PREFIX" "/var/run/kubernetes")
+path_ovs_etc_openv=$(append_prefix "$CONFIG_PREFIX" "/etc/openvswitch")
+path_ovs_run_openv=$(append_prefix "$CONFIG_PREFIX" "/run/openvswitch")
+path_ovs_var_openv=$(append_prefix "$CONFIG_PREFIX" "/var/run/openvswitch")
 
 invalid_file_list=""
 
@@ -162,18 +170,18 @@ fi
 check_1_1_10="1.1.10  - Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
 
 valid_ownership=true
-path_cni_netd="/etc/cni/net.d"
-path_cni_bin="/opt/cni/bin"
-path_cni_multus="/var/run/multus/cni/net.d"
+path_cni_netd=$(append_prefix "$CONFIG_PREFIX" "/etc/cni/net.d")
+path_cni_bin=$(append_prefix "$CONFIG_PREFIX" "/opt/cni/bin")
+path_cni_multus=$(append_prefix "$CONFIG_PREFIX" "/var/run/multus/cni/net.d")
 
-path_sdn_lib_ocpsdn="/var/lib/cni/networks/openshift-sdn"
-path_sdn_run_ocpsdn="/var/run/openshift-sdn"
+path_sdn_lib_ocpsdn=$(append_prefix "$CONFIG_PREFIX" "/var/lib/cni/networks/openshift-sdn")
+path_sdn_run_ocpsdn=$(append_prefix "$CONFIG_PREFIX" "/var/run/openshift-sdn")
 
-path_ovs_openv="/var/run/openvswitch"
-path_ovs_k8s="/var/run/kubernetes"
-path_ovs_etc_openv="/etc/openvswitch"
-path_ovs_run_openv="/run/openvswitch"
-path_ovs_var_openv="/var/run/openvswitch"
+path_ovs_openv=$(append_prefix "$CONFIG_PREFIX" "/var/run/openvswitch")
+path_ovs_k8s=$(append_prefix "$CONFIG_PREFIX" "/var/run/kubernetes")
+path_ovs_etc_openv=$(append_prefix "$CONFIG_PREFIX" "/etc/openvswitch")
+path_ovs_run_openv=$(append_prefix "$CONFIG_PREFIX" "/run/openvswitch")
+path_ovs_var_openv=$(append_prefix "$CONFIG_PREFIX" "/var/run/openvswitch")
 
 invalid_file_list=""
 
@@ -218,6 +226,7 @@ fi
 check_1_1_11="1.1.11  - Ensure that the etcd data directory permissions are set to 700 or more restrictive (Manual)"
 
 file="/var/lib/etcd"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -d "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 700 ]; then
     pass "$check_1_1_11"
@@ -233,6 +242,7 @@ fi
 check_1_1_12="1.1.12  - Ensure that the etcd data directory ownership is set to root:root (Manual)"
 
 file="/var/lib/etcd"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -d "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_12"
@@ -247,6 +257,7 @@ fi
 check_1_1_13="1.1.13  - Ensure that the admin.conf file permissions are set to 644 or more restrictive (Manual)"
 
 file="/etc/kubernetes/kubeconfig"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -le 644 ]; then
     pass "$check_1_1_13"
@@ -262,6 +273,7 @@ fi
 check_1_1_14="1.1.14  - Ensure that the admin.conf file ownership is set to root:root (Manual)"
 
 file="/etc/kubernetes/kubeconfig"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_1_1_14"
@@ -275,7 +287,7 @@ fi
 
 check_1_1_15="1.1.15  - Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Manual)"
 
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
 
 valid_permission=false
 for i in $files
@@ -296,7 +308,7 @@ fi
 
 check_1_1_16="1.1.16  - Ensure that the scheduler.conf file ownership is set to root:root (Manual)"
 
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
 
 valid_permission=false
 for i in $files
@@ -317,7 +329,7 @@ fi
 
 check_1_1_17="1.1.17  - Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Manual)"
 
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
 
 valid_permission=false
 for i in $files
@@ -338,7 +350,7 @@ fi
 
 check_1_1_18="1.1.18  - Ensure that the controller-manager.conf file ownership is set to root:root (Manual)"
 
-files=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
+files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
 
 valid_permission=false
 for i in $files
@@ -360,6 +372,7 @@ fi
 check_1_1_19="1.1.19  - Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Manual)"
 
 cert_path="/etc/kubernetes/static-pod-certs"
+cert_path=$(append_prefix "$CONFIG_PREFIX" "$cert_path")
 valid_perm_dir=false
 valid_perm_file=false
 
@@ -401,6 +414,7 @@ fi
 check_1_1_20="1.1.20  - Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
 
 cert_path="/etc/kubernetes/static-pod-certs"
+cert_path=$(append_prefix "$CONFIG_PREFIX" "$cert_path")
 if [ -f "$cert_path" ]; then
   files=$(find $cert_path -type f -wholename '*/secrets/*.crt')
   valid_perm_file=false
@@ -427,6 +441,7 @@ fi
 check_1_1_21="1.1.21  - Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
 
 cert_path="/etc/kubernetes/static-pod-certs"
+cert_path=$(append_prefix "$CONFIG_PREFIX" "$cert_path")
 
 if [ -f "$cert_path" ]; then
   files=$(find $cert_path -type f -wholename '*/secrets/*.key')

--- a/agent/nvbench/ocp/4.5/enforcer/master/2_etcd.sh
+++ b/agent/nvbench/ocp/4.5/enforcer/master/2_etcd.sh
@@ -2,6 +2,7 @@ info "2 - etcd"
 
 check_2_1="2.1  - Ensure that the --cert-file and --key-file arguments are set as appropriate (Manual)"
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output_cert=$(grep "\(--cert-file=\)" $file)
 output_key=$(grep "\(--key-file=\)" $file)
 if [ -z "$output_cert" ] || [ -z "$output_key" ]; then
@@ -12,6 +13,7 @@ fi
 
 check_2_2="2.2  - Ensure that the --client-cert-auth argument is set to true (Manual)"
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep "\(--client-cert-auth=true\)" $file)
 if [ -z "$output" ]; then
     warn "$check_2_2"
@@ -22,6 +24,7 @@ fi
 #todo review with Andson (OCP doesn't use auto-tls)
 check_2_3="2.3  - Ensure that the --auto-tls argument is not set to true (Manual)"
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep "\(--auto-tls=true\)" $file)
 if [ -z "$output" ]; then
     pass "$check_2_3"
@@ -31,6 +34,7 @@ fi
 
 check_2_4="2.4  - Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Manual)"
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output_cert=$(grep "\(--peer-cert-file=\)" $file)
 output_key=$(grep "\(--peer-key-file=\)" $file)
 if [ -z "$output_cert" ] || [ -z "$output_key" ]; then
@@ -41,6 +45,7 @@ fi
 
 check_2_5="2.5  - Ensure that the --peer-client-cert-auth argument is set to true (Manual)"
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep "\(--peer-client-cert-auth=true\)" $file)
 if [ -z "$output" ]; then
     warn "$check_2_5"
@@ -50,6 +55,7 @@ fi
 
 check_2_6="2.6  - Ensure that the --peer-auto-tls argument is not set to true (Manual)"
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep "\(--peer-auto-tls=true\)" $file)
 if [ -z "$output" ]; then
     pass "$check_2_6"
@@ -59,6 +65,7 @@ fi
 
 check_2_7="2.7  - Ensure that a unique Certificate Authority is used for etcd (Manual)"
 file="/etc/kubernetes/manifests/etcd-pod.yaml"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output_1=$(grep "\(--trusted-ca-file=\)" $file)
 output_2=$(grep "\(--peer-trusted-ca-file=\)" $file)
 if [ -z "$output_1" ] || [ -z "$output_2" ]; then

--- a/agent/nvbench/ocp/4.5/enforcer/master/3_control_plane_configuration.sh
+++ b/agent/nvbench/ocp/4.5/enforcer/master/3_control_plane_configuration.sh
@@ -4,7 +4,7 @@ info "3.1 - Authentication and Authorization"
 
 #todo review
 check_3_1_1="3.1.1  - Client certificate authentication should not be used for users (Manual)"
-output=$(find /etc/kubernetes/static-pod-resources -type f -wholename '*configmaps/client-ca/ca-bundle.crt')
+output=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*configmaps/client-ca/ca-bundle.crt')
 if [ -z "$output" ]; then
   warn "$check_3_1_1"
 else

--- a/agent/nvbench/ocp/4.5/enforcer/worker/4_worker_nodes.sh
+++ b/agent/nvbench/ocp/4.5/enforcer/worker/4_worker_nodes.sh
@@ -2,6 +2,7 @@ info "4.1 - Worker Node Configuration Files"
 
 check_4_1_1="4.1.1  - Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
 file="/etc/systemd/system/kubelet.service"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_1"
@@ -16,6 +17,7 @@ fi
 
 check_4_1_2="4.1.2  - Ensure that the kubelet service file ownership is set to root:root (Automated)"
 file="/etc/systemd/system/kubelet.service"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_2"
@@ -36,6 +38,7 @@ info "$check_4_1_4"
 
 check_4_1_5="4.1.5  - Ensure that the kubelet.conf file permissions are set to 644 or more restrictive (Manual)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_5"
@@ -50,6 +53,7 @@ fi
 
 check_4_1_6="4.1.6  - Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Manual)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_6"
@@ -63,6 +67,7 @@ fi
 
 check_4_1_7="4.1.7  - Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Automated)"
 file="/etc/kubernetes/kubelet-ca.crt"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
     pass "$check_4_1_7"
@@ -77,6 +82,7 @@ fi
 
 check_4_1_8="4.1.8  - Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
 file="/etc/kubernetes/kubelet-ca.crt"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_8"
@@ -90,6 +96,7 @@ fi
 
 check_4_1_9="4.1.9  - Ensure that the kubelet --config configuration file has permissions set to 644 or more restrictive (Automated)"
 file="/var/lib/kubelet/kubeconfig"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %a $file)" -eq 600 ]; then
     pass "$check_4_1_9"
@@ -104,6 +111,7 @@ fi
 
 check_4_1_10="4.1.10  - Ensure that the kubelet configuration file ownership is set to root:root (Automated)"
 file="/var/lib/kubelet/kubeconfig"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 if [ -f "$file" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_4_1_10"
@@ -120,7 +128,9 @@ info "4.2 - Kubelet"
 #todo review all audits
 check_4_2_1="4.2.1  - Ensure that the anonymous-auth argument is set to false (Automated)"
 file="/etc/kubernetes/kubelet.conf"
-output_ca=$(grep '\(clientCAFile: /etc/kubernetes/kubelet-ca.crt\)' $file)
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+ca_cert=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet-ca.crt")
+output_ca=$(grep "clientCAFile: $ca_cert" $file)
 output_auth=$(grep '\(enabled: false\)' $file)
 if [ -z "$output_ca" ] || [ -z "$output_auth" ] ; then
     warn "$check_4_2_1"
@@ -130,6 +140,7 @@ fi
 
 check_4_2_2="4.2.2  - Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(authorization-mode\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_2"
@@ -139,7 +150,9 @@ fi
 
 check_4_2_3="4.2.3  - Ensure that the --client-ca-file argument is set as appropriate (Automated)"
 file="/etc/kubernetes/kubelet.conf"
-output_ca=$(grep '\(clientCAFile: /etc/kubernetes/kubelet-ca.crt\)' $file)
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
+ca_cert=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/kubelet-ca.crt")
+output_ca=$(grep "clientCAFile: $ca_cert" $file)
 if [ -z "$output_ca" ]; then
     warn "$check_4_2_3"
 else
@@ -149,6 +162,7 @@ fi
 #todo review (ocp by default setting)
 check_4_2_4="4.2.4  - Verify that the read only port is not used or is set to 0 (Automated)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(read-only-port\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_4"
@@ -158,6 +172,7 @@ fi
 
 check_4_2_5="4.2.5  - Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Automated)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(streaming-connection-idle-timeout\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_5"
@@ -167,6 +182,7 @@ fi
 
 check_4_2_6="4.2.6  - Ensure that the --protect-kernel-defaults argument is not set (Manual)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(protectKernelDefaults\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_5"
@@ -176,6 +192,7 @@ fi
 
 check_4_2_7="4.2.7  - Ensure that the --make-iptables-util-chains argument is set to true (Manual)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(make-iptables-util-chains\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_7"
@@ -185,6 +202,7 @@ fi
 
 check_4_2_8="4.2.8  - Ensure that the --hostname-override argument is not set (Manual)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(hostname-override\)' $file)
 if [ -z "$output" ]; then
     pass "$check_4_2_7"
@@ -194,6 +212,7 @@ fi
 
 check_4_2_9="4.2.9  - Ensure that the kubeAPIQPS [--event-qps] argument is set to 0 or a level which ensures appropriate event capture (Automated)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output=$(grep '\(kubeAPIQPS: 50\)' $file)
 if [ -z "$output" ]; then
     warn "$check_4_2_9"
@@ -203,6 +222,7 @@ fi
 
 check_4_2_10="4.2.10  - Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output_cert=$(grep '\(tls-cert-file\)' $file)
 output_key=$(grep '\(tls-private-key-file\)' $file)
 if [ -z "$output_cert" ] && [ -z "$output_key" ]; then
@@ -226,6 +246,7 @@ fi
 
 check_4_2_11="4.2.11  - Ensure that the --rotate-certificates argument is not set to false (Manual)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output1=$(grep '\(rotateKubeletClientCertificates: false\)' $file)
 output2=$(grep '\(rotateCertificates: true\)' $file)
 if [ -z "$output1"] && [ -n "$output2" ]; then
@@ -247,6 +268,7 @@ fi
 
 check_4_2_12="4.2.12  - Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
 file="/etc/kubernetes/kubelet.conf"
+file=$(append_prefix "$CONFIG_PREFIX" "$file")
 output1=$(grep '\(RotateKubeletServerCertificate: true\)' $file)
 output2=$(grep '\(rotateCertificates: true\)' $file)
 if [ -n "$output1" ] && [ -n "$output2" ] ; then

--- a/agent/nvbench/ocp/helper_ocp.sh
+++ b/agent/nvbench/ocp/helper_ocp.sh
@@ -113,6 +113,11 @@ yell "# ------------------------------------------------------------------------
 # security concerns slow down your CI/CD processes.
 # ------------------------------------------------------------------------------"
 
+BASE_IMAGE_BIN_PATH="<<<.Replace_baseImageBin_path>>>"
+export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
+export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
+CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
+
 #get a process command line from /proc
 get_command_line_args() {
     PROC="$1"

--- a/agent/nvbench/ocp/helper_ocp.sh
+++ b/agent/nvbench/ocp/helper_ocp.sh
@@ -158,3 +158,16 @@ check_argument() {
     grep "^${OPTION}"
 }
 
+append_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  # Remove any trailing slash from prefix
+  prefix="${prefix%/}"
+
+  # Remove a leading slash from file, if it exists
+  file="${file#/}"
+
+  # Concatenate and return the result
+  echo "$prefix/$file"
+}


### PR DESCRIPTION
### Summary
1. we check if the current OS is bottlerocket,

- we access the config with /proc/1/root/ and run it like a pure shell (without nstool)

2. **Export base image bin and LD bin as part of the env variable** to make sure we are able to run under lack of instruction circumstance
3. Remove **kubeCheckPrerequisite.**,  since we will make sure the env has the corresponding linux command.