### PR TITLE
NVSHAS-8613 repeated sigsegv in one controller

### DIFF
--- a/controller/cache/scan.go
+++ b/controller/cache/scan.go
@@ -575,7 +575,9 @@ func scanDone(id string, objType share.ScanObjectType, report *share.CLUSScanRep
 	// all controller should call auditUpdate to record the log, the leader will take action
 	if alives != nil {
 		clog := scanReport2ScanLog(id, objType, report, highs, meds, nil, nil, "")
+		syncLock(syncCatgAuditIdx)
 		auditUpdate(id, share.EventCVEReport, objType, clog, alives, fixedHighsInfo)
+		syncUnlock(syncCatgAuditIdx)
 	}
 }
 
@@ -1006,11 +1008,15 @@ func registryImageStateHandler(nType cluster.ClusterNotifyType, key string, valu
 				if fedRole != api.FedRoleJoint || !strings.HasPrefix(name, api.FederalGroupPrefix) {
 					if alives != nil {
 						clog := scanReport2ScanLog(id, share.ScanObjectType_IMAGE, report, highs, meds, layerHighs, layerMeds, name)
+						syncLock(syncCatgAuditIdx)
 						auditUpdate(id, share.EventCVEReport, share.ScanObjectType_IMAGE, clog, alives, fixedHighsInfo)
+						syncUnlock(syncCatgAuditIdx)
 					}
 
 					clog := scanReport2BenchLog(id, share.ScanObjectType_IMAGE, report, name)
+					syncLock(syncCatgAuditIdx)
 					benchUpdate(share.EventCompliance, clog)
+					syncUnlock(syncCatgAuditIdx)
 				}
 
 				if fedRegName != "" {

--- a/controller/cache/sync.go
+++ b/controller/cache/sync.go
@@ -26,7 +26,7 @@ type syncCatgInfo struct {
 
 type syncCatgAux struct {
 	modifyIdx uint64
-	mtx       sync.Mutex
+	mtx       sync.RWMutex
 }
 
 const (
@@ -113,6 +113,14 @@ func syncLock(catg int) {
 
 func syncUnlock(catg int) {
 	syncCatgAuxArray[catg].mtx.Unlock()
+}
+
+func syncRLock(catg int) {
+	syncCatgAuxArray[catg].mtx.RLock()
+}
+
+func syncRUnlock(catg int) {
+	syncCatgAuxArray[catg].mtx.RUnlock()
 }
 
 func GetSyncTxData(catgName string) []byte {
@@ -455,6 +463,7 @@ func putHotSyncRequest() int {
 }
 
 var lastSyncAt time.Time
+
 const GraphNodeCountSmall uint32 = 500
 const GraphNodeCountMedium uint32 = 1500
 const GraphNodeCountLarge uint32 = 3000
@@ -484,10 +493,10 @@ func syncCheck(isLeader bool) {
 	if len(ss.Mismatches) > 0 && !syncInProcess {
 
 		log.WithFields(log.Fields{
-			"graphcnt": ss.GraphNodeCount,
+			"graphcnt":   ss.GraphNodeCount,
 			"lastSyncAt": api.RESTTimeString(lastSyncAt),
-			"now": api.RESTTimeString(time.Now().UTC()),
-			}).Debug("")
+			"now":        api.RESTTimeString(time.Now().UTC()),
+		}).Debug("")
 		//sync consumes large memory, when cluster has large number of
 		//groups it affects cluster ramping up performance, so we ratelimit
 		//sync frequence based on number of GraphNodeCount


### PR DESCRIPTION
## Why we need this change

This is a rework of https://github.com/neuvector/neuvector/pull/1172.

In the previous PR, some existing code paths already lock the mutex.  When `recordAudit()` is called, it caused double lock and resulted in deadlock.  In this PR, the lock is moved to `scanDone()` and `registryImageStateHandler()`. 

## Tests performed
Sanity test that includes:

1. Fresh install and trigger node/container/image scans a few times.
2. Upgrade and trigger scans a few times.
3. Make sure the data is still persistent after rolling update via `kubectl rollout restart deployment neuvector-controller-pod`. 