### PR TITLE
NVSHAS-8736: unexpected jar package alert from pod deployment

### DIFF
--- a/agent/probe/probe.go
+++ b/agent/probe/probe.go
@@ -733,9 +733,20 @@ func (p *Probe) addContainerFAccessBlackList(id string, list []string) {
 	}
 }
 
+const skipJarEventPeriod = time.Duration(time.Second * 30)
 func (p *Probe) ProcessFsnEvent(id string, files []string, finfo fileInfo) {
 	if finfo.bExec || finfo.bJavaPkg {
 		mLog.WithFields(log.Fields{"id": id, "files": files, "finfo": finfo}).Debug("FSN:")
+		p.lockProcMux()
+		c, ok := p.containerMap[id]
+		p.unlockProcMux()
+		if ok {
+			if time.Since(c.startAt) < skipJarEventPeriod {
+				mLog.WithFields(log.Fields{"start": c.startAt}).Debug("FSN: Skip jar")
+				return
+			}
+		}
+
 		if finfo.bJavaPkg && (finfo.fileType == file_added || finfo.fileType == file_deleted) {
 			p.sendFsnJavaPkgReport(id, files, finfo.fileType == file_added)
 		}

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -50,6 +50,7 @@ type procContainer struct {
 	outsider utils.Set // pid pool from outside
 	newBorn  int
 	userns   *userNs
+	startAt  time.Time
 	//map of port listened by multiple processes
 	portsMap         map[osutil.SocketInfo]*procApp
 	checkRemovedPort uint
@@ -415,6 +416,7 @@ func (p *Probe) addHost(pid int) {
 		userns:   &userNs{users: make(map[int]string), uidMin: osutil.UserUidMin},
 		portsMap: make(map[osutil.SocketInfo]*procApp),
 		fInfo:    make(map[string]*fileInfo),
+		startAt:  time.Now(),
 	}
 
 	p.containerMap[""] = c
@@ -457,6 +459,7 @@ func (p *Probe) addContainer(id string, proc *procInternal, scanMode bool) {
 		userns:   &userNs{users: make(map[int]string), uidMin: osutil.UserUidMin},
 		portsMap: make(map[osutil.SocketInfo]*procApp),
 		fInfo:    make(map[string]*fileInfo),
+		startAt:  time.Now(),
 	}
 
 	if p.containerStops.Contains(c.id) {
@@ -3215,6 +3218,7 @@ func (p *Probe) BuildProcessFamilyGroups(id string, rootPid int, bSandboxPod, bP
 				userns:   &userNs{users: make(map[int]string), uidMin: osutil.UserUidMin},
 				portsMap: make(map[osutil.SocketInfo]*procApp),
 				fInfo:    make(map[string]*fileInfo),
+				startAt: time.Now(),
 			}
 			p.containerMap[id] = c
 		} else {


### PR DESCRIPTION
Some Java pods repackage their jar package by putting some individual jars in a temporary folder. We need to filter out those events during the pod creation.