### PR TITLE
NVSHAS-8224, batch delete empty groups to improve auto removal performance

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -1665,11 +1665,13 @@ const unManagedWlProcDelayFast = time.Duration(time.Minute * 2)
 const unManagedWlProcDelaySlow = time.Duration(time.Minute * 8)
 const pruneKVPeriod = time.Duration(time.Minute * 30)
 const pruneGroupPeriod = time.Duration(time.Minute * 1)
+const rmEmptyGroupPeriod = time.Duration(time.Minute * 1)
 
 var unManagedWlTimer *time.Timer
 
 func startWorkerThread(ctx *Context) {
 	ephemeralTicker := time.NewTicker(workloadEphemeralPeriod)
+	emptyGrpTicker := time.NewTicker(rmEmptyGroupPeriod)
 	scannerTicker := time.NewTicker(scannerCleanupPeriod)
 	usageReportTicker := time.NewTicker(usageReportPeriod)
 	unManagedWlTimer = time.NewTimer(unManagedWlProcDelaySlow)
@@ -1720,6 +1722,8 @@ func startWorkerThread(ctx *Context) {
 				}
 			case <-pruneTicker.C:
 				pruneGroupsByNamespace()
+			case <-emptyGrpTicker.C:
+				rmEmptyGroupsFromCluster()
 			case <-unManagedWlTimer.C:
 				cacheMutexRLock()
 				refreshInternalIPNet()

--- a/controller/cache/group.go
+++ b/controller/cache/group.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
+	"sync"
 	"strings"
 	"time"
 
@@ -1001,6 +1002,9 @@ type groupRemovalEvent struct {
 	groupname string
 }
 
+var emptyGroups []string
+var emptyGroupsMutex sync.Mutex
+
 func (p *groupRemovalEvent) Expire() {
 	cacheMutexLock()
 	if cache, ok := groupCacheMap[p.groupname]; ok {
@@ -1017,13 +1021,60 @@ func (p *groupRemovalEvent) Expire() {
 		//is really deleted or not
 		cache.timerTask = ""
 		cacheMutexUnlock()
-		deleted := deleteGroupFromCluster(p.groupname)
 
-		if deleted {
-			groupRemoveEvent(share.CLUSEvGroupAutoRemove, p.groupname)
-		}
+		//log.WithFields(log.Fields{"group": p.groupname}).Info("To be deleted")
+		emptyGroupsMutex.Lock()
+		emptyGroups = append(emptyGroups, p.groupname)
+		emptyGroupsMutex.Unlock()
 	} else {
 		cacheMutexUnlock()
+	}
+}
+
+func rmEmptyGroupsFromCluster() {
+	if isLeader() == false {
+		return
+	}
+	emptyGroupsMutex.Lock()
+	groups := emptyGroups
+	emptyGroups = nil
+	emptyGroupsMutex.Unlock()
+
+	if len(groups) <= 0 {
+		return
+	}
+
+	lock, err := clusHelper.AcquireLock(share.CLUSLockPolicyKey, clusterLockWait)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("Acquire lock error")
+		return
+	}
+	defer clusHelper.ReleaseLock(lock)
+
+	//log.WithFields(log.Fields{"groups": groups}).Debug("")
+	kv.DeletePolicyByGroups(groups)
+	kv.DeleteResponseRuleByGroups(groups)
+
+	accAll := access.NewAdminAccessControl()
+	txn := cluster.Transact()
+	defer txn.Close()
+
+	for _, name := range groups {
+		cg, _, _ := clusHelper.GetGroup(name, accAll)
+		if cg == nil {
+			log.WithFields(log.Fields{"group": name}).Error("Group doesn't exist in kv")
+			if _, ok := groupCacheMap[name]; ok {
+				delete(groupCacheMap, name)
+			}
+		} else {
+			clusHelper.DeleteGroupTxn(txn, name)
+		}
+	}
+	if ok, err1 := txn.Apply(); err1 != nil || !ok {
+		log.WithFields(log.Fields{"ok": ok, "error": err1}).Error("Atomic write to the cluster failed")
+	}
+	for _, name := range groups {
+		groupRemoveEvent(share.CLUSEvGroupAutoRemove, name)
 	}
 }
 


### PR DESCRIPTION
In customer's case, there are more than 1500 empty groups schedule to be removed at the same time, when scheduled task expire, each task is executed with one goroutine, each task tries to AcquireLock which cause error message "Your IP is issuing too many concurrent connections, please rate limit your calls"
The solution is for each expired task only save group name to a groups slice, and 1 minute ticker is added to remove empty groups in batch, DeletePolicyByGroups and DeleteResponseRuleByGroups by groups also saves much more time than delete by single group