### PR TITLE
NVSHAS-5391 & 8631 Improve Host i/f update monitoring

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -35,6 +35,8 @@ var errRestartChan chan interface{} = make(chan interface{}, 1)
 var restartChan chan interface{} = make(chan interface{}, 1)
 var monitorExitChan chan interface{} = make(chan interface{}, 1)
 
+var monitorHostIfaceStopCh chan struct{} = make(chan struct{})
+
 var Host share.CLUSHost = share.CLUSHost{
 	Platform: share.PlatformDocker,
 	Network:  share.NetworkDefault,
@@ -74,6 +76,7 @@ func isAgentContainer(id string) bool {
 }
 
 func getHostIPs() {
+	gInfo.linkStates = getHostLinks()
 	addrs := getHostAddrs()
 	Host.Ifaces, gInfo.hostIPs, gInfo.jumboFrameMTU, gInfo.ciliumCNI = parseHostAddrs(addrs, Host.Platform, Host.Network)
 	if tun := global.ORCH.GetHostTunnelIP(addrs); tun != nil {
@@ -438,6 +441,9 @@ func main() {
 		time.Sleep(time.Second * 4)
 	}
 
+	//NVSHAS-6638,monitor host to see whether there is i/f or IP changes
+	go StartMonitorHostInterface(Host.ID, 1, monitorHostIfaceStopCh)
+
 	// Check anti-affinity
 	var retry int
 	retryDuration := time.Duration(time.Second * 2)
@@ -651,8 +657,6 @@ func main() {
 	Agent.JoinedAt = time.Now().UTC()
 	putLocalInfo()
 	logAgent(share.CLUSEvAgentJoin)
-	//NVSHAS-6638,monitor host to see whether there is i/f or IP changes
-	prober.StartMonitorHostInterface(Host.ID, 1)
 
 	clusterLoop(existing)
 	existing = nil
@@ -703,6 +707,7 @@ func main() {
 	fileWatcher.Close()
 	bench.Close()
 
+	close(monitorHostIfaceStopCh) // stop host interface monitor 
 	stopMonitorLoop()
 	closeCluster()
 

--- a/agent/agent_linux.go
+++ b/agent/agent_linux.go
@@ -21,6 +21,21 @@ func getHostAddrs() map[string]sk.NetIface {
 	return ifaces
 }
 
+func getHostLinks() map[string]bool {
+	var linkAttrs map[string]sk.NetLinkAttrs
+	links := make(map[string]bool)
+
+	global.SYS.CallNetNamespaceFunc(1, func(params interface{}) {
+		linkAttrs = sk.GetNetLinkAttrs()
+	}, nil)
+
+	for name, linkAttr := range linkAttrs {
+		links[name] = linkAttr.OperState
+	}
+
+	return links
+}
+
 /*
 With Azure advanced networking plugin:
  link - link=eth0 type=device

--- a/agent/probe/intf.go
+++ b/agent/probe/intf.go
@@ -15,7 +15,7 @@ var intfMonitorPollTimeoutShort = syscall.Timeval{0, 500000}
 
 type intfMonitorInterface interface {
 	WaitAddrChange(*syscall.Timeval) (bool, error)
-	WaitHostAddrChange(*syscall.Timeval) (bool, error)
+	WaitHostAddrChange(*syscall.Timeval) (bool, error) // obsolete
 	Close()
 }
 
@@ -89,6 +89,7 @@ func (p *Probe) StopMonitorInterface(id string) {
 	}
 }
 
+// obsolete
 func (p *Probe) intfHostMonitorLoop(hid string, m intfMonitorInterface, stopCh chan struct{}) {
 	toNotify := false
 	pollTimeout := intfMonitorPollTimeoutLong
@@ -120,6 +121,7 @@ func (p *Probe) intfHostMonitorLoop(hid string, m intfMonitorInterface, stopCh c
 	}
 }
 
+// obsolete
 func (p *Probe) StartMonitorHostInterface(hid string, pid int) {
 	log.WithFields(log.Fields{"hostid": hid}).Debug("")
 

--- a/agent/probe/intf_linux.go
+++ b/agent/probe/intf_linux.go
@@ -103,6 +103,8 @@ func (m *netlinkIntfMonitor) WaitAddrChange(intval *syscall.Timeval) (bool, erro
 	}
 }
 
+// obsolete
+// use netlink.LinkUpdate and netlink.AddrUpdate
 func (m *netlinkIntfMonitor) WaitHostAddrChange(intval *syscall.Timeval) (bool, error) {
 	for {
 		// select() changes timer value, so reinitiate every time.

--- a/agent/probe/types.go
+++ b/agent/probe/types.go
@@ -47,7 +47,7 @@ const (
 	PROBE_REPORT_FILE_MODIFIED
 	PROBE_REPORT_PROCESS_VIOLATION
 	PROBE_REPORT_PROCESS_DENIED
-	PROBE_HOST_NEW_IP
+	PROBE_HOST_NEW_IP              // obsolete
 )
 
 var ProbeMsgName = []string{
@@ -61,7 +61,7 @@ var ProbeMsgName = []string{
 	PROBE_REPORT_FILE_MODIFIED:     "file_modified",
 	PROBE_REPORT_PROCESS_VIOLATION: "process_profile_violation",
 	PROBE_REPORT_PROCESS_DENIED:    "process_profile_denied",
-	PROBE_HOST_NEW_IP:         		"host_new_ip",
+	PROBE_HOST_NEW_IP:         		"host_new_ip",               // obsolete
 }
 
 type ProbeMessage struct {

--- a/share/system/sidekick/net_linux.go
+++ b/share/system/sidekick/net_linux.go
@@ -22,6 +22,12 @@ type NetIface struct {
 	Addrs []NetAddr `json:"addrs"`
 }
 
+type NetLinkAttrs struct {
+	Index     int    `json:"index"`
+	Name      string `json:"name"`
+	OperState bool   `json:"OperState"`
+}
+
 func GetGlobalAddrs() map[string]NetIface {
 	ifaces := make(map[string]NetIface)
 
@@ -89,4 +95,27 @@ func GetRouteIfaceAddr(ip net.IP) (string, *net.IPNet, error) {
 	}
 
 	return link.Attrs().Name, addrs[0].IPNet, nil
+}
+
+func GetNetLinkAttrs() map[string]NetLinkAttrs {
+	linkAttrs := make(map[string]NetLinkAttrs)
+
+	links, err := netlink.LinkList()
+	if err != nil {
+		return linkAttrs
+	}
+
+	for _, link := range links {
+		attrs := link.Attrs()
+
+		linkAttr := NetLinkAttrs{
+			Index:     attrs.Index,
+			Name:      attrs.Name,
+			OperState: attrs.OperState == netlink.OperUp,
+		}
+
+		linkAttrs[attrs.Name] = linkAttr
+	}
+
+	return linkAttrs
 }


### PR DESCRIPTION
1. Use netlink.LinkSubscribe() and netlink.AddrSubscribe() to monitor link and ip address changes
2. Add cache for link state and host ips to do comparison
3. Move Host i/f change monitoring from Probe to engine.go