### PR TITLE
[NVSHAS-8474] Resolve the symbolic link files under proc's root path

### DIFF
--- a/share/osutil/file_linux.go
+++ b/share/osutil/file_linux.go
@@ -150,7 +150,11 @@ func GetContainerRealFilePath(pid int, symlinkPath string, inTest bool) (string,
 				if os.IsNotExist(err) {
 					log.WithError(err).Error("File not exist")
 					return "", err
+				} else if os.IsPermission(err) {
+					log.WithError(err).Error("Permission error accessing file")
+					return "", err
 				} else {
+					// Others we assume such file exist
 					return resolvedPath, nil 
 				}
 			}

--- a/share/osutil/file_linux.go
+++ b/share/osutil/file_linux.go
@@ -2,14 +2,14 @@ package osutil
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
-	"errors"
 	"regexp"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 
@@ -44,26 +44,25 @@ type FileInfoExt struct {
 	UserAdded   bool
 }
 
-
 func fileExists(path string) bool {
-    _, err := os.Lstat(path)
-    if err == nil {
-        // No error, file exists and is accessible
-        return true
-    }
+	_, err := os.Lstat(path)
+	if err == nil {
+		// No error, file exists and is accessible
+		return true
+	}
 
-    if errors.Is(err, os.ErrNotExist) {
-        return false
-    }
+	if errors.Is(err, os.ErrNotExist) {
+		return false
+	}
 
-    if os.IsPermission(err) {
+	if os.IsPermission(err) {
 		log.WithError(err).Error("Permission error accessing file")
-        return false
-    }
+		return false
+	}
 
-    // Other types of errors
+	// Other types of errors
 	log.WithError(err).Error("")
-    return false
+	return false
 }
 
 func extractProcRootPath(pid int, input string, inTest bool) (string, error) {
@@ -83,7 +82,7 @@ func extractProcRootPath(pid int, input string, inTest bool) (string, error) {
 	}
 }
 
-// GetContainerRealFilePath resolves the real file path of a container file from a given symlink. 
+// GetContainerRealFilePath resolves the real file path of a container file from a given symlink.
 // It handles nested symlinks and detects circular references to prevent infinite loops.
 // Input: pid (process id), symlinkPath (path of the symlink)
 // Output: real file path (string) or an error if the resolution fails.
@@ -104,8 +103,8 @@ func GetContainerRealFilePath(pid int, symlinkPath string, inTest bool) (string,
 		underProcRoot = false
 
 		if _, exists := visitedSymlink[currentPath]; exists {
-            return "", fmt.Errorf("Error: Circular symlink detected. The symlink structure creates a loop and cannot be resolved.")
-        }
+			return "", fmt.Errorf("Error: Circular symlink detected. The symlink structure creates a loop and cannot be resolved.")
+		}
 
 		if !fileExists(currentPath) {
 			log.WithError(err).Error("File not exist")
@@ -121,7 +120,7 @@ func GetContainerRealFilePath(pid int, symlinkPath string, inTest bool) (string,
 			log.WithError(err).Error("Get Proc Root Path fail")
 			return "", err
 		}
-		
+
 		// if absolute symlink, we will join with procroot directly.
 		if filepath.IsAbs(symlink) {
 			underProcRoot = true

--- a/share/osutil/file_linux_test.go
+++ b/share/osutil/file_linux_test.go
@@ -1,0 +1,460 @@
+package osutil
+
+import (
+	"os"
+	"testing"
+	"path/filepath"
+	"io/ioutil"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type MockFile struct {
+	Pid 		  int
+	SymlinkFile   string
+	Symlink 	  string
+	Exist  		  bool
+	ResolvePath   string
+	ExpectResult  string
+}
+
+func PrepareCircularLayerSymlink(root string) []MockFile {
+	return []MockFile{
+		// length 1 cycle 
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C1P1"),
+			Symlink:      "../bin/C1P1",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Error: Circular symlink detected. The symlink structure creates a loop and cannot be resolved.",
+		},
+
+		// length 2 cycle 
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C2P1"),
+			Symlink:      "../bin/C2P2",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Error: Circular symlink detected. The symlink structure creates a loop and cannot be resolved.",
+		},
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C2P2"),
+			Symlink:      "./../bin/C2P1",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Error: Circular symlink detected. The symlink structure creates a loop and cannot be resolved.",
+		},
+
+		// length 3 cycle
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C3P1"),
+			Symlink:      "../bin/C3P2",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Error: Circular symlink detected. The symlink structure creates a loop and cannot be resolved.",
+		},
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C3P2"),
+			Symlink:      "./../bin/C3P3",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Error: Circular symlink detected. The symlink structure creates a loop and cannot be resolved.",
+		},
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C3P3"),
+			Symlink:      "../bin/C3P1",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Error: Circular symlink detected. The symlink structure creates a loop and cannot be resolved.",
+		},
+
+		// length 4 cycle => fit the rule
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C4P1"),
+			Symlink:      "../bin/C4P2",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Error: Circular symlink detected. The symlink structure creates a loop and cannot be resolved.",
+		},
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C4P2"),
+			Symlink:      "./../bin/C4P3",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Error: Circular symlink detected. The symlink structure creates a loop and cannot be resolved.",
+		},
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C4P3"),
+			Symlink:      "../bin/C4P4",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Error: Circular symlink detected. The symlink structure creates a loop and cannot be resolved.",
+		},		
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C4P4"),
+			Symlink:      "../bin/C4P1",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Error: Circular symlink detected. The symlink structure creates a loop and cannot be resolved.",
+		},
+
+		// length 5 cycle => break the rule
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C5P1"),
+			Symlink:      "../bin/C4P1",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Get file symlink fail",
+		},
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C5P2"),
+			Symlink:      "./../bin/C5P3",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Get file symlink fail",
+		},
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C5P3"),
+			Symlink:      "../bin/C5P4",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Get file symlink fail",
+		},		
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C5P4"),
+			Symlink:      "../bin/C5P5",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Get file symlink fail",
+		},
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C5P5"),
+			Symlink:      "./../bin/C5P1",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Get file symlink fail",
+		},
+
+		// length 6 cycle => break the rule
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C6P1"),
+			Symlink:      "../bin/C6P2",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Get file symlink fail",
+		},
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C6P2"),
+			Symlink:      "./../bin/C6P3",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Get file symlink fail",
+		},
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C6P3"),
+			Symlink:      "../bin/C6P4",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Get file symlink fail",
+		},
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C6P4"),
+			Symlink:      "../bin/C6P5",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Get file symlink fail",
+		},
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C6P5"),
+			Symlink:      "./../bin/C6P6",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Get file symlink fail",
+		},
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C6P6"),
+			Symlink:      "../bin/C6P1",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Get file symlink fail",
+		},
+
+		// random access to one of the cycle, say cycle with length 2
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","CRP1"),
+			Symlink:      "../bin/C2P1",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Error: Circular symlink detected. The symlink structure creates a loop and cannot be resolved.",
+		},
+	}
+}
+
+func PrepareNestLayerSymlink(root string) []MockFile {
+	return []MockFile{
+		// one layer 
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","rpmNest"),
+			Symlink:      "../bin/rpmverify",
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "1", "root", "bin","rpm"),
+			ExpectResult: "",
+		},
+		{
+			Pid:          2,
+			SymlinkFile:  filepath.Join(root, "proc", "2", "root", "bin","rpmNest"),
+			Symlink:      "./../bin/rpmverify",
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "2", "root", "bin","rpm"),
+			ExpectResult: "",
+		},
+		{
+			Pid:          3,
+			SymlinkFile:  filepath.Join(root, "proc", "3", "root", "bin","rpmNest"),
+			Symlink:      "../../bin/rpmverify",
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "3", "root", "bin","rpm"),
+			ExpectResult: "",
+		},
+		{
+			Pid:          4,
+			SymlinkFile:  filepath.Join(root, "proc", "4", "root", "bin","rpmNest"),
+			Symlink:      "../../../bin/rpmverify",
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "4", "root", "bin","rpm"),
+			ExpectResult: "",
+		},
+		{
+			Pid:          5,
+			SymlinkFile:  filepath.Join(root, "proc", "5", "root", "bin","rpmNest"),
+			Symlink:      "./../../../bin/rpmverify",
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "5", "root", "bin","rpm"),
+			ExpectResult: "",
+		},
+		{
+			Pid:          6,
+			SymlinkFile:  filepath.Join(root, "proc", "6", "root", "bin","rpmNest"),
+			Symlink:      "../../bin/notExist",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Get file symlink fail",
+		},
+		{
+			Pid:          7,
+			SymlinkFile:  filepath.Join(root, "proc", "7", "root", "bin","rpmNest"),
+			Symlink:      "../../bin/rpmquery",
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "bin", "pwd"),
+			ExpectResult: "Get file symlink fail",
+		},
+
+		// two layer 
+		{
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","rpmNest1"),
+			Symlink:      "../bin/rpmNest",
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "1", "root", "bin","rpm"),
+			ExpectResult: "",
+		},
+		{
+			Pid:          2,
+			SymlinkFile:  filepath.Join(root, "proc", "2", "root", "bin","rpmNest1"),
+			Symlink:      "./../bin/rpmNest",
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "2", "root", "bin","rpm"),
+			ExpectResult: "",
+		},
+		{
+			Pid:          3,
+			SymlinkFile:  filepath.Join(root, "proc", "3", "root", "bin","rpmNest1"),
+			Symlink:      "../../bin/rpmNest",
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "3", "root", "bin","rpm"),
+			ExpectResult: "",
+		},
+		{
+			Pid:          4,
+			SymlinkFile:  filepath.Join(root, "proc", "4", "root", "bin","rpmNest1"),
+			Symlink:      "../../../bin/rpmNest",
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "4", "root", "bin","rpm"),
+			ExpectResult: "",
+		},
+		{
+			Pid:          5,
+			SymlinkFile:  filepath.Join(root, "proc", "5", "root", "bin","rpmNest1"),
+			Symlink:      "./../../../bin/rpmNest",
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "5", "root", "bin","rpm"),
+			ExpectResult: "",
+		},
+		{
+			Pid:          6,
+			SymlinkFile:  filepath.Join(root, "proc", "6", "root", "bin","rpmNest1"),
+			Symlink:      "../../bin/rpmNest",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "Get file symlink fail",
+		},
+		{
+			Pid:          7,
+			SymlinkFile:  filepath.Join(root, "proc", "7", "root", "bin","rpmNest1"),
+			Symlink:      "../../bin/rpmNest",
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "bin", "pwd"),
+			ExpectResult: "Get file symlink fail",
+		},
+	}
+}
+
+func PrepareSingleLayerSymlink(root string) []MockFile {
+    return []MockFile{
+        {
+            Pid:          1,
+            SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","rpmverify"),
+            Symlink:      "../bin/rpm",
+            Exist:        true,
+            ResolvePath:  filepath.Join(root, "proc", "1", "root", "bin","rpm"),
+            ExpectResult: "",
+        },
+        {
+            Pid:          2,
+            SymlinkFile:  filepath.Join(root, "proc", "2", "root", "bin","rpmverify"),
+            Symlink:      "./../bin/rpm",
+            Exist:        true,
+            ResolvePath:  filepath.Join(root, "proc", "2", "root", "bin","rpm"),
+            ExpectResult: "",
+        },
+        {
+            Pid:          3,
+            SymlinkFile:  filepath.Join(root, "proc", "3", "root", "bin","rpmverify"),
+            Symlink:      "../../bin/rpm",
+            Exist:        true,
+            ResolvePath:  filepath.Join(root, "proc", "3", "root", "bin","rpm"),
+            ExpectResult: "",
+        },
+		{
+            Pid:          4,
+            SymlinkFile:  filepath.Join(root, "proc", "4", "root", "bin","rpmverify"),
+            Symlink:      "../../../bin/rpm",
+            Exist:        true,
+            ResolvePath:  filepath.Join(root, "proc", "4", "root", "bin","rpm"),
+            ExpectResult: "",
+        },
+		{
+            Pid:          5,
+            SymlinkFile:  filepath.Join(root, "proc", "5", "root", "bin","rpmverify"),
+            Symlink:      "./../../../bin/rpm",
+            Exist:        true,
+            ResolvePath:  filepath.Join(root, "proc", "5", "root", "bin","rpm"),
+            ExpectResult: "",
+        },
+        {
+            Pid:          6,
+            SymlinkFile:  filepath.Join(root, "proc", "6", "root", "bin","notExist"),
+            Symlink:      "../../bin/rpm",
+            Exist:        false,
+            ResolvePath:  "",
+            ExpectResult: "Get file symlink fail",
+        },
+        {
+            Pid:          7,
+            SymlinkFile:  filepath.Join(root, "proc", "7", "root", "bin","rpmquery"),
+            Symlink:      filepath.Join(root, "bin", "pwd"),
+            Exist:        true,
+            ResolvePath:  filepath.Join(root, "bin", "pwd"),
+            ExpectResult: "Get file symlink fail",
+        },
+	}
+}
+
+func PrepareMockFilesMetaData(root string) []MockFile {
+	mockFilesMetaData := append(PrepareSingleLayerSymlink(root), PrepareNestLayerSymlink(root)...)
+	mockFilesMetaData = append(mockFilesMetaData, PrepareCircularLayerSymlink(root)...)
+	return mockFilesMetaData
+}
+
+func initMockFileSystem(root string, mockFileMetaDatas []MockFile) error {
+	for _, mockFileMetaData := range mockFileMetaDatas {
+
+		if err := os.MkdirAll(filepath.Dir(mockFileMetaData.SymlinkFile), 0755); err != nil {
+			return err
+		}
+
+		if err := os.Symlink(mockFileMetaData.Symlink, mockFileMetaData.SymlinkFile); err != nil {
+			log.WithFields(log.Fields{"mockFileMetaData.SymlinkFile": mockFileMetaData.SymlinkFile, "mockFileMetaData.Symlink": mockFileMetaData.Symlink, "err": err}).Info("Failed to create symlink:")
+			return err
+		} else {
+			log.WithFields(log.Fields{"mockFileMetaData.SymlinkFile": mockFileMetaData.SymlinkFile, "mockFileMetaData.Symlink": mockFileMetaData.Symlink, "err": err}).Info("Success to create symlink:")
+		}
+
+		if mockFileMetaData.Exist {
+			if err := os.MkdirAll(filepath.Dir(mockFileMetaData.ResolvePath), 0755); err != nil {
+				return err
+			}
+			if _, err := os.Create(mockFileMetaData.ResolvePath); err != nil {
+				log.WithFields(log.Fields{"mockFileMetaData.ResolvePath": mockFileMetaData.ResolvePath, "err": err}).Info("Failed to create mockFileMetaData.ResolvePath:")
+				return err
+			} else {
+				log.WithFields(log.Fields{"mockFileMetaData.ResolvePath": mockFileMetaData.ResolvePath, "err": err}).Info("Success to create mockFileMetaData.ResolvePath:")
+			}
+		}
+	}
+
+	return nil
+}
+
+func TestGetContainerRealFilePath(t *testing.T) {
+	// Define the base directory for the test, using a temporary directory
+	// create a /proc/ like folder then mimic the link.
+	// type of test cases
+	// 1. one layer of symlink
+	// 2. append another layer on type 1, make it a nest link
+	// 3. circular link
+	tempDir, err := ioutil.TempDir("", "proc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	mockFileMetaDatas := PrepareMockFilesMetaData(tempDir)
+	
+	if err := initMockFileSystem(tempDir, mockFileMetaDatas); err != nil {
+		t.Errorf("Error: initMockFileSystem failure: %s \n", err)
+	}
+
+	for _, mockFileMetaData := range mockFileMetaDatas {
+		if resolvePath, err := GetContainerRealFilePath(mockFileMetaData.Pid, mockFileMetaData.SymlinkFile); err != nil {
+			if err.Error() != mockFileMetaData.ExpectResult {
+				t.Errorf("Error: Unknown failure %s, expect %s\n", err.Error(), mockFileMetaData.ExpectResult)
+			}
+		} else if resolvePath != mockFileMetaData.ResolvePath {
+			t.Errorf("Error: failed to reolve the path of %s with result %s\n", mockFileMetaData.ResolvePath, resolvePath)
+		}
+	}
+}

--- a/share/osutil/file_linux_test.go
+++ b/share/osutil/file_linux_test.go
@@ -261,7 +261,7 @@ func PrepareNestLayerSymlink(root string) []MockFile {
 			Symlink:      "../../bin/notExist",
 			Exist:        false,
 			ResolvePath:  "",
-			ExpectResult: "lstat " + filepath.Join(root, "proc", "6", "root", "bin","rpm") + ": no such file or directory",
+			ExpectResult: "readlink " + filepath.Join(root, "proc", "6", "root", "bin","rpm") + ": no such file or directory",
 		},
 		{
 			Pid:          7,
@@ -269,7 +269,7 @@ func PrepareNestLayerSymlink(root string) []MockFile {
 			Symlink:      "../../bin/rpmquery",
 			Exist:        true,
 			ResolvePath:  filepath.Join(root, "bin", "pwd"),
-			ExpectResult: "lstat " + filepath.Join(root, "proc", "7", "root", "bin","pwd") + ": no such file or directory",
+			ExpectResult: "readlink " + filepath.Join(root, "proc", "7", "root", filepath.Join(root, "bin", "pwd")) + ": no such file or directory",
 		},
 
 		// two layer 
@@ -319,7 +319,7 @@ func PrepareNestLayerSymlink(root string) []MockFile {
 			Symlink:      "../../bin/rpmNest",
 			Exist:        false,
 			ResolvePath:  "",
-			ExpectResult: "lstat " + filepath.Join(root, "proc", "6", "root", "bin","rpm") + ": no such file or directory",
+			ExpectResult: "readlink " + filepath.Join(root, "proc", "6", "root", "bin","rpm") + ": no such file or directory",
 		},
 		{
 			Pid:          7,
@@ -327,7 +327,7 @@ func PrepareNestLayerSymlink(root string) []MockFile {
 			Symlink:      "../../bin/rpmNest",
 			Exist:        true,
 			ResolvePath:  filepath.Join(root, "bin", "pwd"),
-			ExpectResult: "lstat " + filepath.Join(root, "proc", "7", "root", "bin","pwd") + ": no such file or directory",
+			ExpectResult: "readlink " + filepath.Join(root, "proc", "7", "root", filepath.Join(root, "bin", "pwd")) + ": no such file or directory",
 		},
 	}
 }
@@ -338,7 +338,7 @@ func PrepareSingleLayerAbsSymlink(root string) []MockFile {
         {
             Pid:          8,
             SymlinkFile:  filepath.Join(root, "proc", "8", "root", "bin","rpmverify"),
-            Symlink:      filepath.Join(root, "proc", "8", "root", "bin","rpm"),
+            Symlink:      filepath.Join("/bin","rpm"),
             Exist:        true,
             ResolvePath:  filepath.Join(root, "proc", "8", "root", "bin","rpm"),
 			ExpectResult: "",
@@ -346,7 +346,7 @@ func PrepareSingleLayerAbsSymlink(root string) []MockFile {
         {
             Pid:          9,
             SymlinkFile:  filepath.Join(root, "proc", "9", "root", "bin","rpmverify"),
-            Symlink:      filepath.Join(root, "proc", "9", "root", "bin","neu","vector","rpm"),
+            Symlink:      filepath.Join("/bin","neu","vector","rpm"),
             Exist:        true,
             ResolvePath:  filepath.Join(root, "proc", "9", "root", "bin","neu","vector","rpm"),
 			ExpectResult: "",
@@ -354,26 +354,26 @@ func PrepareSingleLayerAbsSymlink(root string) []MockFile {
         {
             Pid:          10,
             SymlinkFile:  filepath.Join(root, "proc", "10", "root", "bin","rpmverify"),
-            Symlink:      filepath.Join(root, "proc", "10", "root", "bin","rpm"),
+            Symlink:      filepath.Join("/bin","rpm"),
             Exist:        false,
             ResolvePath:  "",
-            ExpectResult: "lstat " + filepath.Join(root, "proc", "10", "root", "bin","rpm") + ": no such file or directory",
+            ExpectResult: "readlink " + filepath.Join(root, "proc", "10", "root", "bin","rpm") + ": no such file or directory",
         },
         {
             Pid:          11,
             SymlinkFile:  filepath.Join(root, "proc", "11", "root", "bin","rpmverify"),
-            Symlink:      filepath.Join(root, "proc", "11", "root", "bin","neu","vector","rpm"),
+            Symlink:      filepath.Join("/bin","neu","vector","rpm"),
             Exist:        true,
             ResolvePath:  filepath.Join(root, "proc", "11", "root", "bin","rpm"),
-			ExpectResult: "lstat " + filepath.Join(root, "proc", "11", "root", "bin","neu","vector","rpm") + ": no such file or directory",
+			ExpectResult: "readlink " + filepath.Join(root, "proc", "11", "root", "bin","neu","vector","rpm") + ": no such file or directory",
         },
         {
             Pid:          12,
             SymlinkFile:  filepath.Join(root, "proc", "12", "root", "bin","rpmverify"),
-            Symlink:      filepath.Join(root, "a", "b","..","..","..","bin","rpm"),
+            Symlink:      filepath.Join("/a", "b","..","..","..","bin","rpm"),
             Exist:        true,
             ResolvePath:  filepath.Join(root,"bin","rpm"),
-			ExpectResult: "lstat " + filepath.Join(root, "proc", "12", "root", "bin","rpm") + ": no such file or directory",
+			ExpectResult: "readlink " + filepath.Join(root, "proc", "12", "root", "bin","rpm") + ": no such file or directory",
         },
 	}
 }
@@ -426,7 +426,7 @@ func PrepareSingleLayerSymlink(root string) []MockFile {
             Symlink:      "../../bin/rpm",
             Exist:        false,
             ResolvePath:  "",
-            ExpectResult: "lstat " + filepath.Join(root, "proc", "6", "root", "bin","rpm") + ": no such file or directory",
+            ExpectResult: "readlink " + filepath.Join(root, "proc", "6", "root", "bin","rpm") + ": no such file or directory",
         },
         {
             Pid:          7,
@@ -434,7 +434,7 @@ func PrepareSingleLayerSymlink(root string) []MockFile {
             Symlink:      filepath.Join(root, "bin", "pwd"),
             Exist:        true,
             ResolvePath:  filepath.Join(root, "bin", "pwd"),
-            ExpectResult: "lstat " + filepath.Join(root, "proc", "7", "root", "bin","pwd") + ": no such file or directory",
+            ExpectResult: "readlink " + filepath.Join(root, "proc", "7", "root", filepath.Join(root, "bin", "pwd")) + ": no such file or directory",
         },
 	}
 }

--- a/share/osutil/file_linux_test.go
+++ b/share/osutil/file_linux_test.go
@@ -261,7 +261,7 @@ func PrepareNestLayerSymlink(root string) []MockFile {
 			Symlink:      "../../bin/notExist",
 			Exist:        false,
 			ResolvePath:  "",
-			ExpectResult: "readlink " + filepath.Join(root, "proc", "6", "root", "bin","rpm") + ": no such file or directory",
+			ExpectResult: "lstat " + filepath.Join(root, "proc", "6", "root", "bin","rpm") + ": no such file or directory",
 		},
 		{
 			Pid:          7,
@@ -269,7 +269,7 @@ func PrepareNestLayerSymlink(root string) []MockFile {
 			Symlink:      "../../bin/rpmquery",
 			Exist:        true,
 			ResolvePath:  filepath.Join(root, "bin", "pwd"),
-			ExpectResult: "readlink " + filepath.Join(root, "proc", "7", "root", filepath.Join(root, "bin", "pwd")) + ": no such file or directory",
+			ExpectResult: "lstat " + filepath.Join(root, "proc", "7", "root", filepath.Join(root, "bin", "pwd")) + ": no such file or directory",
 		},
 
 		// two layer 
@@ -319,7 +319,7 @@ func PrepareNestLayerSymlink(root string) []MockFile {
 			Symlink:      "../../bin/rpmNest",
 			Exist:        false,
 			ResolvePath:  "",
-			ExpectResult: "readlink " + filepath.Join(root, "proc", "6", "root", "bin","rpm") + ": no such file or directory",
+			ExpectResult: "lstat " + filepath.Join(root, "proc", "6", "root", "bin","rpm") + ": no such file or directory",
 		},
 		{
 			Pid:          7,
@@ -327,7 +327,7 @@ func PrepareNestLayerSymlink(root string) []MockFile {
 			Symlink:      "../../bin/rpmNest",
 			Exist:        true,
 			ResolvePath:  filepath.Join(root, "bin", "pwd"),
-			ExpectResult: "readlink " + filepath.Join(root, "proc", "7", "root", filepath.Join(root, "bin", "pwd")) + ": no such file or directory",
+			ExpectResult: "lstat " + filepath.Join(root, "proc", "7", "root", filepath.Join(root, "bin", "pwd")) + ": no such file or directory",
 		},
 	}
 }
@@ -357,7 +357,7 @@ func PrepareSingleLayerAbsSymlink(root string) []MockFile {
             Symlink:      filepath.Join("/bin","rpm"),
             Exist:        false,
             ResolvePath:  "",
-            ExpectResult: "readlink " + filepath.Join(root, "proc", "10", "root", "bin","rpm") + ": no such file or directory",
+            ExpectResult: "lstat " + filepath.Join(root, "proc", "10", "root", "bin","rpm") + ": no such file or directory",
         },
         {
             Pid:          11,
@@ -365,7 +365,7 @@ func PrepareSingleLayerAbsSymlink(root string) []MockFile {
             Symlink:      filepath.Join("/bin","neu","vector","rpm"),
             Exist:        true,
             ResolvePath:  filepath.Join(root, "proc", "11", "root", "bin","rpm"),
-			ExpectResult: "readlink " + filepath.Join(root, "proc", "11", "root", "bin","neu","vector","rpm") + ": no such file or directory",
+			ExpectResult: "lstat " + filepath.Join(root, "proc", "11", "root", "bin","neu","vector","rpm") + ": no such file or directory",
         },
         {
             Pid:          12,
@@ -373,7 +373,7 @@ func PrepareSingleLayerAbsSymlink(root string) []MockFile {
             Symlink:      filepath.Join("/a", "b","..","..","..","bin","rpm"),
             Exist:        true,
             ResolvePath:  filepath.Join(root,"bin","rpm"),
-			ExpectResult: "readlink " + filepath.Join(root, "proc", "12", "root", "bin","rpm") + ": no such file or directory",
+			ExpectResult: "lstat " + filepath.Join(root, "proc", "12", "root", "bin","rpm") + ": no such file or directory",
         },
 	}
 }
@@ -426,7 +426,7 @@ func PrepareSingleLayerSymlink(root string) []MockFile {
             Symlink:      "../../bin/rpm",
             Exist:        false,
             ResolvePath:  "",
-            ExpectResult: "readlink " + filepath.Join(root, "proc", "6", "root", "bin","rpm") + ": no such file or directory",
+            ExpectResult: "lstat " + filepath.Join(root, "proc", "6", "root", "bin","rpm") + ": no such file or directory",
         },
         {
             Pid:          7,
@@ -434,7 +434,7 @@ func PrepareSingleLayerSymlink(root string) []MockFile {
             Symlink:      filepath.Join(root, "bin", "pwd"),
             Exist:        true,
             ResolvePath:  filepath.Join(root, "bin", "pwd"),
-            ExpectResult: "readlink " + filepath.Join(root, "proc", "7", "root", filepath.Join(root, "bin", "pwd")) + ": no such file or directory",
+            ExpectResult: "lstat " + filepath.Join(root, "proc", "7", "root", filepath.Join(root, "bin", "pwd")) + ": no such file or directory",
         },
 	}
 }

--- a/share/osutil/file_linux_test.go
+++ b/share/osutil/file_linux_test.go
@@ -1,39 +1,39 @@
 package osutil
 
 import (
-	"os"
-	"testing"
-	"path/filepath"
 	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
 
 	log "github.com/sirupsen/logrus"
 )
 
 type MockFile struct {
-	Pid 		  int
-	SymlinkFile   string
-	Symlink 	  string
-	Exist  		  bool
-	ResolvePath   string
-	ExpectResult  string
+	Pid          int
+	SymlinkFile  string
+	Symlink      string
+	Exist        bool
+	ResolvePath  string
+	ExpectResult string
 }
 
 func PrepareCircularLayerSymlink(root string) []MockFile {
 	return []MockFile{
-		// length 1 cycle 
+		// length 1 cycle
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C1P1"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C1P1"),
 			Symlink:      "../bin/C1P1",
 			Exist:        false,
 			ResolvePath:  "",
 			ExpectResult: "Error: Circular symlink detected. The symlink structure creates a loop and cannot be resolved.",
 		},
 
-		// length 2 cycle 
+		// length 2 cycle
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C2P1"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C2P1"),
 			Symlink:      "../bin/C2P2",
 			Exist:        false,
 			ResolvePath:  "",
@@ -41,7 +41,7 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		},
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C2P2"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C2P2"),
 			Symlink:      "./../bin/C2P1",
 			Exist:        false,
 			ResolvePath:  "",
@@ -51,7 +51,7 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		// length 3 cycle
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C3P1"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C3P1"),
 			Symlink:      "../bin/C3P2",
 			Exist:        false,
 			ResolvePath:  "",
@@ -59,7 +59,7 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		},
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C3P2"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C3P2"),
 			Symlink:      "./../bin/C3P3",
 			Exist:        false,
 			ResolvePath:  "",
@@ -67,7 +67,7 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		},
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C3P3"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C3P3"),
 			Symlink:      "../bin/C3P1",
 			Exist:        false,
 			ResolvePath:  "",
@@ -77,7 +77,7 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		// length 4 cycle => fit the rule
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C4P1"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C4P1"),
 			Symlink:      "../bin/C4P2",
 			Exist:        false,
 			ResolvePath:  "",
@@ -85,7 +85,7 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		},
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C4P2"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C4P2"),
 			Symlink:      "./../bin/C4P3",
 			Exist:        false,
 			ResolvePath:  "",
@@ -93,15 +93,15 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		},
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C4P3"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C4P3"),
 			Symlink:      "../bin/C4P4",
 			Exist:        false,
 			ResolvePath:  "",
 			ExpectResult: "Error: Circular symlink detected. The symlink structure creates a loop and cannot be resolved.",
-		},		
+		},
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C4P4"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C4P4"),
 			Symlink:      "../bin/C4P1",
 			Exist:        false,
 			ResolvePath:  "",
@@ -111,7 +111,7 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		// length 5 cycle => break the rule
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C5P1"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C5P1"),
 			Symlink:      "../bin/C4P1",
 			Exist:        false,
 			ResolvePath:  "",
@@ -119,7 +119,7 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		},
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C5P2"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C5P2"),
 			Symlink:      "./../bin/C5P3",
 			Exist:        false,
 			ResolvePath:  "",
@@ -127,15 +127,15 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		},
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C5P3"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C5P3"),
 			Symlink:      "../bin/C5P4",
 			Exist:        false,
 			ResolvePath:  "",
 			ExpectResult: "Get file symlink fail",
-		},		
+		},
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C5P4"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C5P4"),
 			Symlink:      "../bin/C5P5",
 			Exist:        false,
 			ResolvePath:  "",
@@ -143,7 +143,7 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		},
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C5P5"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C5P5"),
 			Symlink:      "./../bin/C5P1",
 			Exist:        false,
 			ResolvePath:  "",
@@ -153,7 +153,7 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		// length 6 cycle => break the rule
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C6P1"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C6P1"),
 			Symlink:      "../bin/C6P2",
 			Exist:        false,
 			ResolvePath:  "",
@@ -161,7 +161,7 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		},
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C6P2"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C6P2"),
 			Symlink:      "./../bin/C6P3",
 			Exist:        false,
 			ResolvePath:  "",
@@ -169,7 +169,7 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		},
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C6P3"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C6P3"),
 			Symlink:      "../bin/C6P4",
 			Exist:        false,
 			ResolvePath:  "",
@@ -177,7 +177,7 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		},
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C6P4"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C6P4"),
 			Symlink:      "../bin/C6P5",
 			Exist:        false,
 			ResolvePath:  "",
@@ -185,7 +185,7 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		},
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C6P5"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C6P5"),
 			Symlink:      "./../bin/C6P6",
 			Exist:        false,
 			ResolvePath:  "",
@@ -193,7 +193,7 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		},
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","C6P6"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "C6P6"),
 			Symlink:      "../bin/C6P1",
 			Exist:        false,
 			ResolvePath:  "",
@@ -203,7 +203,7 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 		// random access to one of the cycle, say cycle with length 2
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","CRP1"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "CRP1"),
 			Symlink:      "../bin/C2P1",
 			Exist:        false,
 			ResolvePath:  "",
@@ -214,116 +214,116 @@ func PrepareCircularLayerSymlink(root string) []MockFile {
 
 func PrepareNestLayerSymlink(root string) []MockFile {
 	return []MockFile{
-		// one layer 
+		// one layer
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","rpmNest"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "rpmNest"),
 			Symlink:      "../bin/rpmverify",
 			Exist:        true,
-			ResolvePath:  filepath.Join(root, "proc", "1", "root", "bin","rpm"),
+			ResolvePath:  filepath.Join(root, "proc", "1", "root", "bin", "rpm"),
 			ExpectResult: "",
 		},
 		{
 			Pid:          2,
-			SymlinkFile:  filepath.Join(root, "proc", "2", "root", "bin","rpmNest"),
+			SymlinkFile:  filepath.Join(root, "proc", "2", "root", "bin", "rpmNest"),
 			Symlink:      "./../bin/rpmverify",
 			Exist:        true,
-			ResolvePath:  filepath.Join(root, "proc", "2", "root", "bin","rpm"),
+			ResolvePath:  filepath.Join(root, "proc", "2", "root", "bin", "rpm"),
 			ExpectResult: "",
 		},
 		{
 			Pid:          3,
-			SymlinkFile:  filepath.Join(root, "proc", "3", "root", "bin","rpmNest"),
+			SymlinkFile:  filepath.Join(root, "proc", "3", "root", "bin", "rpmNest"),
 			Symlink:      "../../bin/rpmverify",
 			Exist:        true,
-			ResolvePath:  filepath.Join(root, "proc", "3", "root", "bin","rpm"),
+			ResolvePath:  filepath.Join(root, "proc", "3", "root", "bin", "rpm"),
 			ExpectResult: "",
 		},
 		{
 			Pid:          4,
-			SymlinkFile:  filepath.Join(root, "proc", "4", "root", "bin","rpmNest"),
+			SymlinkFile:  filepath.Join(root, "proc", "4", "root", "bin", "rpmNest"),
 			Symlink:      "../../../bin/rpmverify",
 			Exist:        true,
-			ResolvePath:  filepath.Join(root, "proc", "4", "root", "bin","rpm"),
+			ResolvePath:  filepath.Join(root, "proc", "4", "root", "bin", "rpm"),
 			ExpectResult: "",
 		},
 		{
 			Pid:          5,
-			SymlinkFile:  filepath.Join(root, "proc", "5", "root", "bin","rpmNest"),
+			SymlinkFile:  filepath.Join(root, "proc", "5", "root", "bin", "rpmNest"),
 			Symlink:      "./../../../bin/rpmverify",
 			Exist:        true,
-			ResolvePath:  filepath.Join(root, "proc", "5", "root", "bin","rpm"),
+			ResolvePath:  filepath.Join(root, "proc", "5", "root", "bin", "rpm"),
 			ExpectResult: "",
 		},
 		{
 			Pid:          6,
-			SymlinkFile:  filepath.Join(root, "proc", "6", "root", "bin","rpmNest"),
+			SymlinkFile:  filepath.Join(root, "proc", "6", "root", "bin", "rpmNest"),
 			Symlink:      "../../bin/notExist",
 			Exist:        false,
 			ResolvePath:  "",
-			ExpectResult: "lstat " + filepath.Join(root, "proc", "6", "root", "bin","rpm") + ": no such file or directory",
+			ExpectResult: "lstat " + filepath.Join(root, "proc", "6", "root", "bin", "rpm") + ": no such file or directory",
 		},
 		{
 			Pid:          7,
-			SymlinkFile:  filepath.Join(root, "proc", "7", "root", "bin","rpmNest"),
+			SymlinkFile:  filepath.Join(root, "proc", "7", "root", "bin", "rpmNest"),
 			Symlink:      "../../bin/rpmquery",
 			Exist:        true,
 			ResolvePath:  filepath.Join(root, "bin", "pwd"),
 			ExpectResult: "lstat " + filepath.Join(root, "proc", "7", "root", filepath.Join(root, "bin", "pwd")) + ": no such file or directory",
 		},
 
-		// two layer 
+		// two layer
 		{
 			Pid:          1,
-			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","rpmNest1"),
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "rpmNest1"),
 			Symlink:      "../bin/rpmNest",
 			Exist:        true,
-			ResolvePath:  filepath.Join(root, "proc", "1", "root", "bin","rpm"),
+			ResolvePath:  filepath.Join(root, "proc", "1", "root", "bin", "rpm"),
 			ExpectResult: "",
 		},
 		{
 			Pid:          2,
-			SymlinkFile:  filepath.Join(root, "proc", "2", "root", "bin","rpmNest1"),
+			SymlinkFile:  filepath.Join(root, "proc", "2", "root", "bin", "rpmNest1"),
 			Symlink:      "./../bin/rpmNest",
 			Exist:        true,
-			ResolvePath:  filepath.Join(root, "proc", "2", "root", "bin","rpm"),
+			ResolvePath:  filepath.Join(root, "proc", "2", "root", "bin", "rpm"),
 			ExpectResult: "",
 		},
 		{
 			Pid:          3,
-			SymlinkFile:  filepath.Join(root, "proc", "3", "root", "bin","rpmNest1"),
+			SymlinkFile:  filepath.Join(root, "proc", "3", "root", "bin", "rpmNest1"),
 			Symlink:      "../../bin/rpmNest",
 			Exist:        true,
-			ResolvePath:  filepath.Join(root, "proc", "3", "root", "bin","rpm"),
+			ResolvePath:  filepath.Join(root, "proc", "3", "root", "bin", "rpm"),
 			ExpectResult: "",
 		},
 		{
 			Pid:          4,
-			SymlinkFile:  filepath.Join(root, "proc", "4", "root", "bin","rpmNest1"),
+			SymlinkFile:  filepath.Join(root, "proc", "4", "root", "bin", "rpmNest1"),
 			Symlink:      "../../../bin/rpmNest",
 			Exist:        true,
-			ResolvePath:  filepath.Join(root, "proc", "4", "root", "bin","rpm"),
+			ResolvePath:  filepath.Join(root, "proc", "4", "root", "bin", "rpm"),
 			ExpectResult: "",
 		},
 		{
 			Pid:          5,
-			SymlinkFile:  filepath.Join(root, "proc", "5", "root", "bin","rpmNest1"),
+			SymlinkFile:  filepath.Join(root, "proc", "5", "root", "bin", "rpmNest1"),
 			Symlink:      "./../../../bin/rpmNest",
 			Exist:        true,
-			ResolvePath:  filepath.Join(root, "proc", "5", "root", "bin","rpm"),
+			ResolvePath:  filepath.Join(root, "proc", "5", "root", "bin", "rpm"),
 			ExpectResult: "",
 		},
 		{
 			Pid:          6,
-			SymlinkFile:  filepath.Join(root, "proc", "6", "root", "bin","rpmNest1"),
+			SymlinkFile:  filepath.Join(root, "proc", "6", "root", "bin", "rpmNest1"),
 			Symlink:      "../../bin/rpmNest",
 			Exist:        false,
 			ResolvePath:  "",
-			ExpectResult: "lstat " + filepath.Join(root, "proc", "6", "root", "bin","rpm") + ": no such file or directory",
+			ExpectResult: "lstat " + filepath.Join(root, "proc", "6", "root", "bin", "rpm") + ": no such file or directory",
 		},
 		{
 			Pid:          7,
-			SymlinkFile:  filepath.Join(root, "proc", "7", "root", "bin","rpmNest1"),
+			SymlinkFile:  filepath.Join(root, "proc", "7", "root", "bin", "rpmNest1"),
 			Symlink:      "../../bin/rpmNest",
 			Exist:        true,
 			ResolvePath:  filepath.Join(root, "bin", "pwd"),
@@ -333,109 +333,109 @@ func PrepareNestLayerSymlink(root string) []MockFile {
 }
 
 func PrepareSingleLayerAbsSymlink(root string) []MockFile {
-    return []MockFile{
+	return []MockFile{
 		// absolute path
-        {
-            Pid:          8,
-            SymlinkFile:  filepath.Join(root, "proc", "8", "root", "bin","rpmverify"),
-            Symlink:      filepath.Join("/bin","rpm"),
-            Exist:        true,
-            ResolvePath:  filepath.Join(root, "proc", "8", "root", "bin","rpm"),
+		{
+			Pid:          8,
+			SymlinkFile:  filepath.Join(root, "proc", "8", "root", "bin", "rpmverify"),
+			Symlink:      filepath.Join("/bin", "rpm"),
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "8", "root", "bin", "rpm"),
 			ExpectResult: "",
-        },
-        {
-            Pid:          9,
-            SymlinkFile:  filepath.Join(root, "proc", "9", "root", "bin","rpmverify"),
-            Symlink:      filepath.Join("/bin","neu","vector","rpm"),
-            Exist:        true,
-            ResolvePath:  filepath.Join(root, "proc", "9", "root", "bin","neu","vector","rpm"),
+		},
+		{
+			Pid:          9,
+			SymlinkFile:  filepath.Join(root, "proc", "9", "root", "bin", "rpmverify"),
+			Symlink:      filepath.Join("/bin", "neu", "vector", "rpm"),
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "9", "root", "bin", "neu", "vector", "rpm"),
 			ExpectResult: "",
-        },
-        {
-            Pid:          10,
-            SymlinkFile:  filepath.Join(root, "proc", "10", "root", "bin","rpmverify"),
-            Symlink:      filepath.Join("/bin","rpm"),
-            Exist:        false,
-            ResolvePath:  "",
-            ExpectResult: "lstat " + filepath.Join(root, "proc", "10", "root", "bin","rpm") + ": no such file or directory",
-        },
-        {
-            Pid:          11,
-            SymlinkFile:  filepath.Join(root, "proc", "11", "root", "bin","rpmverify"),
-            Symlink:      filepath.Join("/bin","neu","vector","rpm"),
-            Exist:        true,
-            ResolvePath:  filepath.Join(root, "proc", "11", "root", "bin","rpm"),
-			ExpectResult: "lstat " + filepath.Join(root, "proc", "11", "root", "bin","neu","vector","rpm") + ": no such file or directory",
-        },
-        {
-            Pid:          12,
-            SymlinkFile:  filepath.Join(root, "proc", "12", "root", "bin","rpmverify"),
-            Symlink:      filepath.Join("/a", "b","..","..","..","bin","rpm"),
-            Exist:        true,
-            ResolvePath:  filepath.Join(root,"bin","rpm"),
-			ExpectResult: "lstat " + filepath.Join(root, "proc", "12", "root", "bin","rpm") + ": no such file or directory",
-        },
+		},
+		{
+			Pid:          10,
+			SymlinkFile:  filepath.Join(root, "proc", "10", "root", "bin", "rpmverify"),
+			Symlink:      filepath.Join("/bin", "rpm"),
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "lstat " + filepath.Join(root, "proc", "10", "root", "bin", "rpm") + ": no such file or directory",
+		},
+		{
+			Pid:          11,
+			SymlinkFile:  filepath.Join(root, "proc", "11", "root", "bin", "rpmverify"),
+			Symlink:      filepath.Join("/bin", "neu", "vector", "rpm"),
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "11", "root", "bin", "rpm"),
+			ExpectResult: "lstat " + filepath.Join(root, "proc", "11", "root", "bin", "neu", "vector", "rpm") + ": no such file or directory",
+		},
+		{
+			Pid:          12,
+			SymlinkFile:  filepath.Join(root, "proc", "12", "root", "bin", "rpmverify"),
+			Symlink:      filepath.Join("/a", "b", "..", "..", "..", "bin", "rpm"),
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "bin", "rpm"),
+			ExpectResult: "lstat " + filepath.Join(root, "proc", "12", "root", "bin", "rpm") + ": no such file or directory",
+		},
 	}
 }
 
 func PrepareSingleLayerSymlink(root string) []MockFile {
-    return []MockFile{
-        {
-            Pid:          1,
-            SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin","rpmverify"),
-            Symlink:      "../bin/rpm",
-            Exist:        true,
-            ResolvePath:  filepath.Join(root, "proc", "1", "root", "bin","rpm"),
-            ExpectResult: "",
-        },
-        {
-            Pid:          2,
-            SymlinkFile:  filepath.Join(root, "proc", "2", "root", "bin","rpmverify"),
-            Symlink:      "./../bin/rpm",
-            Exist:        true,
-            ResolvePath:  filepath.Join(root, "proc", "2", "root", "bin","rpm"),
-            ExpectResult: "",
-        },
-        {
-            Pid:          3,
-            SymlinkFile:  filepath.Join(root, "proc", "3", "root", "bin","rpmverify"),
-            Symlink:      "../../bin/rpm",
-            Exist:        true,
-            ResolvePath:  filepath.Join(root, "proc", "3", "root", "bin","rpm"),
-            ExpectResult: "",
-        },
+	return []MockFile{
 		{
-            Pid:          4,
-            SymlinkFile:  filepath.Join(root, "proc", "4", "root", "bin","rpmverify"),
-            Symlink:      "../../../bin/rpm",
-            Exist:        true,
-            ResolvePath:  filepath.Join(root, "proc", "4", "root", "bin","rpm"),
-            ExpectResult: "",
-        },
+			Pid:          1,
+			SymlinkFile:  filepath.Join(root, "proc", "1", "root", "bin", "rpmverify"),
+			Symlink:      "../bin/rpm",
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "1", "root", "bin", "rpm"),
+			ExpectResult: "",
+		},
 		{
-            Pid:          5,
-            SymlinkFile:  filepath.Join(root, "proc", "5", "root", "bin","rpmverify"),
-            Symlink:      "./../../../bin/rpm",
-            Exist:        true,
-            ResolvePath:  filepath.Join(root, "proc", "5", "root", "bin","rpm"),
-            ExpectResult: "",
-        },
-        {
-            Pid:          6,
-            SymlinkFile:  filepath.Join(root, "proc", "6", "root", "bin","notExist"),
-            Symlink:      "../../bin/rpm",
-            Exist:        false,
-            ResolvePath:  "",
-            ExpectResult: "lstat " + filepath.Join(root, "proc", "6", "root", "bin","rpm") + ": no such file or directory",
-        },
-        {
-            Pid:          7,
-            SymlinkFile:  filepath.Join(root, "proc", "7", "root", "bin","rpmquery"),
-            Symlink:      filepath.Join(root, "bin", "pwd"),
-            Exist:        true,
-            ResolvePath:  filepath.Join(root, "bin", "pwd"),
-            ExpectResult: "lstat " + filepath.Join(root, "proc", "7", "root", filepath.Join(root, "bin", "pwd")) + ": no such file or directory",
-        },
+			Pid:          2,
+			SymlinkFile:  filepath.Join(root, "proc", "2", "root", "bin", "rpmverify"),
+			Symlink:      "./../bin/rpm",
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "2", "root", "bin", "rpm"),
+			ExpectResult: "",
+		},
+		{
+			Pid:          3,
+			SymlinkFile:  filepath.Join(root, "proc", "3", "root", "bin", "rpmverify"),
+			Symlink:      "../../bin/rpm",
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "3", "root", "bin", "rpm"),
+			ExpectResult: "",
+		},
+		{
+			Pid:          4,
+			SymlinkFile:  filepath.Join(root, "proc", "4", "root", "bin", "rpmverify"),
+			Symlink:      "../../../bin/rpm",
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "4", "root", "bin", "rpm"),
+			ExpectResult: "",
+		},
+		{
+			Pid:          5,
+			SymlinkFile:  filepath.Join(root, "proc", "5", "root", "bin", "rpmverify"),
+			Symlink:      "./../../../bin/rpm",
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "proc", "5", "root", "bin", "rpm"),
+			ExpectResult: "",
+		},
+		{
+			Pid:          6,
+			SymlinkFile:  filepath.Join(root, "proc", "6", "root", "bin", "notExist"),
+			Symlink:      "../../bin/rpm",
+			Exist:        false,
+			ResolvePath:  "",
+			ExpectResult: "lstat " + filepath.Join(root, "proc", "6", "root", "bin", "rpm") + ": no such file or directory",
+		},
+		{
+			Pid:          7,
+			SymlinkFile:  filepath.Join(root, "proc", "7", "root", "bin", "rpmquery"),
+			Symlink:      filepath.Join(root, "bin", "pwd"),
+			Exist:        true,
+			ResolvePath:  filepath.Join(root, "bin", "pwd"),
+			ExpectResult: "lstat " + filepath.Join(root, "proc", "7", "root", filepath.Join(root, "bin", "pwd")) + ": no such file or directory",
+		},
 	}
 }
 
@@ -487,7 +487,7 @@ func TestGetContainerRealFilePath(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	mockFileMetaDatas := PrepareMockFilesMetaData(tempDir)
-	
+
 	if err := initMockFileSystem(tempDir, mockFileMetaDatas); err != nil {
 		t.Errorf("Error: initMockFileSystem failure: %s \n", err)
 	}


### PR DESCRIPTION
### Root cause

- The symlink in different mnt namespace sometime would escape the proc root by accident.

### Summary
1. Resolve the symbolic link files under proc's root path by parsing the symlink, and make sure it doesn't escape the proc root by check the prefix of the resolved path

2. Add unit test to cover GetContainerRealFilePath function with following cases

- one layer of symlink
- abs path for symlink
- append another layer on type 1, make it a nest link
- circular link
- one node accidentally access to the circular link


### Flow chart
![image](https://github.com/neuvector/neuvector/assets/145627854/546cb9a9-96b5-4176-b7e7-edd6ad4a3926)
