### PR TITLE
NVSHAS-8911: ProcessProfile: Child process of sshd should be reported as process violation when sshd parent is allowed but reported as suspicious process

### DIFF
--- a/agent/system.go
+++ b/agent/system.go
@@ -613,7 +613,7 @@ func cbGetLearnedGroupName(id string) (string, bool, bool) {
 	return makeLearnedGroupName(utils.NormalizeForURL(svc)), true, bNeuvector
 }
 
-func processPolicyLookup(id, riskType, pname, ppath string, pid, pgid, shellCmd int, proc *share.CLUSProcessProfileEntry) (string, string, string, string, bool, error) {
+func processPolicyLookup(id, riskType, pname, ppath string, pid, pgid, shellCmd int, ppe *share.CLUSProcessProfileEntry) (string, string, string, string, bool, error) {
 	var svcGroup string
 	var bAllowSuspicious bool
 	svc, capBlock, bNeuvector := getContainerService(id)
@@ -625,33 +625,34 @@ func processPolicyLookup(id, riskType, pname, ppath string, pid, pgid, shellCmd 
 		svcGroup = makeLearnedGroupName(utils.NormalizeForURL(svc))
 	}
 
-	mode, setting, group, err := pe.ProcessPolicyLookup(svcGroup, id, proc, pid)
+	mode, setting, group, err := pe.ProcessPolicyLookup(svcGroup, id, ppe, pid)
 	if err == nil {
 		// log.WithFields(log.Fields{"mode": mode, "group": group, "proc": proc, "pid": pid, "shellCmd": shellCmd}).Debug("PROC: ")
-		bNotInWhitelist := (proc.Uuid == share.CLUSReservedUuidNotAlllowed)
+		bNotInWhitelist := (ppe.Uuid == share.CLUSReservedUuidNotAlllowed)
 		// not in the whitelist, not a risk app, and shell script name
 		if bNotInWhitelist && riskType == "" && shellCmd == 1 {
-			proc.Action = share.PolicyActionAllow // not recording
+			ppe.Action = share.PolicyActionAllow // not recording
 		}
 
-		switch proc.Action {
+		switch ppe.Action {
 		case share.PolicyActionLearn:
-			if riskType != "" && !pe.IsAllowedSuspiciousApp(svcGroup, id, riskType) { // risky processs
+			if riskType != "" { // risky processs
+				bAllowSuspicious = pe.IsAllowedSuspiciousApp(svcGroup, id, riskType)
 				// override the action to checkApp
-				proc.Action = share.PolicyActionCheckApp
+				ppe.Action = share.PolicyActionCheckApp
 			}
 		case share.PolicyActionViolate: // policy mode decision
-			if !bNeuvector && pe.IsAllowedByParentApp(svcGroup, id, proc.Name, pname, ppath, pgid) {
-				proc.Action = share.PolicyActionAllow
+			if !bNeuvector && pe.IsAllowedByParentApp(svcGroup, id, ppe.Name, pname, ppath, pgid) {
+				ppe.Action = share.PolicyActionAllow
 				bAllowSuspicious = true
-				log.WithFields(log.Fields{"group": svcGroup, "pname": pname, "name": proc.Name}).Debug("PROC: allowed by parent")
+				log.WithFields(log.Fields{"group": svcGroup, "pname": pname, "name": ppe.Name}).Debug("PROC: allowed by parent")
 			}
 		case share.PolicyActionCheckApp, share.PolicyActionAllow: // a real policy
 			if riskType != "" {
 				bAllowSuspicious = pe.IsAllowedSuspiciousApp(svcGroup, id, riskType)
 				if !bAllowSuspicious {
 					// override the action to checkApp
-					proc.Action = share.PolicyActionCheckApp
+					ppe.Action = share.PolicyActionCheckApp
 				}
 			}
 		case share.PolicyActionDeny: // a real policy
@@ -659,17 +660,17 @@ func processPolicyLookup(id, riskType, pname, ppath string, pid, pgid, shellCmd 
 			if bNeuvector {
 				group = share.GroupNVProtect // updated
 				svcGroup = group
-				log.WithFields(log.Fields{"id": id, "name": proc.Name, "path": proc.Path}).Info("GRP: NV Protect")
-			} else if pe.IsAllowedByParentApp(svcGroup, id, proc.Name, pname, ppath, pgid) {
-				proc.Action = share.PolicyActionAllow
+				log.WithFields(log.Fields{"id": id, "name": ppe.Name, "path": ppe.Path}).Info("GRP: NV Protect")
+			} else if pe.IsAllowedByParentApp(svcGroup, id, ppe.Name, pname, ppath, pgid) {
+				ppe.Action = share.PolicyActionAllow
 				bAllowSuspicious = true
-				log.WithFields(log.Fields{"group": svcGroup, "pname": pname, "name": proc.Name}).Debug("PROC: allowed by parent")
+				log.WithFields(log.Fields{"group": svcGroup, "pname": pname, "name": ppe.Name}).Debug("PROC: allowed by parent")
 			}
 		}
 
-		if mode == share.PolicyModeEnforce && proc.Action != share.PolicyActionAllow && !capBlock {
+		if mode == share.PolicyModeEnforce && ppe.Action != share.PolicyActionAllow && !capBlock {
 			// override the action for system containers to generate alert only
-			proc.Action = share.PolicyActionViolate
+			ppe.Action = share.PolicyActionViolate
 		}
 	}
 	return mode, setting, group, svcGroup, bAllowSuspicious, err


### PR DESCRIPTION
The remote shells created by the "suspicious" daemons, like "nc" server, "sshd" and "iodined", are more complicated than the external processes.

To simplify this, we need to exclude them from the regular family-tree detection in the "zero-drift".
 ** A not-allowed suspicious process
	(1) alerted as "suspicious" events
	(2) its children: also alerted as "suspicious" events

 ** An allowed suspicious process:    
    (1) No further alerts
	(2) its children: 
	    (a) allowed: no alerts
	    (b) not-whitelisted, or deny: mark as process violations (regardless of its container's family tree relationship)