### PR TITLE
NVSHAS-8741: NeuVector scan shows inconsistent baseos image

### DIFF
--- a/agent/grpc.go
+++ b/agent/grpc.go
@@ -62,16 +62,19 @@ func (ss *ScanService) ScanGetFiles(ctx context.Context, req *share.ScanRunningR
 
 	var pid int
 	var data share.ScanData
+	var pidHost bool
 
 	gInfoRLock()
 	if req.Type == share.ScanObjectType_HOST {
 		pid = 1
+		pidHost = true   // default
 		if gInfo.hostScanCache != nil {
 			data.Buffer = gInfo.hostScanCache
 			data.Error = share.ScanErrorCode_ScanErrNone
 		}
 	} else if c, ok := gInfo.activeContainers[req.ID]; ok {
 		pid = c.pid
+		pidHost = (c.info.PidMode == "host")
 		if c.scanCache != nil {
 			data.Buffer = c.scanCache
 			data.Error = share.ScanErrorCode_ScanErrNone
@@ -97,6 +100,7 @@ func (ss *ScanService) ScanGetFiles(ctx context.Context, req *share.ScanRunningR
 		Id:      req.ID,
 		Kernel:  Host.Kernel,
 		ObjType: req.Type,
+		PidHost: pidHost,
 	}
 
 	bytesValue, _, err := walkerTask.Run(taskReq, req.ID)

--- a/agent/workerlet/pathWalker/pathWalker.go
+++ b/agent/workerlet/pathWalker/pathWalker.go
@@ -286,7 +286,7 @@ func (tm *taskMain) WalkPathTask(req workerlet.WalkPathRequest) {
 func (tm *taskMain) WalkPackageTask(req workerlet.WalkGetPackageRequest) {
 	var data share.ScanData
 	scanUtil := scan.NewScanUtil(tm.sys)
-	data.Buffer, data.Error = scanUtil.GetRunningPackages(req.Id, req.ObjType, req.Pid, req.Kernel)
+	data.Buffer, data.Error = scanUtil.GetRunningPackages(req.Id, req.ObjType, req.Pid, req.Kernel, req.PidHost)
 
 	// outputs:
 	output, err := json.Marshal(data)

--- a/agent/workerlet/types.go
+++ b/agent/workerlet/types.go
@@ -25,6 +25,7 @@ type WalkGetPackageRequest struct {
 	Id      string               `json:"id"`
 	Kernel  string               `json:"kernel"`
 	ObjType share.ScanObjectType `json:"objType"`
+	PidHost bool                 `json:"pidHost"`
 }
 
 type WalkSecretRequest struct {


### PR DESCRIPTION
The target container is privileged with the "pidHost" attribute. We need to adjust the base OS identification method,   