### PR TITLE
NVSHAS-7917: Deleting vulnerable "java package" files doesn't remove from vulnerability list

### DIFF
--- a/agent/probe/incident_reporter.go
+++ b/agent/probe/incident_reporter.go
@@ -348,3 +348,25 @@ func (p *Probe) sendReport(pmsga probeMsgAggregate) {
 		p.sendProbeReport(*pmsga.msg, pmsga.count-1, pmsga.startTime)
 	}
 }
+
+func (p *Probe) sendFsnJavaPkgReport(id string, files []string, bAdd bool) {
+	group, _, _ := p.getServiceGroupName(id)
+	fsMsg := fsmon.MonitorMessage {
+		ID:      id,
+		Path:    strings.Join(files, ", "),
+		Group:   group,
+		Package: true,
+		Msg:     fsPackageUpdate,
+		Action:  share.PolicyActionViolate,
+		StartAt: time.Now().UTC(),
+	}
+
+	if bAdd {	// inofrmative
+		fsMsg.Path += " (added)"
+	} else {
+		fsMsg.Path += " (removed)"
+	}
+
+	p.notifyFsTaskChan <- &fsMsg
+	log.WithFields(log.Fields{"report": fsMsg}).Debug("PROC:")
+}

--- a/agent/probe/probe.go
+++ b/agent/probe/probe.go
@@ -733,15 +733,11 @@ func (p *Probe) addContainerFAccessBlackList(id string, list []string) {
 	}
 }
 
-func (p *Probe) FsnExecFileChanged(id, file string, bNewFile bool, finfo fileInfo) {
-	if bNewFile {
-		if finfo.bExec {
-			mLog.WithFields(log.Fields{"file": file, "id": id, "finfo": finfo}).Debug("FSN: new file")
-		}
-	} else {
-		// TODO: file changed
-		if finfo.bExec {
-			mLog.WithFields(log.Fields{"file": file, "id": id, "finfo": finfo}).Debug("FSN: file changed")
+func (p *Probe) ProcessFsnEvent(id string, files []string, finfo fileInfo) {
+	if finfo.bExec || finfo.bJavaPkg {
+		mLog.WithFields(log.Fields{"id": id, "files": files, "finfo": finfo}).Debug("FSN:")
+		if finfo.bJavaPkg && (finfo.fileType == file_added || finfo.fileType == file_deleted) {
+			p.sendFsnJavaPkgReport(id, files, finfo.fileType == file_added)
 		}
 	}
 }

--- a/share/scan/apps.go
+++ b/share/scan/apps.go
@@ -114,7 +114,7 @@ func NewScanApps(v2 bool) *ScanApps {
 }
 
 func isAppsPkgFile(filename, fullpath string) bool {
-	if isNodejs(filename) || isJava(filename) || isPython(filename) ||
+	if isNodejs(filename) || IsJava(filename) || isPython(filename) ||
 		isRuby(filename) || isDotNet(filename) || isWordpress(filename) {
 		return true
 	}
@@ -160,7 +160,7 @@ func (s *ScanApps) extractAppPkg(filename, fullpath string) {
 
 	if isNodejs(filename) {
 		s.parseNodePackage(filename, fullpath)
-	} else if isJava(filename) {
+	} else if IsJava(filename) {
 		if r, err := zip.OpenReader(fullpath); err == nil {
 			s.parseJarPackage(r.Reader, filename, filename, fullpath, 0)
 			r.Close()
@@ -317,7 +317,7 @@ func isJavaJar(filename string) bool {
 	return strings.HasSuffix(filename, ".jar")
 }
 
-func isJava(filename string) bool {
+func IsJava(filename string) bool {
 	return strings.HasSuffix(filename, ".war") ||
 		strings.HasSuffix(filename, ".jar") ||
 		strings.HasSuffix(filename, ".ear")
@@ -342,7 +342,7 @@ func (s *ScanApps) parseJarPackage(r zip.Reader, tfile, filename, fullpath strin
 		if f.FileInfo().IsDir() {
 			continue
 		}
-		if depth+1 < jarMaxDepth && isJava(f.Name) {
+		if depth+1 < jarMaxDepth && IsJava(f.Name) {
 			// Parse jar file recursively
 			if jarFile, err := f.Open(); err == nil {
 				// Unzip the jar file to disk then walk through. Can we unzip on the fly?


### PR DESCRIPTION
Add package update incidents for the "java packages (jar, war, and ear)" file changes in a container. With the incidents, the controller would trigger a re-scan running container action if the "auto-scan" option is enabled.