### PR TITLE
NVSHAS-8613 repeated sigsegv in one controller

### DIFF
--- a/controller/cache/automode.go
+++ b/controller/cache/automode.go
@@ -50,6 +50,7 @@ func automode_m2p_test_func(group string, probeDuration int64) (bool, error) {
 		traceback := time.Now().Unix() - probeDuration - 10
 
 		// process incidents
+		syncRLock(syncCatgIncidentIdx)
 		for i := 0; i < curIncidentIndex; i++ {
 			incd := incidentCache[curIncidentIndex-i-1]
 			if incd == nil || incd.AggregationFrom < traceback {
@@ -61,8 +62,10 @@ func automode_m2p_test_func(group string, probeDuration int64) (bool, error) {
 				incd_last = incd
 			}
 		}
+		syncRUnlock(syncCatgIncidentIdx)
 
 		// suspicious threats
+		syncRLock(syncCatgThreatIdx)
 		for i := 0; i < curThrtIndex; i++ {
 			thrt := thrtCache[curThrtIndex-i-1]
 			if thrt == nil || thrt.ReportedTimeStamp < traceback {
@@ -74,8 +77,10 @@ func automode_m2p_test_func(group string, probeDuration int64) (bool, error) {
 				thrt_last = thrt
 			}
 		}
+		syncRUnlock(syncCatgThreatIdx)
 
 		// network violations
+		syncRLock(syncCatgViolationIdx)
 		service := strings.TrimPrefix(group, "nv.")
 		for i := 0; i < curVioIndex; i++ {
 			vio := vioCache[curVioIndex-i-1]
@@ -88,6 +93,7 @@ func automode_m2p_test_func(group string, probeDuration int64) (bool, error) {
 				vio_last = vio
 			}
 		}
+		syncRUnlock(syncCatgViolationIdx)
 
 		if count > 0 {
 			log.WithFields(log.Fields{"incident": count, "group": group, "incd_last": incd_last, "thrt_last": thrt_last, "vio_last": vio_last}).Debug("ATMO:")
@@ -292,7 +298,7 @@ func automodeConfigUpdate(cfg, cache share.CLUSSystemConfig) {
 	}
 }
 
-//////////////////////
+// ////////////////////
 func automodeGroupDelete(name string, param interface{}) {
 	log.WithFields(log.Fields{"group": name}).Debug("ATMO:")
 	if bD2M, bM2P := atmoHelper.Enabled(); bD2M || bM2P {

--- a/controller/cache/learn.go
+++ b/controller/cache/learn.go
@@ -723,7 +723,7 @@ func unlearnAll(groupName string) {
 	}
 }
 
-//reduce maxLearnRuleID when delete rules
+// reduce maxLearnRuleID when delete rules
 func adjustMaxLearnRuleID(id uint32) {
 	lprActiveRuleIDs.Remove(id)
 	if id == maxLearnRuleID {
@@ -1501,10 +1501,12 @@ func syncGraphTx() *syncDataMsg {
 		i++
 	}
 
+	syncRLock(syncCatgViolationIdx)
 	var violations []*api.Violation
 	if curVioIndex > 0 {
 		violations = vioCache[0:curVioIndex]
 	}
+	syncRUnlock(syncCatgViolationIdx)
 
 	learnedRules := make([]*graphSyncLearnedRule, 0, len(lprWrapperMap))
 	for pair, rw := range lprWrapperMap {
@@ -1629,11 +1631,18 @@ func syncGraphRx(msg *syncDataMsg) int {
 				}
 			}
 
-			curVioIndex = len(gd.Vios)
-			for i, vio := range gd.Vios {
+			syncLock(syncCatgViolationIdx)
+			num := 0
+			for _, vio := range gd.Vios {
+				if vio == nil {
+					continue
+				}
 				vio.Level = api.UpgradeLogLevel(vio.Level)
-				vioCache[i] = vio
+				vioCache[num] = vio
+				num++
 			}
+			curVioIndex = num
+			syncUnlock(syncCatgViolationIdx)
 
 			maxLearnRuleID = gd.MaxLearnRuleID
 			//after sync clear active rule id list

--- a/controller/cache/sync.go
+++ b/controller/cache/sync.go
@@ -26,7 +26,7 @@ type syncCatgInfo struct {
 
 type syncCatgAux struct {
 	modifyIdx uint64
-	mtx       sync.Mutex
+	mtx       sync.RWMutex
 }
 
 const (
@@ -57,9 +57,10 @@ const (
 	syncCatgIncidentIdx
 	syncCatgAuditIdx
 	syncCatgActivityIdx
+	syncCatgViolationIdx
 )
 
-var syncCatgAuxArray []syncCatgAux = make([]syncCatgAux, 6)
+var syncCatgAuxArray []syncCatgAux = make([]syncCatgAux, 7)
 
 const (
 	syncCatgEvent    = "event"
@@ -113,6 +114,14 @@ func syncLock(catg int) {
 
 func syncUnlock(catg int) {
 	syncCatgAuxArray[catg].mtx.Unlock()
+}
+
+func syncRLock(catg int) {
+	syncCatgAuxArray[catg].mtx.RLock()
+}
+
+func syncRUnlock(catg int) {
+	syncCatgAuxArray[catg].mtx.RUnlock()
 }
 
 func GetSyncTxData(catgName string) []byte {
@@ -455,6 +464,7 @@ func putHotSyncRequest() int {
 }
 
 var lastSyncAt time.Time
+
 const GraphNodeCountSmall uint32 = 500
 const GraphNodeCountMedium uint32 = 1500
 const GraphNodeCountLarge uint32 = 3000
@@ -484,10 +494,10 @@ func syncCheck(isLeader bool) {
 	if len(ss.Mismatches) > 0 && !syncInProcess {
 
 		log.WithFields(log.Fields{
-			"graphcnt": ss.GraphNodeCount,
+			"graphcnt":   ss.GraphNodeCount,
 			"lastSyncAt": api.RESTTimeString(lastSyncAt),
-			"now": api.RESTTimeString(time.Now().UTC()),
-			}).Debug("")
+			"now":        api.RESTTimeString(time.Now().UTC()),
+		}).Debug("")
 		//sync consumes large memory, when cluster has large number of
 		//groups it affects cluster ramping up performance, so we ratelimit
 		//sync frequence based on number of GraphNodeCount


### PR DESCRIPTION
## Why we need this change

User reported that they saw repeated crashes with sigsegv in one controller and it can't be recovered automatically.  After running `kubectl rollout restart`, the issue is gone.  

After reviewing code, it's likely that the oldest/leader controller hit a race condition, which resulted in a corrupted audit event cache.

In this PR, proper protection is added to all slicers and maps, so these objects will not be corrupted.

Another check is also added in Rx side, so already corrupted data can be corrected.

## Tests performed

Sanity test that includes:
1. Generate kube bench and container scan (audit)
2. Generate process events (incidents) and network events (violation)
3. Generate ICMP flood events (threat) 
4. Do rolling update and verifies these events still come back normal.
5. Verify container events using CLI (activity)
6. Verify events using console.  (events)