### PR TITLE
NVSHAS-8532 Fix find container's symbolic link with correct proc root.

### DIFF
--- a/share/osutil/file_linux.go
+++ b/share/osutil/file_linux.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/neuvector/neuvector/share/global"
 	"github.com/neuvector/neuvector/share/utils"
+	"github.com/neuvector/neuvector/share/system"
 )
 
 const (
@@ -78,7 +79,8 @@ func extractProcRootPath(pid int, input string, inTest bool) (string, error) {
 		return matches[0], nil
 
 	} else {
-		return fmt.Sprintf("/proc/%d/root", pid), nil
+		SYS := system.NewSystemTools()
+		return fmt.Sprintf(SYS.GetProcDir() + "%d/root", pid), nil
 	}
 }
 
@@ -123,8 +125,10 @@ func GetContainerRealFilePath(pid int, symlinkPath string, inTest bool) (string,
 
 		// if absolute symlink, we will join with procroot directly.
 		if filepath.IsAbs(symlink) {
-			underProcRoot = true
 			resolvedPath = filepath.Join(procRoot, symlink)
+			if strings.HasPrefix(resolvedPath, procRoot) {
+				underProcRoot = true
+			}
 		} else {
 			parts := strings.Split(symlink, "/")
 			for i := range parts {

--- a/share/osutil/file_linux.go
+++ b/share/osutil/file_linux.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/neuvector/neuvector/share/global"
 	"github.com/neuvector/neuvector/share/utils"
-	"github.com/neuvector/neuvector/share/system"
 )
 
 const (
@@ -77,10 +76,8 @@ func extractProcRootPath(pid int, input string, inTest bool) (string, error) {
 			return "", fmt.Errorf("no match found")
 		}
 		return matches[0], nil
-
 	} else {
-		SYS := system.NewSystemTools()
-		return fmt.Sprintf(SYS.GetProcDir() + "%d/root", pid), nil
+		return fmt.Sprintf(global.SYS.GetProcDir() + "%d/root", pid), nil
 	}
 }
 
@@ -126,9 +123,7 @@ func GetContainerRealFilePath(pid int, symlinkPath string, inTest bool) (string,
 		// if absolute symlink, we will join with procroot directly.
 		if filepath.IsAbs(symlink) {
 			resolvedPath = filepath.Join(procRoot, symlink)
-			if strings.HasPrefix(resolvedPath, procRoot) {
-				underProcRoot = true
-			}
+			underProcRoot = true
 		} else {
 			parts := strings.Split(symlink, "/")
 			for i := range parts {

--- a/share/system/system_linux.go
+++ b/share/system/system_linux.go
@@ -119,6 +119,10 @@ func (s *SystemTools) GetSystemInfo() *sysinfo.SysInfo {
 	return &s.info
 }
 
+func (s *SystemTools) GetProcDir() string {
+	return s.procDir
+}
+
 func (s *SystemTools) CallNetNamespaceFunc(pid int, cb NSCallback, params interface{}) error {
 	// Lock the OS Thread so we don't accidentally switch namespaces
 	runtime.LockOSThread()


### PR DESCRIPTION
### Summary

- Fix find container's symbolic link with correct proc root by system.NewSystemTools().

### How to verify

- use docker.io/pohanhuangtw/allinone:procRoot to verify the code changes as allinone image, then check the log if there is unusual log.




