### PR TITLE
NVSHAS-8432: un-managed node with "zombie" enforcer running

### DIFF
--- a/agent/cluster.go
+++ b/agent/cluster.go
@@ -120,6 +120,7 @@ func clusterStart(clusterCfg *cluster.ClusterConfig) error {
 		}
 	}
 
+	cluster.RegisterLeadChangeWatcher(leadChangeHandler, leadAddr)
 	if err = waitForAdmission(); err != nil {
 		return err
 	}
@@ -807,7 +808,6 @@ func clusterLoop(existing utils.Set) {
 		cluster.RegisterStoreWatcher(share.CLUSNodeCommonProfileStore, systemUpdateHandler, agentEnv.kvCongestCtrl)
 		cluster.RegisterStoreWatcher(share.CLUSNodeProfileStoreKey(Host.ID), systemUpdateHandler, agentEnv.kvCongestCtrl)
 		cluster.RegisterStoreWatcher(share.CLUSConfigDomainStore, domainConfigUpdate, false)
-		cluster.RegisterLeadChangeWatcher(leadChangeHandler, leadAddr)
 	}()
 }
 


### PR DESCRIPTION
During a rolling upgrade of a multiple-controller setup, the enforcer could request admission on a phase-out old controller and can not detect the controller's leadership change. This situation leads to the enforcer's failure eventually.

This PR moves the leadership detection from a later procedure to help the admission request( grpc calls) with the most updated leader address and gain successful admission registrations.