### PR TITLE
NVSHAS-8812: rootlessKeypairsOnly overrides isPrivate

### DIFF
--- a/controller/rest/sigstore.go
+++ b/controller/rest/sigstore.go
@@ -59,6 +59,10 @@ func handlerSigstoreRootOfTrustPost(w http.ResponseWriter, r *http.Request, ps h
 		Comment:              rootOfTrust.Comment,
 	}
 
+	if clusRootOfTrust.RootlessKeypairsOnly {
+		clusRootOfTrust.IsPrivate = false // RootlessKeypairsOnly overrides IsPrivate
+	}
+
 	if err := validateCLUSRootOfTrust(&clusRootOfTrust); err != nil {
 		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, err.Error())
 		return


### PR DESCRIPTION
Even though the back-end behavior is not affected by both fields being true, this was causing issues with the UI after having created a root of trust.