### PR TITLE
NVSHAS-8573 do not print call stack for error

### DIFF
--- a/share/utils/utils.go
+++ b/share/utils/utils.go
@@ -854,7 +854,12 @@ func (f *LogFormatter) Format(entry *log.Entry) ([]byte, error) {
 		for i, key := range keys {
 			b.WriteString(key)
 			b.WriteByte('=')
-			fmt.Fprintf(b, "%+v", entry.Data[key])
+			item := entry.Data[key]
+			if err, ok := item.(error); ok {
+				fmt.Fprintf(b, "%+v", err.Error())
+			} else {
+				fmt.Fprintf(b, "%+v", item)
+			}
 			if i < len(keys)-1 {
 				b.WriteByte(' ')
 			}


### PR DESCRIPTION
# NVSHAS-8573 do not print call stack for error

## Why we need this change

NeuVector uses logrus custom formatter to print log messages.  This is done at below:

https://github.com/neuvector/neuvector/blob/315badd1e7b085485b8cf295b0e899ec63a3eb73/share/utils/utils.go#L857

However, `%+v` will print all internal data for extended error types, e.g., errors created by github.com/pkg/errors.Wrap().

As a result, the stacktrace is included in the error printed, which is not desirable.

This commit changes the way formatter prints error.  It checks if the data being printed is an error.  If so, err.Error() will be used, so unexposed part of an error will not be printed.

For this line of code
```
err := errors.New("test")
err = errors.Wrap(err, "asd")
log.WithField("e", err).Warn("Scenario A")
```

Before the change:

```
2024-01-03T12:44:14.771|WARN|CTL|fn: Scenario A - e=test main.main
	/tmp/go-test/main.go:57
runtime.main
	/usr/local/go/src/runtime/proc.go:203
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1373
```

After:

```
2024-01-03T12:45:01.951|WARN|CTL|fn: Scenario A - e=asd: test
```

## Tests performed

1. Enter wrong password.  Its result has no stacktrace anymore. 
```
2024-01-03T17:34:49.045|INFO|CTL|rest.handlerAuthLogin: - error=Wrong password user=admin
2024-01-03T17:34:49.047|ERRO|CTL|rest.handlerAuthLogin: User login failed - msg=Wrong password user=admin
```

2. log.WithFields works fine.
```
2024-01-03T17:34:10.322|INFO|CTL|cache.syncGraphRx: - links=37 maxLearnRuleID=10017 nodes=32 rules=17 vios=0
```

3. In enforcer logs can be printed normally.
```
2024-01-03T17:32:44.436|ERRO|AGT|osutil.GetContainerRealFilePath: failed to read resolvedPath - error=lstat /host/proc/1/root/share/python3/py3versions.py: no such file or directory

2024-01-03T17:32:43.358|INFO|AGT|main.(*TaskScanner).scanSecretLoop: SCRT: done - Finished=10 TimeUsed=10.005058595s
```
