### PR TITLE
NVSHAS-8752: Increase container task channel size to 512

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -34,7 +34,7 @@ import (
 const containerWaitParentPeriod time.Duration = (time.Second * 1)
 const containerReexamIntfMax time.Duration = (time.Second * 180)
 const containerReexamIntfIPv4Min time.Duration = (time.Second * 4)
-const containerTaskChanSizeMin = 256
+const containerTaskChanSizeMin = 512
 
 var errHostModeUnsupported = errors.New("Host mode not supported")
 var errChildUnsupported = errors.New("Child container not supported")


### PR DESCRIPTION
The customer has ~180 existing containers in the cluster. Once enforcer is up, it will add those containers into cluster in ContainerTaskChan. ContainerTaskChan also has other tasks need to handle, so it may exceed the original size 256.