### PR TITLE
NVSHAS-8460 fix for UI showing in-complete message

### DIFF
--- a/controller/rest/bench.go
+++ b/controller/rest/bench.go
@@ -2,7 +2,6 @@ package rest
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"sort"
@@ -80,9 +79,6 @@ func bench2REST(bench share.BenchType, item *share.CLUSBenchItem, cpf *complianc
 
 	for _, m := range item.Message {
 		r.Message = append(r.Message, m)
-	}
-	if len(r.Message) > 0 {
-		r.Description = fmt.Sprintf("%s - %s", r.Description, r.Message[0])
 	}
 
 	// add tags


### PR DESCRIPTION
### Summary
Since we add more message, we should remove this to avoid confusion

### How to verify
enforcer: [docker.io/pohanhuangtw/enforcer:8460](http://docker.io/pohanhuangtw/enforcer:8460)
controller: [docker.io/pohanhuangtw/controller:8460](http://docker.io/pohanhuangtw/controller:8460)

### Before
5.1.4 Minimize access to create pods - Review the users who have create access to pod objects in the Kubernetes API with the following command:
### After
5.1.4 Minimize access to create pods 
