### PR TITLE
NVSHAS-8456: controllers: remove the mounting runtime socket requirement

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"net"
 	"os"
 	"os/signal"
@@ -360,7 +361,7 @@ func main() {
 		log.Info("Not running in container.")
 	}
 
-	if platform == share.PlatformKubernetes {
+	if platform == share.PlatformKubernetes && global.RT.String() != container.StubRtName {
 		if selfID, err = global.IdentifyK8sContainerID(selfID); err != nil {
 			log.WithFields(log.Fields{"selfID": selfID, "error": err}).Error("lookup")
 		}
@@ -387,6 +388,12 @@ func main() {
 
 		log.Info("Wait for local interface ...")
 		time.Sleep(time.Second * 4)
+	}
+
+	if platform == share.PlatformKubernetes && global.RT.String() == container.StubRtName {
+		if err := amendStubRtInfo(); err != nil {
+			log.WithFields(log.Fields{"error": err, "Ctrler": Ctrler}).Error("Failed to get local device information")
+		}
 	}
 
 	Host.Platform = platform
@@ -838,4 +845,45 @@ func main() {
 	ctrlDeleteLocalInfo()
 	cluster.LeaveCluster(true)
 	grpcServer.Stop()
+}
+
+func amendStubRtInfo() error {
+	podname := Ctrler.Name
+	objs, err := global.ORCH.ListResource(resource.RscTypeNamespace)
+	if err == nil {
+		for _, obj := range objs {
+			if domain := obj.(*resource.Namespace); domain != nil {
+				if o, err := global.ORCH.GetResource(resource.RscTypePod, domain.Name, podname); err == nil {
+					if pod := o.(*resource.Pod); pod != nil {
+						log.WithFields(log.Fields{"pod": pod}).Debug()
+						Ctrler.Domain = domain.Name
+						Ctrler.Labels = pod.Labels
+						if Ctrler.Labels != nil {
+							Ctrler.Labels["io.kubernetes.container.name"] = resource.NvDeploymentName
+							Ctrler.Labels["io.kubernetes.pod.name"] = podname
+							Ctrler.Labels["io.kubernetes.pod.namespace"] = Ctrler.Domain
+							Ctrler.Labels["io.kubernetes.pod.uid"] = pod.UID
+							Ctrler.Labels["name"] = share.NeuVectorRoleController
+							Ctrler.Labels["neuvector.role"] = share.NeuVectorRoleController
+							Ctrler.Labels["release"] = ""
+							Ctrler.Labels["vendor"] = "NeuVector Inc."
+							Ctrler.Labels["version"] = ""
+						}
+						if pod.HostNet {
+							Ctrler.NetworkMode = "host"
+						} else {
+							Ctrler.NetworkMode = "default"
+						}
+						Ctrler.HostName = pod.Node
+						Ctrler.Name = "k8s_" + Ctrler.Labels["io.kubernetes.container.name"] + "_" +
+							Ctrler.Labels["io.kubernetes.pod.name"] + "_" +
+							Ctrler.Labels["io.kubernetes.pod.namespace"] + "_" +
+							Ctrler.Labels["io.kubernetes.pod.uid"] + "_0"
+						return nil
+					}
+				}
+			}
+		}
+	}
+	return fmt.Errorf("can not found: err = %v", err)
 }

--- a/controller/resource/kubernetes_resource.go
+++ b/controller/resource/kubernetes_resource.go
@@ -1716,7 +1716,7 @@ func (d *kubernetes) GetResource(rt, namespace, name string) (interface{}, error
 }
 
 func (d *kubernetes) getResource(rt, namespace, name string) (interface{}, error) {
-	log.WithFields(log.Fields{"resource": rt}).Debug()
+	//log.WithFields(log.Fields{"resource": rt}).Debug()
 
 	maker, err := d.discoverResource(rt)
 	if err != nil {

--- a/share/container/stub.go
+++ b/share/container/stub.go
@@ -1,0 +1,150 @@
+package container
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/neuvector/neuvector/share"
+	"github.com/neuvector/neuvector/share/system"
+	"github.com/neuvector/neuvector/share/system/sysinfo"
+	"github.com/neuvector/neuvector/share/utils"
+)
+
+// This is a virtual runtime device driver.
+// It supports the limited device information when the runtime driver is not available.
+const StubRtName = "stubRtDriver"
+
+// a dummy static runtime driver
+type stubRTDriver struct {
+	sys      *system.SystemTools
+	sysInfo  *sysinfo.SysInfo
+
+	rootPid      int
+	initTime     time.Time
+
+	selfID		 string
+	podName      string
+	nodeHostname string
+	ipAddress    string
+}
+
+func (d *stubRTDriver) IsRuntimeProcess(proc string, cmds []string) bool { return false }
+func (d *stubRTDriver) String() string { return StubRtName }
+func (d *stubRTDriver) MonitorEvent(cb EventCallback, cpath bool) error { return ErrMethodNotSupported }
+func (d *stubRTDriver) StopMonitorEvent() {}
+func (d *stubRTDriver) GetContainer(id string) (*ContainerMetaExtra, error) {	return nil, nil }
+func (d *stubRTDriver) ListContainers(runningOnly bool) ([]*ContainerMeta, error) { return nil, nil }
+func (d *stubRTDriver) ListContainerIDs() (utils.Set, utils.Set) { return nil, nil }
+func (d *stubRTDriver) GetImageHistory(name string) ([]*ImageHistory, error) { return nil, nil }
+func (d *stubRTDriver) GetImage(name string) (*ImageMeta, error) { return nil, nil }
+func (d *stubRTDriver) GetImageFile(id string) (io.ReadCloser, error)      { return nil, nil }
+func (d *stubRTDriver) GetNetworkEndpoint(netName, container, epName string) (*NetworkEndpoint, error) { return nil, nil}
+func (d *stubRTDriver) GetParent(meta *ContainerMetaExtra, pidMap map[int]string) (bool, string) { return false, ""}
+func (d *stubRTDriver) IsDaemonProcess(proc string, cmds []string) bool { return false }
+func (d *stubRTDriver) GetDefaultRegistries() []string                  { return nil }
+func (d *stubRTDriver) GetStorageDriver() string                        { return "" }
+func (d *stubRTDriver) GetService(id string) (*Service, error) { return nil, ErrMethodNotSupported }
+func (d *stubRTDriver) ListServices() ([]*Service, error) {	return make([]*Service, 0), nil }
+
+/////////
+func InitStubRtDriver(sys *system.SystemTools) (Runtime, error) {
+	var id, podname, ipaddress string
+	log.Info()
+	ppid := os.Getppid()
+
+	id, _, _, _ = sys.GetContainerIDByPID(ppid)
+	if dat, err := ioutil.ReadFile("/etc/hostname"); err == nil {
+		podname = strings.TrimSpace(string(dat))
+		if dat, err = ioutil.ReadFile("/etc/hosts"); err == nil {
+			for _, line := range strings.Split(strings.Trim(string(dat), " \t\r\n"), "\n") {
+				line = strings.Replace(strings.Trim(line, " \t"), "\t", " ", -1)
+				if len(line) == 0 || line[0] == ';' || line[0] == '#' {
+					continue
+				}
+				slices := strings.SplitN(line, " ", 2)
+				// log.WithFields(log.Fields{"slices": slices}).Debug()
+				if len(slices) > 1 && strings.Contains(slices[1], podname) {
+					ipaddress = slices[0]
+					break
+				}
+			}
+		}
+	}
+
+	if podname == "" && id == "" {
+		return nil, fmt.Errorf("failed: id=%v, pod=%v", id, podname)
+	}
+
+	log.WithFields(log.Fields{"selfID": id, "podName": podname, "ipaddress": ipaddress}).Debug()
+	return &stubRTDriver{sys: sys, sysInfo: sys.GetSystemInfo(), initTime: time.Now().UTC(),
+		rootPid: ppid, selfID: id, podName: podname, nodeHostname: podname, ipAddress: ipaddress}, nil
+}
+/////////
+func (d *stubRTDriver) GetSelfID() string {
+	return d.selfID
+}
+
+func (d *stubRTDriver) GetHost() (*share.CLUSHost, error) {
+	var host share.CLUSHost
+
+	host.Runtime = d.String()
+	host.RuntimeVer = "1.0"
+	host.RuntimeAPIVer = "1.0"
+
+	if d.sysInfo != nil {
+		host.Name = d.nodeHostname
+		host.ID = fmt.Sprintf("%s:%s", d.nodeHostname, d.sysInfo.Product.UUID)
+		host.OS = d.sysInfo.OS.Name
+		host.Kernel = d.sysInfo.Kernel.Release
+		host.CPUs = int64(d.sysInfo.CPU.Threads)
+		host.Memory = int64(d.sysInfo.Memory.Size) * 1024 * 1024
+	}
+
+	return &host, nil
+}
+
+func (d *stubRTDriver) GetDevice(id string) (*share.CLUSDevice, *ContainerMetaExtra, error) {
+	if id != d.selfID {
+		return &share.CLUSDevice{}, nil, nil
+	}
+
+	dev := &share.CLUSDevice{
+		ID:           d.selfID,
+		Name:         d.podName,
+		Labels:       make(map[string]string),
+		Pid:          d.rootPid,
+		CreatedAt:    d.initTime,
+		StartedAt:    d.initTime,
+	}
+
+	// Read address
+	ifaces := d.sys.GetGlobalAddrs(false)
+
+	dev.Ifaces = make(map[string][]share.CLUSIPAddr)
+	for name, addrs := range ifaces {
+		log.WithFields(log.Fields{"name": name, "addrs": addrs}).Debug()
+		dev.Ifaces[name] = make([]share.CLUSIPAddr, len(addrs))
+		for i, addr := range addrs {
+			dev.Ifaces[name][i] = share.CLUSIPAddr{
+				IPNet: addr,
+				Scope: share.CLUSIPAddrScopeLocalhost,
+			}
+		}
+	}
+
+	return dev, nil, nil
+}
+
+func (d *stubRTDriver) GetProxy() (string, string, string) {
+	return "", "", ""
+}
+
+func (d *stubRTDriver) ListNetworks() (map[string]*Network, error) {
+	return make(map[string]*Network), nil
+}

--- a/share/container/types.go
+++ b/share/container/types.go
@@ -209,7 +209,7 @@ func Connect(endpoint string, sys *system.SystemTools) (Runtime, error) {
 			return rt, nil
 		}
 
-		if isPidHost() {
+		if IsPidHost() {
 			if rtEndpoint, ok := obtainRtEndpointFromKubelet(sys); ok {
 				log.WithFields(log.Fields{"rtEndpoint": rtEndpoint}).Info()
 				edpt := filepath.Join("/proc/1/root", rtEndpoint)
@@ -401,7 +401,7 @@ func obtainRtEndpointFromKubelet(sys *system.SystemTools) (string, bool) {
 	return "", false
 }
 
-func isPidHost() bool {	// pid host, pid-1 is the Linux bootup process
+func IsPidHost() bool {	// pid host, pid-1 is the Linux bootup process
 	name, _ := os.Readlink("/proc/1/exe")
 	// nv containers: "monitor" is for the controller
 	return name != "/usr/local/bin/monitor"

--- a/share/global/global.go
+++ b/share/global/global.go
@@ -30,37 +30,34 @@ var ORCH *orchHub
 func SetGlobalObjects(rtSocket string, regResource RegisterDriverFunc) (string, string, string, []*container.ContainerMeta, error) {
 	var err error
 	var containers []*container.ContainerMeta
+	var platform, flavor, network string
 
 	SYS = system.NewSystemTools()
-
 	RT, err = container.Connect(rtSocket, SYS)
- 	if err != nil {
-		return "", "", "", nil, err
-	}
-
-	// List only at least one running containers: 3 tries
-	for i := 0; i < 3; i++ {
-		if containers, err = RT.ListContainers(true); err == nil && len(containers) > 0 {
-			break
+	if err == nil {
+		// List only at least one running containers: 3 tries
+		for i := 0; i < 3; i++ {
+			if containers, err = RT.ListContainers(true); err == nil && len(containers) > 0 {
+				break
+			}
+			time.Sleep(time.Millisecond * 50)
 		}
-		time.Sleep(time.Millisecond * 50)
-	}
+		if len(containers) == 0 {
+			return "", "", "", nil, ErrEmptyContainerList
+		}
+		platform, flavor, network = getPlatform(containers)
+	} else {
+		if container.IsPidHost() {
+			return "", "", "", nil, err
+		}
 
-	if len(containers) == 0 {
-		return "", "", "", nil, ErrEmptyContainerList
+		if RT, err = container.InitStubRtDriver(SYS); err != nil {
+			return "", "", "", nil, err
+		}
+		platform, flavor, network = getPlatformFromEnv()
 	}
-
-	platform, flavor, network := getPlatform(containers)
-	/*-- for testing --
-	if platform == share.PlatformKubernetes || flavor == share.FlavorOpenShift {
-		platform = ""
-		flavor = ""
-		log.Debug("=> for testing")
-	}
-	*/
 
 	k8sVer, ocVer := orchAPI.GetK8sVersion(true, true)
-
 	if platform == "" && k8sVer != "" {
 		platform = share.PlatformKubernetes
 	}
@@ -221,4 +218,13 @@ func (d *orchHub) SetFlavor(flavor string) error {
 	}
 
 	return nil
+}
+
+func getPlatformFromEnv() (string, string, string) {
+	network := share.NetworkDefault
+
+	// First decide the platform
+	envParser := utils.NewEnvironParser(os.Environ())
+	platform, flavor := normalize(envParser.GetPlatformName())
+	return platform, flavor, network
 }


### PR DESCRIPTION
(1) Add a virtual (stub) runtime driver to handle the standalone controller cases( NOT pid==host environment) if there is no mounted runtime socket. 
(2) No mounted runtime socket is required on the k8s environment.
(3) It is backward compatible if the mounted runtime engine socket is still assigned (the runtime driver is used).
(4) For native docker/swarm, the mounted runtime engine socket is applicable.
(5) Not affecting the allinone (pid==host).