### PR TITLE
Compare strings with `strings.EqualFold`

### DIFF
--- a/controller/rest/policy.go
+++ b/controller/rest/policy.go
@@ -209,7 +209,7 @@ func parseRange(s string) (int, int, error) {
 func normalizePorts(s string) (string, error) {
 	s = strings.Trim(s, " ")
 
-	if len(s) == 0 || strings.ToUpper(s) == strings.ToUpper(api.PolicyPortAny) {
+	if len(s) == 0 || strings.EqualFold(s, api.PolicyPortAny) {
 		return api.PolicyPortAny, nil
 	}
 
@@ -228,14 +228,14 @@ func normalizePorts(s string) (string, error) {
 
 		proto := syscall.IPPROTO_TCP
 		if strings.HasPrefix(f, "tcp/") || strings.HasPrefix(f, "TCP/") {
-			if strings.ToUpper(f[4:]) == strings.ToUpper(api.PolicyPortAny) {
+			if strings.EqualFold(f[4:], api.PolicyPortAny) {
 				tcpAny = true
 				continue
 			} else {
 				low, high, err = parseRange(f[4:])
 			}
 		} else if strings.HasPrefix(f, "udp/") || strings.HasPrefix(f, "UDP/") {
-			if strings.ToUpper(f[4:]) == strings.ToUpper(api.PolicyPortAny) {
+			if strings.EqualFold(f[4:], api.PolicyPortAny) {
 				udpAny = true
 				continue
 			} else {
@@ -246,7 +246,7 @@ func normalizePorts(s string) (string, error) {
 			icmp = true
 			continue
 		} else {
-			if strings.ToUpper(f) == strings.ToUpper(api.PolicyPortAny) {
+			if strings.EqualFold(f, api.PolicyPortAny) {
 				tcpAny = true
 				udpAny = true
 				continue
@@ -319,7 +319,7 @@ func appNames2IDs(apps []string) []uint32 {
 
 	var ids []uint32 = make([]uint32, 0)
 	for _, app := range apps {
-		if strings.ToUpper(app) == strings.ToUpper(api.PolicyAppAny) {
+		if strings.EqualFold(app, api.PolicyAppAny) {
 			return []uint32{}
 		}
 		if id := common.GetAppIDByName(app); id != 0 {
@@ -338,7 +338,7 @@ func normalizeApps(apps []string) ([]string, error) {
 
 	appSet := utils.NewSet()
 	for _, app := range apps {
-		if strings.ToUpper(app) == strings.ToUpper(api.PolicyAppAny) {
+		if strings.EqualFold(app, api.PolicyAppAny) {
 			return []string{api.PolicyAppAny}, nil
 		}
 		if id := common.GetAppIDByName(app); id != 0 {


### PR DESCRIPTION
Comparing two strings to the same case with `strings.ToUpper` is more computational expensive than `strings.EqualFold`.

Sample benchmark:

```go
func BenchmarkToUpper(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if strings.ToUpper("any") != strings.ToUpper(api.PolicyPortAny) {
			b.Fail()
		}
	}
}

func BenchmarkEqualFold(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if !strings.EqualFold("any", api.PolicyPortAny) {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/neuvector/neuvector/controller/rest
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkToUpper-16      	 9510127	       141.6 ns/op	       6 B/op	       2 allocs/op
BenchmarkEqualFold-16    	286476537	         3.719 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/neuvector/neuvector/controller/rest	3.002s
```