### PR TITLE
NVSHAS-8502 authentication token missing

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -534,10 +534,8 @@ func main() {
 
 	// Initialize installation ID.  Ignore if ID is already set.
 	clusHelper := kv.GetClusterHelper()
-	if id, err := clusHelper.GetInstallationID(); err != nil {
+	if _, err := clusHelper.GetInstallationID(); err != nil {
 		log.WithError(err).Warn("installation id is not readable. Will retry later.")
-	} else {
-		log.WithField("installation-id", id).Info("Installation id is created")
 	}
 
 	if Ctrler.Leader {

--- a/controller/rest/auth.go
+++ b/controller/rest/auth.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -13,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/julienschmidt/httprouter"
@@ -165,14 +166,6 @@ func GetJWTSigningKey() JWTCertificateState {
 	jwtKeyMutex.RLock()
 	defer jwtKeyMutex.RUnlock()
 	return jwtCertState
-}
-
-func GetInstallationID() string {
-	if installID == nil {
-		id, _ := clusHelper.GetInstallationID()
-		installID = &id
-	}
-	return *installID
 }
 
 // With userMutex locked when calling this because it does loginSession lookup first
@@ -707,7 +700,11 @@ func restReq2User(r *http.Request) (*loginSession, int, string) {
 	if !ok {
 		if claims.MainSessionID == "" || strings.HasPrefix(claims.MainSessionID, _rancherSessionPrefix) { // meaning it's not a master token issued by master cluster
 			// Check if the token is from the same "installation"
-			installID := GetInstallationID()
+			installID, err := clusHelper.GetInstallationID()
+			if err != nil {
+				log.WithError(err).Error("failed to get installation ID")
+				return nil, userTimeout, rsessToken
+			}
 			if installID != claims.Subject {
 				log.Debug("Token from different installation")
 				return nil, userTimeout, rsessToken
@@ -1231,7 +1228,11 @@ func jwtValidateToken(encryptedToken, secret string, rsaPublicKey *rsa.PublicKey
 	var alternativeKey *rsa.PublicKey
 
 	jwtCert := GetJWTSigningKey()
-	installID := GetInstallationID()
+	installID, err := clusHelper.GetInstallationID()
+	if err != nil {
+		log.WithError(err).Error("failed to get installation ID")
+		return nil, errors.Wrap(err, "failed to get installation ID")
+	}
 
 	if secret == "" {
 		tokenString = utils.DecryptUserToken(encryptedToken, []byte(installID))
@@ -1329,7 +1330,11 @@ func jwtValidateFedJoinTicket(encryptedTicket, secret string) error {
 
 func jwtGenerateToken(user *share.CLUSUser, roles access.DomainRole, remote, mainSessionID, mainSessionUser string, sso *SsoSession) (string, string, *tokenClaim) {
 	id := utils.GetRandomID(idLength, "")
-	installID := GetInstallationID()
+	installID, err := clusHelper.GetInstallationID()
+	if err != nil {
+		log.WithError(err).Error("failed to get installation ID")
+		return "", "", &tokenClaim{}
+	}
 	now := time.Now()
 	c := tokenClaim{
 		Remote:          remote,

--- a/share/cluster/consul.go
+++ b/share/cluster/consul.go
@@ -1205,7 +1205,7 @@ func compareStoreKeys(cache map[string]uint64, kvs api.KVPairs) []string {
 	}
 
 	var ret []string
-	for key, _ := range cache {
+	for key := range cache {
 		if _, ok := m[key]; ok {
 			continue
 		}
@@ -1334,7 +1334,7 @@ func (m *consulMethod) RegisterExistingWatchers() {
 		go registerNodeUpdate()
 	}
 	keyWatcherMutex.RLock()
-	for key, _ := range keyWatchers {
+	for key := range keyWatchers {
 		go registerKeyUpdate(key)
 	}
 	keyWatcherMutex.RUnlock()
@@ -1342,7 +1342,7 @@ func (m *consulMethod) RegisterExistingWatchers() {
 		go registerStateUpdate()
 	}
 	storeWatcherMutex.RLock()
-	for store, _ := range storeWatchers {
+	for store := range storeWatchers {
 		go registerStoreUpdate(store, storeWatchersCongestCtl[store])
 	}
 	storeWatcherMutex.RUnlock()


### PR DESCRIPTION
This PR fixes https://github.com/neuvector/neuvector/issues/1118 and NVSHAS-8502.

## Finding

Some users reported that after upgrade to 5.2.4 or 5.2.2-s1, they become unable to login NV console and receive empty authentication token from /auth API.
After checking consul kv, `/state/installation` is empty.

```
/ # consul kv get /state/installation
Error! No key exists at: state/installation
```

The ID is written in this line: 
https://github.com/neuvector/neuvector/blob/14751a0283320206642992c8e92283615e25b05b/controller/controller.go#L553C14-L553C31

However, no error is handled around that line.

After reviewing codes, a few possible causes were come up with:

1. The installation ID is not correctly initialized during fresh install.
2. No recovery mechanism

### The installation ID is not correctly initialized during fresh install.

#### ERROR: leader is lost

1. During fresh install, multiple controllers start at the same time.  If there is a leader change during this process, since all write operations in consul are strongly consistent, write operations happening during this period will fail with "leadership lost while committing log" or similar error. It's possible that the writing operation suffered from this issue and failed silently.

![image](https://github.com/neuvector/neuvector/assets/11805094/d8bc51dc-269a-483c-862c-cd71d7fd2915)


#### ERROR: Two nodes are in bootstrap mode

2. In the experiment, below error is also noticed in my cluster, which implies a possible race condition regarding `--bootstrap` flag on consul, which can lead to split-brain and data inconsistency.

```
2023-12-01T18:18:07.532Z [ERROR] agent.server: Two nodes are in bootstrap mode. Only one node should be in bootstrap mode, not adding Raft peer.: node_to_add=10.233.88.88 other=10.233.88.85
```

### No recovery mechanism

1. In the current code, installation ID will NOT be re-created during start up because the check ([if Ctrler.Leader](https://github.com/neuvector/neuvector/blob/main/controller/controller.go#L534)) will never be true in rolling update.  

## Solution

1. A retry/synchronization mechanism is added, so data can be written into consul kv in the very beginning. 

2. In addition to the existing cache mechanism in REST API, a TTL is added to the logic, so if empty installation ID or data inconsistency happens, it can recover automatically after the cache expires.

## Testing

In addition to sanity test, two scenarios are covered:
1. Change `/state/installation` to empty manually.  After upgrade, the ID is recovered successfully.
2. Create split-brain scenario using a special build that `isBootstrap()` always return true.  After upgrade to PR build, all nodes are joined together.  The installation ID is inconsistent in the beginning but it gets corrected automatically when its initial cache expires.