### PR TITLE
NVSHAS-8396: Fix strlcpy() without using Null-terminated string as src

### DIFF
--- a/dp/dpi/dpi_entry.c
+++ b/dp/dpi/dpi_entry.c
@@ -139,13 +139,15 @@ void dpi_ep_set_app(dpi_packet_t *p, uint16_t server, uint16_t application)
 void dpi_ep_set_server_ver(dpi_packet_t *p, char *ver, int len)
 {
     dpi_session_t *s = p->session;
+    int size = min(len, SERVER_VER_SIZE - 1);
 
     if (!(s->flags & DPI_SESS_FLAG_INGRESS)) return;
 
     io_app_t *app = ep_app_map_locate(p->ep, s->server.port, s->ip_proto);
     if (unlikely(app == NULL)) return;
 
-    strlcpy(app->version, ver, min(len + 1, SERVER_VER_SIZE));
+    strncpy(app->version, ver, size);
+    app->version[size] = '\0';
 
     DEBUG_LOG(DBG_SESSION, p, "port=%u version=%s\n", s->server.port, app->version);
 }

--- a/dp/dpi/dpi_msg.c
+++ b/dp/dpi/dpi_msg.c
@@ -408,6 +408,17 @@ static void dpi_dump_policy()
         }
     }
 
+    if (th_ip_fqdn_storage_map.map != NULL) {
+        struct cds_lfht_node *ip_fqdn_storage_node;
+        // Iterate through ip fqdn storage map
+        RCU_MAP_FOR_EACH(&th_ip_fqdn_storage_map, ip_fqdn_storage_node) {
+            dpi_ip_fqdn_storage_entry_t *entry = STRUCT_OF(ip_fqdn_storage_node, dpi_ip_fqdn_storage_entry_t, node);
+            fprintf(logfp, "IP-FQDN storage map, IP:"DBG_IPV4_FORMAT" FQDN name:%s\n", DBG_IPV4_TUPLE(entry->r->ip), entry->r->name);
+
+            fflush(logfp);
+        }
+    }
+
     if (dlp_detector != NULL)
     {
         dpi_print_siglist_fp(dlp_detector, logfp);

--- a/dp/dpi/parsers/dpi_http.c
+++ b/dp/dpi/parsers/dpi_http.c
@@ -596,13 +596,14 @@ static int http_header_xforwarded_for_token(void *param, uint8_t *ptr, int len, 
         }
         l ++;
     }
-    ip_str_len = l-ptr+1;
+    ip_str_len = l-ptr;
 
-    ip_str = (char *) calloc(ip_str_len, sizeof(char));
+    ip_str = (char *) calloc(ip_str_len + 1, sizeof(char));
     if (ip_str == NULL) {
         return CONSUME_TOKEN_SKIP_LINE;
     }
-    strlcpy(ip_str, (char *)ptr, ip_str_len);
+    strncpy(ip_str, (char *)ptr, ip_str_len);
+    ip_str[ip_str_len] = '\0';
     s->xff_client_ip = inet_addr(ip_str);
     if (s->xff_client_ip == (uint32_t)(-1)) {
         DEBUG_LOG(DBG_PARSER, p, "ipv6 or wrong format ipv4: %s, ip=0x%08x\n",ip_str, s->xff_client_ip);
@@ -638,10 +639,12 @@ static int http_header_host_token(void *param, uint8_t *ptr, int len, int token_
         }
         l ++;
     }
-    host_str_len = l-ptr+1;
+    host_str_len = l-ptr;
 
-    strlcpy((char *)s->vhost, (char *)ptr, host_str_len);
-    s->vhlen = host_str_len - 1;
+    strncpy((char *)s->vhost, (char *)ptr, host_str_len);
+    s->vhost[host_str_len] = '\0';
+
+    s->vhlen = host_str_len;
     DEBUG_LOG(DBG_PARSER, p, "vhostname(%s) vhlen(%hu)\n", (char *)s->vhost, s->vhlen);
 
     return CONSUME_TOKEN_SKIP_LINE;

--- a/dp/dpi/parsers/dpi_ssl.c
+++ b/dp/dpi/parsers/dpi_ssl.c
@@ -281,7 +281,8 @@ void ssl_get_sni_v3(dpi_packet_t *p, uint8_t *ptr, ssl_record_t *rec)
             uint16_t namelen = GET_BIG_INT16(tptr);
             tptr += 2;
             //DEBUG_LOG(DBG_PARSER, p, "ssl: snilen(%hu), sniname(%s)\n", namelen,(char *)tptr);
-            strlcpy((char *)s->vhost, (char *)tptr, namelen+1);
+            strncpy((char *)s->vhost, (char *)tptr, namelen);
+            s->vhost[namelen] = '\0';
             s->vhlen = namelen;
             tptr += namelen;
             break;


### PR DESCRIPTION
1. For strlcpy(), src must be Null-terminated string.
2. Add debug print to dump ip-fqdn storage map.