### PR TITLE
NVSHAS-8537 and NVSHAS-8538: goroutine crashes from leadChangeHandler()

### DIFF
--- a/agent/cluster.go
+++ b/agent/cluster.go
@@ -709,11 +709,13 @@ func leadChangeHandler(newLead, oldLead string) {
 		if clusterFailed {
 			clusterFailed = false
 			uploadCurrentInfo()
-			if Host.CapDockerBench {
-				bench.RerunDocker(false)
-			}
-			if Host.CapKubeBench {
-				bench.RerunKube("", "", false)
+			if bench != nil {
+				if Host.CapDockerBench {
+					bench.RerunDocker(false)
+				}
+				if Host.CapKubeBench {
+					bench.RerunKube("", "", false)
+				}
 			}
 			cluster.ResumeAllWatchers()
 		}


### PR DESCRIPTION
Those events happened at the leaderChangeHAndler() when the bench worker was not initialized yet.