### PR TITLE
NVSHAS-8716: reverse API version change

### DIFF
--- a/share/container/dockerclient/dockerclient.go
+++ b/share/container/dockerclient/dockerclient.go
@@ -27,8 +27,7 @@ const (
 	// ListVolumes, {Remove,Create}Volume, ListNetworks,
 	// {Inspect,Create,Connect,Disconnect,Remove}Network (v1.21)
 	// Feb1, 2024: API versions before v1.24 are deprecated.
-	APIVersion = "v1.21"
-	APIVersion124 = "v1.24"
+	APIVersion = "v1.24"
 )
 
 var (
@@ -632,7 +631,7 @@ func (client *DockerClient) TagImage(nameOrID string, repo string, tag string, f
 }
 
 func (client *DockerClient) Version() (*Version, error) {
-	uri := fmt.Sprintf("/%s/version", APIVersion124)
+	uri := fmt.Sprintf("/%s/version", APIVersion)
 	data, err := client.doRequest("GET", uri, nil, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Reverse the PR#1219 and keep the docker API at the v1.24. Need to solve the scanner issue at NVSHAS-8718.