### PR TITLE
NVSHAS-7145: correct proxy update

### DIFF
--- a/controller/rest/registry_kits.go
+++ b/controller/rest/registry_kits.go
@@ -294,6 +294,7 @@ func handlerRegistryTest(w http.ResponseWriter, r *http.Request, ps httprouter.P
 			config.AuthToken = rconf.AuthToken
 			config.AuthWithToken = rconf.AuthWithToken
 			config.CreaterDomains = acc.GetAdminDomains(share.PERM_REG_SCAN)
+			config.IgnoreProxy = rconf.IgnoreProxy
 
 			if config.AuthWithToken && config.AuthToken == "" {
 				restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, "Missing authentication token")

--- a/controller/scan/image.go
+++ b/controller/scan/image.go
@@ -208,7 +208,9 @@ func (r *base) SetConfig(cfg *share.CLUSRegistryConfig) {
 	r.scanLayers = cfg.ScanLayers
 	r.scanSecrets = !cfg.DisableFiles
 	r.ignoreProxy = cfg.IgnoreProxy
-	if !r.ignoreProxy {
+	if r.ignoreProxy {
+		r.proxy = ""
+	} else {
 		r.proxy = GetProxy(cfg.Registry)
 	}
 }


### PR DESCRIPTION
Small changes, hard to find.

When running a registry test, the proxy information will now be used conditionally, based on the `use proxy` setting.
Also, when updating a registry, the proxy information will be updated correctly.