### PR TITLE
NVSHAS-8572: secrets/vul scanning engine does not ignore mounted files

### DIFF
--- a/share/scan/scan_utils.go
+++ b/share/scan/scan_utils.go
@@ -251,6 +251,9 @@ func (s *ScanUtil) getContainerAppPkg(pid int) ([]byte, error) {
 				return filepath.SkipDir
 			}
 		} else if info.Mode().IsRegular() && info.Size() > 0 {
+			if utils.IsMountPoint(path) {
+				return nil
+			}
 			inpath := path[rootLen:]
 			apps.extractAppPkg(inpath, path)
 		}

--- a/share/scan/secrets/secrets.go
+++ b/share/scan/secrets/secrets.go
@@ -673,6 +673,10 @@ func FindSecretsByRootpath(rootPath string, envVars []byte, config Config) ([]sh
 				return filepath.SkipDir
 			}
 		} else {
+			if utils.IsMountPoint(path) {
+				return nil
+			}
+
 			////
 			if p, yes := hasChangeAccessPerm(inpath, info.Mode()); yes {
 				log.WithFields(log.Fields{"set-perm": perm}).Debug()


### PR DESCRIPTION
Patch a hole that we still scan the "hostPath" files from the k8s-mounted folders. Standalone allinone with the docker engine will not occur.