### PR TITLE
NVSHAS-8573 remove github.com/pkg/errors

### DIFF
--- a/controller/kv/certmanager_test.go
+++ b/controller/kv/certmanager_test.go
@@ -2,11 +2,11 @@ package kv
 
 import (
 	"crypto/x509"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/neuvector/neuvector/share"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,7 +26,7 @@ func TestCertManager(t *testing.T) {
 		NewCert: func(*share.CLUSX509Cert) (*share.CLUSX509Cert, error) {
 			cert, key, err := GenTlsKeyCert(CN, "", "", ValidityPeriod{}, x509.ExtKeyUsageAny)
 			if err != nil {
-				return nil, errors.Wrap(err, "failed to generate tls key/cert")
+				return nil, fmt.Errorf("failed to generate tls key/cert: %w", err)
 			}
 			return &share.CLUSX509Cert{
 				CN:   CN,

--- a/controller/kv/helper.go
+++ b/controller/kv/helper.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/neuvector/neuvector/controller/access"
@@ -2043,7 +2042,7 @@ func (m clusterHelper) PutObjectCertMemory(cn string, in *share.CLUSX509Cert, ou
 		}
 		return nil
 	} else {
-		return errors.Wrap(err, "cert is not there after PutIfNotExist")
+		return fmt.Errorf("cert is not there after PutIfNotExist: %w", err)
 	}
 }
 

--- a/controller/rest/auth.go
+++ b/controller/rest/auth.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/julienschmidt/httprouter"
@@ -1231,7 +1231,7 @@ func jwtValidateToken(encryptedToken, secret string, rsaPublicKey *rsa.PublicKey
 	installID, err := clusHelper.GetInstallationID()
 	if err != nil {
 		log.WithError(err).Error("failed to get installation ID")
-		return nil, errors.Wrap(err, "failed to get installation ID")
+		return nil, fmt.Errorf("failed to get installation ID: %w", err)
 	}
 
 	if secret == "" {

--- a/controller/rest/rest.go
+++ b/controller/rest/rest.go
@@ -23,8 +23,9 @@ import (
 	"syscall"
 	"time"
 
+	"errors"
+
 	"github.com/dgrijalva/jwt-go"
-	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 
 	"github.com/hashicorp/go-version"
@@ -1314,7 +1315,7 @@ func initJWTSignKey() error {
 		NewCert: func(*share.CLUSX509Cert) (*share.CLUSX509Cert, error) {
 			cert, key, err := kv.GenTlsKeyCert(share.CLUSJWTKey, "", "", kv.ValidityPeriod{Day: JWTCertValidityPeriodDay}, x509.ExtKeyUsageAny)
 			if err != nil {
-				return nil, errors.Wrap(err, "failed to generate tls key/cert")
+				return nil, fmt.Errorf("failed to generate tls key/cert: %w", err)
 			}
 			return &share.CLUSX509Cert{
 				CN:   share.CLUSJWTKey,

--- a/controller/rest/server.go
+++ b/controller/rest/server.go
@@ -13,7 +13,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
+	"errors"
 
 	"github.com/julienschmidt/httprouter"
 	log "github.com/sirupsen/logrus"
@@ -755,7 +755,7 @@ func validateSAMLServer(cs *share.CLUSServer) error {
 		}
 	} else {
 		if _, err := tls.X509KeyPair([]byte(csaml.SigningCert), []byte(csaml.SigningKey)); err != nil {
-			return errors.Wrap(err, "invalid key cert pair")
+			return fmt.Errorf("invalid key cert pair: %w", err)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,6 @@ require (
 	github.com/neuvector/k8s v1.2.1-0.20220214174348-d0b3f377461e
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
-	github.com/pkg/errors v0.9.1
 	github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021
 	github.com/russellhaering/gosaml2 v0.9.1
 	github.com/russellhaering/goxmldsig v1.4.0
@@ -98,6 +97,7 @@ require (
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect
 	gopkg.in/ldap.v2 v2.5.1
 	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.22.5
 	k8s.io/apimachinery v0.25.2
 	k8s.io/cri-api v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,7 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/zstd v1.4.0/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317/go.mod h1:DF8FZRxMHMGv/vP2lQP6h+dYzzjpuRn24VeRiYn3qjQ=
@@ -248,8 +249,6 @@ github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNE
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/doug-martin/goqu v1.0.0 h1:5qQwMzItVsRGYf/3GdAWhb1s0KE5YBaTq9phYI2JUGQ=
-github.com/doug-martin/goqu v5.0.0+incompatible h1:C7O6xQYoWpSGX32C1faMJWe1s82Ktr2jjWf2joReiSQ=
 github.com/doug-martin/goqu/v9 v9.19.0 h1:PD7t1X3tRcUiSdc5TEyOFKujZA5gs3VSA7wxSvBx7qo=
 github.com/doug-martin/goqu/v9 v9.19.0/go.mod h1:nf0Wc2/hV3gYK9LiyqIrzBEVGlI8qW3GuDCEobC4wBQ=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -318,6 +317,7 @@ github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dp
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-ozzo/ozzo-validation v3.5.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-toolsmith/astcast v1.0.0/go.mod h1:mt2OdQTeAQcY4DQgPSArJjHCcOwlX+Wl/kwN+LbLGQ4=
@@ -568,6 +568,7 @@ github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/lib/pq v1.10.1 h1:6VXZrLU0jHBYyAqrSPa+MgPfnSvTPuMgK+k0o5kVFWo=
 github.com/lib/pq v1.10.1/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/libopenstorage/openstorage v1.0.0/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=

--- a/share/auth/auth.go
+++ b/share/auth/auth.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/oauth2"
 	"gopkg.in/ldap.v2"
 
-	"github.com/pkg/errors"
+	"errors"
 
 	"github.com/neuvector/neuvector/controller/api"
 	"github.com/neuvector/neuvector/share"
@@ -172,7 +172,7 @@ func GenerateSamlSP(csaml *share.CLUSServerSAML, spissuer string, redirurl strin
 	if csaml.SigningCert != "" && csaml.SigningKey != "" {
 		cert, err := tls.X509KeyPair([]byte(csaml.SigningCert), []byte(csaml.SigningKey))
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to parse key pair")
+			return nil, fmt.Errorf("failed to parse key pair: %w", err)
 		}
 		keystore = dsig.TLSCertKeyStore(cert)
 	}
@@ -224,7 +224,7 @@ func (a *remoteAuth) SAMLSPGetRedirectURL(csaml *share.CLUSServerSAML, redir *ap
 		for k, v := range overrides {
 			path, err := etree.CompilePath("./samlp:AuthnRequest")
 			if err != nil {
-				return "", errors.Wrap(err, "failed to parse xml path")
+				return "", fmt.Errorf("failed to parse xml path: %w", err)
 			}
 			for _, e := range doc.FindElementsPath(path) {
 				attr := e.SelectAttr(k)
@@ -248,13 +248,13 @@ func (a *remoteAuth) SAMLSPGetLogoutURL(csaml *share.CLUSServerSAML, redir *api.
 	}
 	sp, err := GenerateSamlSP(csaml, issuer, redir.Redirect, a.fakeTime)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to generate saml service provider")
+		return "", fmt.Errorf("failed to generate saml service provider: %w", err)
 	}
 
 	// Should be no sig in document.
 	doc, err := sp.BuildLogoutRequestDocumentNoSig(nameid, sessionIndex)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to build saml slo document")
+		return "", fmt.Errorf("failed to build saml slo document: %w", err)
 	}
 
 	if overrides != nil {
@@ -262,7 +262,7 @@ func (a *remoteAuth) SAMLSPGetLogoutURL(csaml *share.CLUSServerSAML, redir *api.
 		for k, v := range overrides {
 			path, err := etree.CompilePath("./samlp:LogoutRequest")
 			if err != nil {
-				return "", errors.Wrap(err, "failed to parse xml path")
+				return "", fmt.Errorf("failed to parse xml path: %w", err)
 			}
 			for _, e := range doc.FindElementsPath(path) {
 				attr := e.SelectAttr(k)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -314,7 +314,6 @@ github.com/opencontainers/runc/libcontainer/user
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
@@ -489,6 +488,7 @@ gopkg.in/square/go-jose.v2/json
 # gopkg.in/yaml.v2 v2.4.0
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+## explicit
 gopkg.in/yaml.v3
 # k8s.io/api v0.22.5 => k8s.io/api v0.21.14
 ## explicit


### PR DESCRIPTION
## Why we need this change

NeuVector uses logrus custom formatter to print log messages.  This is done at below:

https://github.com/neuvector/neuvector/blob/315badd1e7b085485b8cf295b0e899ec63a3eb73/share/utils/utils.go#L857

However, when `%+v` is used, the error created by github.com/pkg/errors will print stacktrace, which is not desirable. 

Since go supports error-wrapping starting in 1.13, this PR removes github.com/pkg/errors and uses standard library for internal mapping.

## Tests performed

1. Changed the RSA_KEYSIZE to `1` and observed error message.  Those errors are wrapped correctly.
```
2024-01-04T15:24:47.705|ERRO|CTL|kv.GenTlsKeyCert: failed to load ca key pair - error=open /etc/neuvector/certs/internal/adm_ca.cert: no such file or directory
2024-01-04T15:24:47.706|ERRO|CTL|kv.GenTlsCertWithCaAndStoreInKv: wrong cert/key - certPath=/etc/neuvector/certs/neuvector-svc-admission-webhook.neuvector.svc.cert.pem error=failed to generate tls key/cert: failed to load ca key pair: open /etc/neuvector/certs/internal/adm_ca.cert: no such file or directory keyPath=/etc/neuvector/certs/neuvector-svc-admission-webhook.neuvector.svc.key.pem
2024-01-04T15:24:47.706|ERRO|CTL|kv.ValidateWebhookCert: failed to generate Webhook certs - error=failed to generate tls key/cert: failed to load ca key pair: open /etc/neuvector/certs/internal/adm_ca.cert: no such file or directory
```
2. Verified with a wrong password.  The error can be printed correctly.  
```
2024-01-04T15:35:17.988|INFO|CTL|rest.handlerAuthLogin: - error=Wrong password user=admin
2024-01-04T15:35:17.988|ERRO|CTL|rest.handlerAuthLogin: User login failed - msg=Wrong password user=admin
```