### PR TITLE
NVSHAS-8626: accepted alerts selection is not reset after rolling upgrade

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -590,7 +590,14 @@ func main() {
 	// upgrade case, (not new cluster), the new controller (not a lead) should upgrade
 	// the KV so it can behave correctly. The old lead won't be affected, in theory.
 	if Ctrler.Leader || !isNewCluster {
-		clusHelper.UpgradeClusterKV(Version)
+		nvImageVersion := Version
+		if strings.HasPrefix(nvImageVersion, "interim/") {
+			// it's daily dev build image
+			if *teleCurrentVer != "" {
+				nvImageVersion = *teleCurrentVer
+			}
+		}
+		clusHelper.UpgradeClusterKV(nvImageVersion)
 		clusHelper.FixMissingClusterKV()
 	}
 


### PR DESCRIPTION
For testing purpose, we need to allow overriding controller image version info like we did for upgrade responder.
