### PR TITLE
NVSHAS-8678 - Fix for UI showing in-complete message

### DIFF
--- a/controller/rest/bench.go
+++ b/controller/rest/bench.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"sort"
@@ -79,6 +80,11 @@ func bench2REST(bench share.BenchType, item *share.CLUSBenchItem, cpf *complianc
 
 	for _, m := range item.Message {
 		r.Message = append(r.Message, m)
+	}
+
+	if len(r.Message) > 0 {
+		allMessages := strings.Join(r.Message, ", ")
+		r.Description = fmt.Sprintf("%s - %s", r.Description, allMessages)
 	}
 
 	// add tags


### PR DESCRIPTION
### Summary
Since we add more message, we append all message to the desriptions.

### How to verify
controller: [docker.io/pohanhuangtw/controller:8678](http://docker.io/pohanhuangtw/controller:8678)

Before
5.1.4 Minimize access to create pods

After
5.1.4 Minimize access to create pods - Review the users who have create access to pod objects in the Kubernetes API with the following command:, rest of the messages.

### Related PR
https://github.com/neuvector/neuvector/pull/1162