### PR TITLE
NVSHAS-8334: Remote Repository Export

### DIFF
--- a/controller/access/access.go
+++ b/controller/access/access.go
@@ -772,6 +772,8 @@ func CompileUriPermitsMapping() {
 				"v1/system/license",
 				"v1/system/summary",
 				"v1/internal/system",
+				"v1/system/config/remote_repository",
+				"v1/system/config/remote_repository/*",
 			},
 			CONST_API_FED: []string{
 				"v1/fed/join_token",
@@ -869,6 +871,7 @@ func CompileUriPermitsMapping() {
 			CONST_API_SYSTEM_CONFIG: []string{
 				"v1/system/license/update",
 				"v1/system/config/webhook",
+				"v1/system/config/remote_repository",
 			},
 			CONST_API_IBMSA: []string{
 				"v1/partner/ibm_sa/*/setup/*",
@@ -958,6 +961,7 @@ func CompileUriPermitsMapping() {
 				"v1/system/config",
 				"v2/system/config",
 				"v1/system/config/webhook/*",
+				"v1/system/config/remote_repository/*",
 			},
 			CONST_API_FED: []string{
 				"v1/fed/cluster/*/**",
@@ -1020,6 +1024,7 @@ func CompileUriPermitsMapping() {
 			CONST_API_SYSTEM_CONFIG: []string{
 				"v1/system/license",
 				"v1/system/config/webhook/*",
+				"v1/system/config/remote_repository/*",
 			},
 			CONST_API_FED: []string{
 				"v1/fed/cluster/*",

--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -66,6 +66,7 @@ const RESTErrPasswordExpired int = 48
 const RESTErrPromoteFail int = 49
 const RESTErrPlatformAuthDisabled int = 50
 const RESTErrRancherUnauthorized int = 51
+const RESTErrRemoteExportFail int = 52
 
 const FilterPrefix string = "f_"
 const SortPrefix string = "s_"
@@ -519,27 +520,32 @@ type RESTListData struct {
 }
 
 type RESTGroupExport struct {
-	Groups     []string `json:"groups"`
-	PolicyMode string   `json:"policy_mode,omitempty"`
+	Groups              []string                  `json:"groups"`
+	PolicyMode          string                    `json:"policy_mode,omitempty"`
+	RemoteExportOptions *share.RemoteExportConfig `json:"remote_export_options,omitempty"`
 }
 
 type RESTAdmCtrlRulesExport struct {
-	ExportConfig bool     `json:"export_config"`
-	IDs          []uint32 `json:"ids"` // used when ExportRules is true
+	ExportConfig        bool                      `json:"export_config"`
+	IDs                 []uint32                  `json:"ids"` // used when ExportRules is true
+	RemoteExportOptions *share.RemoteExportConfig `json:"remote_export_options,omitempty"`
 }
 
 type RESTWafSensorExport struct {
-	Names []string `json:"names"`
+	Names               []string                  `json:"names"`
+	RemoteExportOptions *share.RemoteExportConfig `json:"remote_export_options,omitempty"`
 }
 
 // vlunerability profile export. only support "default" profile to export(5.3+)
 type RESTVulnProfilesExport struct {
-	Names []string `json:"names"`
+	Names               []string                  `json:"names"`
+	RemoteExportOptions *share.RemoteExportConfig `json:"remote_export_options,omitempty"`
 }
 
 // compliance profile export. only support "default" profile to export(5.3+)
 type RESTCompProfilesExport struct {
-	Names []string `json:"names"`
+	Names               []string                  `json:"names"`
+	RemoteExportOptions *share.RemoteExportConfig `json:"remote_export_options,omitempty"`
 }
 
 type RESTUser struct {
@@ -1876,6 +1882,7 @@ type RESTSystemConfig struct {
 	ScannerAutoscale          RESTSystemConfigAutoscale `json:"scanner_autoscale"`
 	NoTelemetryReport         bool                      `json:"no_telemetry_report"`
 	CspType                   string                    `json:"csp_type"`
+	RemoteRepositories        []share.RemoteRepository  `json:"remote_repositories"`
 }
 
 type RESTSystemConfigData struct {
@@ -2882,7 +2889,8 @@ type RESTCrdDlpGroupConfig struct {
 }
 
 type RESTDlpSensorExport struct {
-	Names []string `json:"names"`
+	Names               []string                  `json:"names"`
+	RemoteExportOptions *share.RemoteExportConfig `json:"remote_export_options,omitempty"`
 }
 
 type RESTDerivedWorkloadDlpRule struct {

--- a/controller/api/apis.yaml
+++ b/controller/api/apis.yaml
@@ -4514,6 +4514,69 @@ paths:
       responses:
         '200':
           description: Success
+  /v1/system/config/remote_repository:
+    post:
+      tags:
+        - Remote Repository
+      summary: Create a remote repository.
+      security:
+        - ApiKeyAuth: []
+        - TokenAuth: []
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Initial Configuration
+          required: true
+          schema:
+            $ref: '#/definitions/RemoteRepository'
+      responses:
+        '200':
+          description: Created the remote repository.
+  /v1/system/config/remote_repository/{alias}:
+    patch:
+      tags:
+        - Remote Repository
+      summary: Update a remote repository.
+      security:
+        - ApiKeyAuth: []
+        - TokenAuth: []
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: alias
+          description: The alias of the remote repository to update.
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: Configuration fields to update
+          required: true
+          schema:
+            $ref: '#/definitions/RemoteRepository'
+      responses:
+        '200':
+          description: Updated the remote repository.
+    delete:
+      tags:
+        - Remote Export Repository
+      summary: Delete a remote repository.
+      security:
+        - ApiKeyAuth: []
+        - TokenAuth: []
+      consumes:
+        - application/json
+      parameters:
+        - in: path
+          name: alias
+          description: The alias of the remote repository to update.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Deleted the remote repository.
 
 ################################################################################
 #                                 Security Definitions                         #
@@ -5072,6 +5135,8 @@ definitions:
           type: integer
           format: uint32
           example: 12
+      remote_export_options:
+        $ref: '#/definitions/RemoteExportOptions'
   RESTAdmCtrlTestRuleInfo:
     type: object
     required:
@@ -6113,6 +6178,8 @@ definitions:
         items:
           type: string
           example: ["default"]
+      remote_export_options:
+        $ref: '#/definitions/RemoteExportOptions'
   RESTController:
     type: object
     required:
@@ -6508,6 +6575,8 @@ definitions:
         items:
           type: string
         example: [""]
+      remote_export_options:
+        $ref: '#/definitions/RemoteExportOptions'
   RESTDlpSensorsData:
     type: object
     required:
@@ -7016,6 +7085,8 @@ definitions:
       policy_mode:
         type: string
         example: Monitor
+      remote_export_options:
+        $ref: '#/definitions/RemoteExportOptions'
   RESTHost:
     type: object
     required:
@@ -11593,6 +11664,8 @@ definitions:
         items:
           type: string
           example: ["default"]
+      remote_export_options:
+        $ref: '#/definitions/RemoteExportOptions'
   RESTVulnPackageVersion:
     type: object
     required:
@@ -11838,6 +11911,8 @@ definitions:
         items:
           type: string
           example: test4321546242574254672462572452615362453
+      remote_export_options:
+        $ref: '#/definitions/RemoteExportOptions'
   RESTWafSensorsData:
     type: object
     required:
@@ -13356,3 +13431,47 @@ definitions:
       comment:
         type: string
         example: example comment
+  RemoteRepository:
+    type: object
+    required:
+      - alias
+      - repository_owner_username
+      - repository_name
+      - repository_branch_name
+      - personal_access_token
+      - personal_access_token_committer_name
+      - personal_access_token_committer_email
+    properties:
+      alias:
+        type: string
+        example: default
+      repository_owner_username:
+        type: string
+        example: myuser
+      repository_name:
+        type: string
+        example: myrepo
+      repository_branch_name:
+        type: string
+        example: main
+      personal_access_token:
+        type: string
+        example: ghp_Agk4DedP5SOHGo8WxSuXCmCcldLyBP0I7CN6
+      personal_access_token_committer_name:
+        type: string
+        example: myuser
+      personal_access_token_committer_email:
+        type: string
+        example: myuser@example.com
+  RemoteExportOptions:
+    type: object
+    required:
+      - filepath
+      - remote_repository_nickname
+    properties:
+      filepath:
+        type: string
+        example: my_exports/example.yaml
+      remote_repository_nickname:
+        type: string
+        example: default

--- a/controller/cache/config.go
+++ b/controller/cache/config.go
@@ -287,6 +287,7 @@ func (m CacheMethod) GetSystemConfig(acc *access.AccessControl) *api.RESTSystemC
 		ModeAutoM2P:               systemConfigCache.ModeAutoM2P,
 		ModeAutoM2PDuration:       systemConfigCache.ModeAutoM2PDuration,
 		NoTelemetryReport:         systemConfigCache.NoTelemetryReport,
+		RemoteRepositories:        systemConfigCache.RemoteRepositories,
 	}
 	if systemConfigCache.SyslogIP != nil {
 		rconf.SyslogServer = systemConfigCache.SyslogIP.String()

--- a/controller/remote_repository/export.go
+++ b/controller/remote_repository/export.go
@@ -1,0 +1,83 @@
+package remote_repository
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/neuvector/neuvector/controller/access"
+	"github.com/neuvector/neuvector/controller/kv"
+	"github.com/neuvector/neuvector/share"
+	log "github.com/sirupsen/logrus"
+)
+
+type Export struct {
+	DefaultFilePath string
+	Options         *share.RemoteExportConfig
+	Content         []byte
+	ClusterHelper   kv.ClusterHelper
+	AccessControl   *access.AccessControl
+}
+
+func (exp *Export) Do() error {
+	log.Info("Initiating remote export.")
+
+	if exp.Options.RemoteRepositoryNickname == "" {
+		return errors.New("no remote repository nickname provided for remote export")
+	}
+
+	if exp.AccessControl == nil {
+		log.Error("no access control object set for export")
+		return errors.New("invalid internal configuration")
+	}
+
+	if exp.ClusterHelper == nil {
+		log.Error("no cluster helper field set for export")
+		return errors.New("invalid internal configuration")
+	}
+
+	lock, err := exp.ClusterHelper.AcquireLock(share.CLUSLockServerKey, (time.Second * 20))
+	if err != nil {
+		return fmt.Errorf("could not get clus lock for system config: %s", err.Error())
+	}
+
+	// remoteRepository, _, err := exp.ClusterHelper.GetRemoteRepository(exp.Options.RemoteRepositoryNickname)
+	systemConfig, _ := exp.ClusterHelper.GetSystemConfigRev(exp.AccessControl)
+	if systemConfig == nil {
+		return fmt.Errorf("could not retrieve remote export repository \"%s\" from clus, denied read access to system config", exp.Options.RemoteRepositoryNickname)
+	}
+
+	exp.ClusterHelper.ReleaseLock(lock)
+
+	var remoteRepository *share.RemoteRepository
+	for _, systemConfigRepo := range systemConfig.RemoteRepositories {
+		if exp.Options.RemoteRepositoryNickname == systemConfigRepo.Nickname {
+			remoteRepository = &systemConfigRepo
+		}
+	}
+	if remoteRepository == nil {
+		return fmt.Errorf("could not retrieve remote export repository \"%s\" from clus, does not exist", exp.Options.RemoteRepositoryNickname)
+	}
+
+	if *remoteRepository.Provider == share.RemoteRepositoryProvider_GitHub {
+		exportFilePath := exp.DefaultFilePath
+		if exp.Options.FilePath != "" {
+			exportFilePath = exp.Options.FilePath
+		}
+
+		githubExport, err := NewGitHubExport(exportFilePath, exp.Content, exportFilePath, remoteRepository.GitHubConfiguration)
+		if err != nil {
+			return fmt.Errorf("could not initialize github export object: %s", err.Error())
+		}
+
+		err = githubExport.Do()
+		if err != nil {
+			return fmt.Errorf("could not do github export: %s", err.Error())
+		}
+	} else {
+		return fmt.Errorf("unsupported provider for export: %s", *remoteRepository.Provider)
+	}
+
+	log.Info("Remote export successful.")
+	return nil
+}

--- a/controller/remote_repository/github.go
+++ b/controller/remote_repository/github.go
@@ -1,0 +1,195 @@
+package remote_repository
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/neuvector/neuvector/share"
+	"github.com/neuvector/neuvector/share/utils"
+)
+
+const githubApiVersion = "2022-11-28"
+const githubRepoContentUrl = "https://api.github.com/repos/%s/%s/contents/%s"
+
+const ErrGitHubRateLimitReached = "github rate limit reached"
+
+type gitHubAPI_Comitter struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+type gitHubAPI_PutRepoContent_RequestBody struct {
+	Message   string             `json:"message"`
+	Committer gitHubAPI_Comitter `json:"comitter"`
+	Content   string             `json:"content"`
+	SHA       string             `json:"sha"`
+}
+
+type gitHubAPI_GetRepoContent_ResponseBody struct {
+	Sha string `json:"sha"`
+}
+
+type githubRepo struct {
+	owner  string
+	name   string
+	branch string
+}
+
+type githubCommitter struct {
+	name                string
+	email               string
+	personalAccessToken string
+}
+
+type GitHubExport struct {
+	repo          githubRepo
+	committer     githubCommitter
+	commitMessage string
+	filePath      string
+	fileContents  []byte
+	url           *url.URL
+	Config        *share.RemoteRepository_GitHubConfiguration
+}
+
+func (exp GitHubExport) Do() error {
+	client := http.DefaultClient
+	request := exp.getBaseRequest()
+	request.Method = http.MethodPut
+
+	encodedFileContents := make([]byte, base64.StdEncoding.EncodedLen(len(exp.fileContents)))
+	base64.StdEncoding.Encode(encodedFileContents, []byte(exp.fileContents))
+
+	existingFileSha, err := exp.getExistingFileSha()
+	if err != nil {
+		return fmt.Errorf("could not retrieve sha for file at filepath %s: %s", exp.filePath, err.Error())
+	}
+
+	requestBody := gitHubAPI_PutRepoContent_RequestBody{
+		Message: exp.commitMessage,
+		Committer: gitHubAPI_Comitter{
+			Name:  exp.committer.name,
+			Email: exp.committer.email,
+		},
+		Content: string(encodedFileContents),
+		SHA:     existingFileSha,
+	}
+
+	requestBodyJSON, err := json.Marshal(requestBody)
+	if err != nil {
+		return fmt.Errorf("could not marshal request body into json: %s", err.Error())
+	}
+
+	request.Body = utils.NopCloser(bytes.NewReader(requestBodyJSON))
+
+	response, err := client.Do(&request)
+	if err != nil {
+		return fmt.Errorf("could not do request: %s", err.Error())
+	}
+
+	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusCreated {
+		if response.Header.Get("x-ratelimit-remaining") == "0" {
+			msg := ErrGitHubRateLimitReached
+			if limitResetDate := getRateLimitResetDate(response.Header.Get("x-ratelimit-reset")); limitResetDate != nil {
+				msg = fmt.Sprintf("%s, rate limit will reset at %s", msg, limitResetDate.String())
+			}
+			return errors.New(msg)
+		} else {
+			return fmt.Errorf("non-OK status response: %v", response)
+		}
+	}
+
+	return nil
+}
+
+func getRateLimitResetDate(rateLimitResetHeader string) *time.Time {
+	if rateLimitResetHeader == "" {
+		return nil
+	}
+	rateLimitEpoch, err := strconv.ParseInt(rateLimitResetHeader, 10, 64)
+	if err != nil {
+		return nil
+	}
+	rateLimitResetDate := time.Unix(rateLimitEpoch, 0)
+	return &rateLimitResetDate
+}
+
+func (exp GitHubExport) getExistingFileSha() (string, error) {
+	client := http.DefaultClient
+
+	req := exp.getBaseRequest()
+	req.Method = http.MethodGet
+
+	resp, err := client.Do(&req)
+	if err != nil {
+		return "", fmt.Errorf("could not do request: %s", err.Error())
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound {
+			return "", nil
+		}
+		return "", fmt.Errorf("could not retrieve file contents from github api, received status code \"%d\"", resp.StatusCode)
+	}
+
+	var body []byte
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading response body: %s", err.Error())
+	}
+
+	err = resp.Body.Close()
+	if err != nil {
+		return "", fmt.Errorf("error closing response body: %s", err.Error())
+	}
+
+	githubApiFile := &gitHubAPI_GetRepoContent_ResponseBody{}
+	err = json.Unmarshal(body, githubApiFile)
+	if err != nil {
+		return "", fmt.Errorf("error unmarshalling response json: %s", err.Error())
+	}
+
+	return githubApiFile.Sha, nil
+}
+
+func (exp GitHubExport) getBaseRequest() http.Request {
+	baseRequest := http.Request{
+		URL:    exp.url,
+		Header: http.Header{},
+	}
+	baseRequest.Header.Add("Accept", "application/vnd.github+json")
+	baseRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", exp.committer.personalAccessToken))
+	baseRequest.Header.Add("X-GitHub-Api-Version", githubApiVersion)
+	return baseRequest
+}
+
+func NewGitHubExport(filePath string, fileContents []byte, commitMessage string, config *share.RemoteRepository_GitHubConfiguration) (GitHubExport, error) {
+	exportUrl, err := url.Parse(fmt.Sprintf(githubRepoContentUrl, *config.RepositoryOwnerUsername, *config.RepositoryName, filePath))
+	if err != nil {
+		return GitHubExport{}, fmt.Errorf("could not parse url for new remote export object: %s", err.Error())
+	}
+
+	return GitHubExport{
+		repo: githubRepo{
+			owner:  *config.RepositoryOwnerUsername,
+			name:   *config.RepositoryName,
+			branch: *config.RepositoryBranchName,
+		},
+		committer: githubCommitter{
+			name:                *config.PersonalAccessTokenCommitterName,
+			email:               *config.PersonalAccessTokenEmail,
+			personalAccessToken: *config.PersonalAccessToken,
+		},
+		filePath:      filePath,
+		fileContents:  fileContents,
+		commitMessage: commitMessage,
+		url:           exportUrl,
+	}, nil
+}

--- a/controller/rest/admission.go
+++ b/controller/rest/admission.go
@@ -16,7 +16,6 @@ import (
 	cmetav1 "github.com/neuvector/k8s/apis/meta/v1"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
 
 	"github.com/neuvector/neuvector/controller/access"
 	"github.com/neuvector/neuvector/controller/api"
@@ -1449,16 +1448,7 @@ func handlerAdmCtrlExport(w http.ResponseWriter, r *http.Request, ps httprouter.
 		resp.Spec.Rules = admissionRules
 	}
 
-	// tell the browser the returned content should be downloaded
-	var data []byte
-	filename := "cfgAdmissionRulesExport.yaml"
-	w.Header().Set("Content-Disposition", "Attachment; filename="+filename)
-	w.Header().Set("Content-Encoding", "gzip")
-	w.WriteHeader(http.StatusOK)
-	json_data, _ := json.MarshalIndent(resp, "", "  ")
-	data, _ = yaml.JSONToYAML(json_data)
-	data = utils.GzipBytes(data)
-	w.Write(data)
+	doExport("cfgAdmissionRulesExport.yaml", rconf.RemoteExportOptions, resp, w, r, acc, login)
 }
 
 func handlerAdmCtrlImport(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {

--- a/controller/rest/compliance.go
+++ b/controller/rest/compliance.go
@@ -21,7 +21,6 @@ import (
 	scanUtils "github.com/neuvector/neuvector/share/scan"
 	"github.com/neuvector/neuvector/share/utils"
 	log "github.com/sirupsen/logrus"
-	"sigs.k8s.io/yaml"
 )
 
 func handlerComplianceList(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
@@ -502,16 +501,7 @@ func handlerCompProfileExport(w http.ResponseWriter, r *http.Request, ps httprou
 		vpNames.Add(name)
 	}
 
-	// tell the browser the returned content should be downloaded
-	var data []byte
-	filename := "cfgComplianceProfileExport.yaml"
-	w.Header().Set("Content-Disposition", "Attachment; filename="+filename)
-	w.Header().Set("Content-Encoding", "gzip")
-	w.WriteHeader(http.StatusOK)
-	json_data, _ := json.MarshalIndent(resp, "", "  ")
-	data, _ = yaml.JSONToYAML(json_data)
-	data = utils.GzipBytes(data)
-	w.Write(data)
+	doExport("cfgComplianceProfileExport.yaml", rconf.RemoteExportOptions, resp, w, r, acc, login)
 }
 
 func handlerCompProfileImport(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {

--- a/controller/rest/crdsecurityrule.go
+++ b/controller/rest/crdsecurityrule.go
@@ -35,7 +35,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spaolacci/murmur3"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	"sigs.k8s.io/yaml"
 )
 
 type nvCrdHandler struct {
@@ -3167,13 +3166,12 @@ func exportAttachRule(rule *api.RESTPolicyRule, useFrom bool, acc *access.Access
 func handlerGroupCfgExport(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	log.WithFields(log.Fields{"URL": r.URL.String()}).Debug()
 	defer r.Body.Close()
-	var data []byte
 	var inCount, eCount int
 	var group *api.RESTGroup
 	var skip bool
 
 	policy_ids := utils.NewSet()
-	acc, _ := getAccessControl(w, r, access.AccessOPRead) // handlerGroupCfgExport() is used for both GET/POST so we force the op to be AccessOPRead for access control
+	acc, login := getAccessControl(w, r, access.AccessOPRead) // handlerGroupCfgExport() is used for both GET/POST so we force the op to be AccessOPRead for access control
 	if acc == nil {
 		return
 	}
@@ -3189,7 +3187,6 @@ func handlerGroupCfgExport(w http.ResponseWriter, r *http.Request, ps httprouter
 	}
 
 	apiVersion := resource.NvSecurityRuleVersion
-	filename := "cfgExport.yaml"
 	resp := resource.NvSecurityRuleList{
 		Kind:       &resource.NvListKind,
 		ApiVersion: &apiVersion,
@@ -3296,14 +3293,7 @@ func handlerGroupCfgExport(w http.ResponseWriter, r *http.Request, ps httprouter
 	// for all the group in the From/To , if learned group we also need export it's policymode
 	// We don't know the default policy mode in other system so in current system just export
 
-	// tell the browser the returned content should be downloaded
-	w.Header().Set("Content-Disposition", "Attachment; filename="+filename)
-	w.Header().Set("Content-Encoding", "gzip")
-	w.WriteHeader(http.StatusOK)
-	json_data, _ := json.MarshalIndent(resp, "", "  ")
-	data, _ = yaml.JSONToYAML(json_data)
-	data = utils.GzipBytes(data)
-	w.Write(data)
+	doExport("cfgExport.yaml", rconf.RemoteExportOptions, resp, w, r, acc, login)
 }
 
 func (h *nvCrdHandler) crdDeleteRecord(kind, recordName string) {

--- a/controller/rest/dlp_rule.go
+++ b/controller/rest/dlp_rule.go
@@ -17,7 +17,6 @@ import (
 	"github.com/julienschmidt/httprouter"
 	cmetav1 "github.com/neuvector/k8s/apis/meta/v1"
 	log "github.com/sirupsen/logrus"
-	"sigs.k8s.io/yaml"
 
 	"github.com/neuvector/neuvector/controller/access"
 	"github.com/neuvector/neuvector/controller/api"
@@ -27,7 +26,6 @@ import (
 	"github.com/neuvector/neuvector/controller/rpc"
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/cluster"
-	"github.com/neuvector/neuvector/share/utils"
 )
 
 func handlerDlpSensorList(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
@@ -292,7 +290,7 @@ func wildCardToRegexp(pattern string) string {
 			if match[1] == '*' {
 				return string(match[0]) + ".*"
 			} else if match[1] == '?' {
-				/* If the pattern starts with 2 continuous "?" characters, convert them to ".*". 
+				/* If the pattern starts with 2 continuous "?" characters, convert them to ".*".
 				   Additionally, single "?" character will be converted to ".". */
 				if match[0] == '?' {
 					return ".*"
@@ -304,7 +302,7 @@ func wildCardToRegexp(pattern string) string {
 			}
 		} else {
 			/* If the pattern starts with multiple continuous "?" characters, convert them to ".*".
- 			   Additionally, convert multiple continuous "?" characters to ".*". */
+			   Additionally, convert multiple continuous "?" characters to ".*". */
 			if match[1] == '?' {
 				if match[0] == '?' {
 					return ".*"
@@ -1675,16 +1673,7 @@ func handlerDlpExport(w http.ResponseWriter, r *http.Request, ps httprouter.Para
 		resp.Items = append(resp.Items, &resptmp)
 	}
 
-	// tell the browser the returned content should be downloaded
-	var data []byte
-	filename := "cfgDlpExport.yaml"
-	w.Header().Set("Content-Disposition", "Attachment; filename="+filename)
-	w.Header().Set("Content-Encoding", "gzip")
-	w.WriteHeader(http.StatusOK)
-	json_data, _ := json.MarshalIndent(resp, "", "  ")
-	data, _ = yaml.JSONToYAML(json_data)
-	data = utils.GzipBytes(data)
-	w.Write(data)
+	doExport("cfgDlpExport.yaml", rconf.RemoteExportOptions, resp, w, r, acc, login)
 }
 
 func handlerDlpImport(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {

--- a/controller/rest/remote_repository.go
+++ b/controller/rest/remote_repository.go
@@ -1,0 +1,234 @@
+package rest
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/neuvector/neuvector/controller/api"
+	"github.com/neuvector/neuvector/share"
+	log "github.com/sirupsen/logrus"
+)
+
+func handlerRemoteRepositoryPost(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	log.WithFields(log.Fields{"URL": r.URL.String()}).Debug()
+	defer r.Body.Close()
+
+	acc, login := getAccessControl(w, r, "")
+	if acc == nil {
+		return
+	} else if !acc.Authorize(&share.RemoteRepository{}, nil) {
+		restRespAccessDenied(w, login)
+		return
+	}
+
+	body, _ := ioutil.ReadAll(r.Body)
+	var remoteRepository share.RemoteRepository
+	err := json.Unmarshal(body, &remoteRepository)
+	if err != nil {
+		msg := fmt.Sprintf("Could not unmarshal request body: %s", err.Error())
+		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, msg)
+		return
+	} else if !isObjectNameValid(remoteRepository.Nickname) {
+		e := "Invalid characters in nickname"
+		log.WithFields(log.Fields{"nickname": remoteRepository.Nickname}).Error(e)
+		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, e)
+		return
+	}
+
+	// in 5.3, only an alias of "default" is allowed
+	if remoteRepository.Nickname != "default" {
+		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, "only \"default\" alias is allowed")
+		return
+	}
+
+	lock, err := clusHelper.AcquireLock(share.CLUSLockServerKey, clusterLockWait)
+	if err != nil {
+		restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailLockCluster, err.Error())
+		return
+	}
+	defer clusHelper.ReleaseLock(lock)
+
+	systemConfig, rev := clusHelper.GetSystemConfigRev(acc)
+	if systemConfig == nil {
+		restRespAccessDenied(w, login)
+		return
+	}
+
+	for i := range systemConfig.RemoteRepositories {
+		if systemConfig.RemoteRepositories[i].Nickname == remoteRepository.Nickname {
+			log.WithFields(log.Fields{"alias": remoteRepository.Nickname}).Error("duplicate remote repository alias")
+			restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, "duplicate remote repository alias")
+			return
+		}
+	}
+
+	systemConfig.RemoteRepositories = append(systemConfig.RemoteRepositories, remoteRepository)
+	err = clusHelper.PutSystemConfigRev(systemConfig, rev)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err, "rev": rev}).Error("could not update system config")
+	}
+
+	restRespSuccess(w, r, nil, acc, login, &remoteRepository, "Create Remote Export Repository")
+}
+
+func handlerRemoteRepositoryDelete(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	log.WithFields(log.Fields{"URL": r.URL.String()}).Debug()
+	defer r.Body.Close()
+
+	acc, login := getAccessControl(w, r, "")
+	if acc == nil {
+		return
+	} else if !acc.Authorize(&share.RemoteRepository{}, nil) {
+		restRespAccessDenied(w, login)
+		return
+	}
+
+	lock, err := clusHelper.AcquireLock(share.CLUSLockServerKey, clusterLockWait)
+	if err != nil {
+		restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailLockCluster, err.Error())
+		return
+	}
+	defer clusHelper.ReleaseLock(lock)
+
+	systemConfig, rev := clusHelper.GetSystemConfigRev(acc)
+	if systemConfig == nil {
+		restRespAccessDenied(w, login)
+		return
+	}
+
+	var found bool
+	targetNickname := ps.ByName("nickname")
+	for i := range systemConfig.RemoteRepositories {
+		if systemConfig.RemoteRepositories[i].Nickname == targetNickname {
+			s := len(systemConfig.RemoteRepositories)
+			systemConfig.RemoteRepositories[i] = systemConfig.RemoteRepositories[s-1]
+			systemConfig.RemoteRepositories = systemConfig.RemoteRepositories[:s-1]
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		log.WithFields(log.Fields{"name": targetNickname}).Error("remote repository not found")
+		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, "remote repository not found")
+		return
+	}
+
+	err = clusHelper.PutSystemConfigRev(systemConfig, rev)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err, "rev": rev}).Error("could not update system config")
+		restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailWriteCluster, "could not delete remote repository")
+	}
+
+	msg := fmt.Sprintf("Deleted remote repository \"%s\"", targetNickname)
+	restRespSuccess(w, r, nil, acc, login, nil, msg)
+}
+
+func handlerRemoteRepositoryPatch(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	log.WithFields(log.Fields{"URL": r.URL.String()}).Debug()
+	defer r.Body.Close()
+
+	acc, login := getAccessControl(w, r, "")
+	if acc == nil {
+		return
+	} else if !acc.Authorize(&share.RemoteRepository{}, nil) {
+		restRespAccessDenied(w, login)
+		return
+	}
+
+	body, _ := ioutil.ReadAll(r.Body)
+	var remoteRepositoryUpdates share.RemoteRepository
+	err := json.Unmarshal(body, &remoteRepositoryUpdates)
+	if err != nil {
+		msg := fmt.Sprintf("Could not unmarshal request body: %s", err.Error())
+		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, msg)
+		return
+	}
+
+	lock, err := clusHelper.AcquireLock(share.CLUSLockServerKey, clusterLockWait)
+	if err != nil {
+		restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailLockCluster, err.Error())
+		return
+	}
+	defer clusHelper.ReleaseLock(lock)
+
+	systemConfig, rev := clusHelper.GetSystemConfigRev(acc)
+	if systemConfig == nil {
+		restRespAccessDenied(w, login)
+		return
+	}
+
+	var found bool
+	targetNickname := ps.ByName("nickname")
+	for i := range systemConfig.RemoteRepositories {
+		if systemConfig.RemoteRepositories[i].Nickname == targetNickname {
+			updatedRemoteRepository, err := getUpdatedRemoteRepository(systemConfig.RemoteRepositories[i], &remoteRepositoryUpdates)
+			if err != nil {
+				msg := fmt.Sprintf("could not update remote repository: %s", err.Error())
+				restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, msg)
+				return
+			}
+			systemConfig.RemoteRepositories[i] = updatedRemoteRepository
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		log.WithFields(log.Fields{"name": targetNickname}).Error("remote repository not found")
+		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, "remote repository not found")
+		return
+	}
+
+	err = clusHelper.PutSystemConfigRev(systemConfig, rev)
+	if err != nil {
+		msg := fmt.Sprintf("Could not save updated remote repository to kv store: %s", err.Error())
+		log.WithFields(log.Fields{"rev": rev}).Error(msg)
+		restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailWriteCluster, msg)
+		return
+	}
+
+	msg := fmt.Sprintf("Updated remote repository \"%s\"", targetNickname)
+	restRespSuccess(w, r, nil, acc, login, &remoteRepositoryUpdates, msg)
+}
+
+// TODO: turn this into a generic function that is directed via struct tags
+func getUpdatedRemoteRepository(base share.RemoteRepository, updates *share.RemoteRepository) (share.RemoteRepository, error) {
+	isSet := func(s *string) bool {
+		return s != nil && *s != ""
+	}
+
+	if updates.Provider != nil {
+		base.Provider = updates.Provider
+	}
+
+	if *base.Provider == share.RemoteRepositoryProvider_GitHub {
+		if isSet(updates.GitHubConfiguration.RepositoryOwnerUsername) {
+			base.GitHubConfiguration.RepositoryOwnerUsername = updates.GitHubConfiguration.RepositoryOwnerUsername
+		}
+		if isSet(updates.GitHubConfiguration.RepositoryName) {
+			base.GitHubConfiguration.RepositoryName = updates.GitHubConfiguration.RepositoryName
+		}
+		if isSet(updates.GitHubConfiguration.RepositoryBranchName) {
+			base.GitHubConfiguration.RepositoryBranchName = updates.GitHubConfiguration.RepositoryBranchName
+		}
+		if isSet(updates.GitHubConfiguration.PersonalAccessToken) {
+			base.GitHubConfiguration.PersonalAccessToken = updates.GitHubConfiguration.PersonalAccessToken
+		}
+		if isSet(updates.GitHubConfiguration.PersonalAccessTokenCommitterName) {
+			base.GitHubConfiguration.PersonalAccessTokenCommitterName = updates.GitHubConfiguration.PersonalAccessTokenCommitterName
+		}
+		if isSet(updates.GitHubConfiguration.PersonalAccessTokenEmail) {
+			base.GitHubConfiguration.PersonalAccessTokenEmail = updates.GitHubConfiguration.PersonalAccessTokenEmail
+		}
+	}
+
+	if !base.IsValid() {
+		return share.RemoteRepository{}, errors.New("updates result in invalid object")
+	}
+	return base, nil
+}

--- a/controller/rest/rest.go
+++ b/controller/rest/rest.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"github.com/hashicorp/go-version"
 	"github.com/julienschmidt/httprouter"
@@ -37,6 +38,7 @@ import (
 	"github.com/neuvector/neuvector/controller/cache"
 	"github.com/neuvector/neuvector/controller/common"
 	"github.com/neuvector/neuvector/controller/kv"
+	"github.com/neuvector/neuvector/controller/remote_repository"
 	"github.com/neuvector/neuvector/controller/scan"
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/auth"
@@ -1759,6 +1761,11 @@ func StartRESTServer() {
 	r.DELETE("/v1/api_key/:name", handlerApikeyDelete)
 	r.GET("/v1/selfapikey", handlerSelfApikeyShow) // Skip API document
 
+	// remote export repository
+	r.POST("/v1/system/config/remote_repository", handlerRemoteRepositoryPost)
+	r.PATCH("/v1/system/config/remote_repository/:nickname", handlerRemoteRepositoryPatch)
+	r.DELETE("/v1/system/config/remote_repository/:nickname", handlerRemoteRepositoryDelete)
+
 	// csp billing adapter integration
 	r.POST("/v1/csp/file/support", handlerCspSupportExport) // Skip API document. For downloading the tar ball that can be submitted to support portal
 
@@ -2015,4 +2022,38 @@ func StartStopFedPingPoll(cmd, interval uint32, param1 interface{}) error {
 	}
 
 	return err
+}
+
+func doExport(filename string, remoteExportOptions *share.RemoteExportConfig, resp interface{}, w http.ResponseWriter, r *http.Request, acc *access.AccessControl, login *loginSession) {
+	var data []byte
+	json_data, _ := json.MarshalIndent(resp, "", "  ")
+	data, _ = yaml.JSONToYAML(json_data)
+
+	if remoteExportOptions != nil {
+		remoteExport := remote_repository.Export{
+			DefaultFilePath: filename,
+			Options:         remoteExportOptions,
+			Content:         data,
+			ClusterHelper:   clusHelper,
+			AccessControl:   acc,
+		}
+		err := remoteExport.Do()
+		if err != nil {
+			msg := "could not do remote export"
+			if strings.Contains(err.Error(), remote_repository.ErrGitHubRateLimitReached) {
+				msg = fmt.Sprintf("%s, %s", msg, err.Error())
+			}
+			restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrRemoteExportFail, msg)
+			log.WithFields(log.Fields{"error": err}).Error("could not do remote export")
+			return
+		}
+		restRespSuccess(w, r, nil, acc, login, nil, "Do remote dlp export")
+	} else {
+		// tell the browser the returned content should be downloaded
+		w.Header().Set("Content-Disposition", "Attachment; filename="+filename)
+		w.Header().Set("Content-Encoding", "gzip")
+		data = utils.GzipBytes(data)
+		w.WriteHeader(http.StatusOK)
+		w.Write(data)
+	}
 }

--- a/controller/rest/vulnerability.go
+++ b/controller/rest/vulnerability.go
@@ -23,7 +23,6 @@ import (
 	"github.com/neuvector/neuvector/share/cluster"
 	"github.com/neuvector/neuvector/share/utils"
 	log "github.com/sirupsen/logrus"
-	"sigs.k8s.io/yaml"
 )
 
 var reservedVulProfEntryNames utils.Set = utils.NewSet(api.VulnerabilityNameRecent, api.VulnerabilityNameRecentWithoutFix)
@@ -749,16 +748,7 @@ func handlerVulnProfileExport(w http.ResponseWriter, r *http.Request, ps httprou
 		vpNames.Add(name)
 	}
 
-	// tell the browser the returned content should be downloaded
-	var data []byte
-	filename := "cfgVulProfileExport.yaml"
-	w.Header().Set("Content-Disposition", "Attachment; filename="+filename)
-	w.Header().Set("Content-Encoding", "gzip")
-	w.WriteHeader(http.StatusOK)
-	json_data, _ := json.MarshalIndent(resp, "", "  ")
-	data, _ = yaml.JSONToYAML(json_data)
-	data = utils.GzipBytes(data)
-	w.Write(data)
+	doExport("cfgVulProfileExport.yaml", rconf.RemoteExportOptions, resp, w, r, acc, login)
 }
 
 func handlerVulnProfileImport(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {

--- a/controller/rest/waf_rule.go
+++ b/controller/rest/waf_rule.go
@@ -17,7 +17,6 @@ import (
 	"github.com/julienschmidt/httprouter"
 	cmetav1 "github.com/neuvector/k8s/apis/meta/v1"
 	log "github.com/sirupsen/logrus"
-	"sigs.k8s.io/yaml"
 
 	"github.com/neuvector/neuvector/controller/access"
 	"github.com/neuvector/neuvector/controller/api"
@@ -26,7 +25,6 @@ import (
 	"github.com/neuvector/neuvector/controller/resource"
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/cluster"
-	"github.com/neuvector/neuvector/share/utils"
 )
 
 func handlerWafSensorList(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
@@ -1109,16 +1107,7 @@ func handlerWafExport(w http.ResponseWriter, r *http.Request, ps httprouter.Para
 		resp.Items = append(resp.Items, &resptmp)
 	}
 
-	// tell the browser the returned content should be downloaded
-	var data []byte
-	filename := "cfgWafExport.yaml"
-	w.Header().Set("Content-Disposition", "Attachment; filename="+filename)
-	w.Header().Set("Content-Encoding", "gzip")
-	w.WriteHeader(http.StatusOK)
-	json_data, _ := json.MarshalIndent(resp, "", "  ")
-	data, _ = yaml.JSONToYAML(json_data)
-	data = utils.GzipBytes(data)
-	w.Write(data)
+	doExport("cfgWafExport.yaml", rconf.RemoteExportOptions, resp, w, r, acc, login)
 }
 
 func handlerWafImport(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {

--- a/share/utils/nopcloser.go
+++ b/share/utils/nopcloser.go
@@ -1,0 +1,15 @@
+package utils
+
+import "io"
+
+// NopCloser returns a ReadCloser with a no-op Close method wrapping
+// the provided Reader r.
+func NopCloser(r io.Reader) io.ReadCloser {
+	return nopCloser{r}
+}
+
+type nopCloser struct {
+	io.Reader
+}
+
+func (nopCloser) Close() error { return nil }


### PR DESCRIPTION
These changes implement NVSHAS-8334 so that a user may export their CRD files directly to a configured remote repository. Currently GitHub is the only supported provider.

The export implementation is found in `controller/remote_repository/`.