### PR TITLE
NVSHAS-8464: Not to run controller in privileged mode in kubernetes

### DIFF
--- a/share/container/containerd.go
+++ b/share/container/containerd.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -106,13 +105,7 @@ func containerdConnect(endpoint string, sys *system.SystemTools) (Runtime, error
 	}
 
 	driver.rtProcMap = utils.NewSet("runc", "containerd", "containerd-shim", "containerd-shim-runc-v1", "containerd-shim-runc-v2")
-
-	name, _ := os.Readlink("/proc/1/exe")
-	if name == "/usr/local/bin/monitor" || strings.HasPrefix(name, "/usr/bin/python") { // when pid mode != host, 'pythohn' is for allinone
-		driver.pidHost = false
-	} else {
-		driver.pidHost = true
-	}
+	driver.pidHost = IsPidHost()
 	return &driver, nil
 }
 

--- a/share/container/crio.go
+++ b/share/container/crio.go
@@ -119,11 +119,8 @@ func crioConnect(endpoint string, sys *system.SystemTools) (Runtime, error) {
 		sysInfo: sys.GetSystemInfo(), nodeHostname: sys.GetHostname(1), daemonInfo: daemon, selfID: id,
 	}
 
-	name, _ := os.Readlink("/proc/1/exe")
-	if name == "/usr/local/bin/monitor" || strings.HasPrefix(name, "/usr/bin/python") { // when pid mode != host, 'pythohn' is for allinone
-		driver.pidHost = false
-	} else {
-		driver.pidHost = true
+	driver.pidHost = IsPidHost()
+	if driver.pidHost {
 		if repoDig, err := getPauseImageRepoDigests(); err != nil {
 			log.WithFields(log.Fields{"error": err}).Error("Fail to get pause image info")
 		} else {
@@ -132,7 +129,6 @@ func crioConnect(endpoint string, sys *system.SystemTools) (Runtime, error) {
 			log.WithFields(log.Fields{"repoDig": driver.podImgRepoDigest, "imgID": driver.podImgID, "imgDigest": driver.podImgDigest}).Debug("CRIO:")
 		}
 	}
-
 	return &driver, nil
 }
 

--- a/share/container/docker.go
+++ b/share/container/docker.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -104,13 +103,7 @@ func dockerConnect(endpoint string, sys *system.SystemTools) (Runtime, error) {
 		                   version: ver, info: info, selfID: id,}
 	driver.rtProcMap = utils.NewSet("runc", "docker-runc", "docker", "docker-runc-current",
 	         "docker-containerd-shim-current", "containerd-shim-runc-v1", "containerd-shim-runc-v2", "containerd", "containerd-shim")
-	name, _ := os.Readlink("/proc/1/exe")
-	if name == "/usr/local/bin/monitor" || strings.HasPrefix(name, "/usr/bin/python") { // when pid mode != host, 'pythohn' is for allinone
-		driver.pidHost = false
-	} else {
-		driver.pidHost = true
-	}
-
+	driver.pidHost = IsPidHost()
 	return &driver, nil
 }
 


### PR DESCRIPTION
Add a patch on the namespace function that failed with the empty node's name because there is no privileged mode of the controllers.