### PR TITLE
NVSHAS-8622: unexpected NV.Protect incidents is found on support command

### DIFF
--- a/agent/policy/process.go
+++ b/agent/policy/process.go
@@ -386,6 +386,7 @@ func buildManagerProfileList(serviceGroup string) *share.CLUSProcessProfile {
 		// python
 		{"support", "*"}, // support
 		{"cli", "*"},     // cli
+		{"python", "/usr/bin/*"},// cli
 		{"*", "/usr/lib/jvm/*"}, // JVM
 
 		// tools


### PR DESCRIPTION
Add a process rule.