### PR TITLE
NVSHAS-7062: Enable NV build to use 1.22 golang version(update deprec…

### DIFF
--- a/agent/bench.go
+++ b/agent/bench.go
@@ -5,17 +5,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
 	"syscall"
 	"text/template"
 	"time"
+
 	"gopkg.in/yaml.v3"
-	"path/filepath"
 
 	"github.com/hashicorp/go-version"
 	log "github.com/sirupsen/logrus"
@@ -33,7 +33,7 @@ import (
 const (
 	srcSh               = "/usr/local/bin/scripts/"
 	srcTmpl             = "/usr/local/bin/scripts/tmpl/"
-	srcRem             = "/usr/local/bin/scripts/rem/"
+	srcRem              = "/usr/local/bin/scripts/rem/"
 	dstSh               = "/tmp/"
 	dstYaml             = "/usr/local/bin/scripts/cis_yamls/"
 	srcHostBenchSh      = srcTmpl + "host.tmpl"
@@ -55,16 +55,16 @@ const (
 	kube160MasterTmpl   = srcTmpl + "kube_master_1_6_0.tmpl"
 	kube160WorkerTmpl   = srcTmpl + "kube_worker_1_6_0.tmpl"
 	kube160Remediation  = srcRem + "kubecis_1_6_0.rem"
-	kubeRunnerTmpl    	= srcTmpl + "kube_runner.tmpl"
-	rhRunnerTmpl    	= srcTmpl + "rh_runner.tmpl"
-	kube160YAMLFolder	= dstYaml + "cis-1.6.0/"
-	kube123YAMLFolder	= dstYaml + "cis-1.23/"
-	kube124YAMLFolder	= dstYaml + "cis-1.24/"
-	kube180YAMLFolder	= dstYaml + "cis-1.8.0/"
-	rh140YAMLFolder		= dstYaml + "rh-1.4.0/"
-	gke140YAMLFolder  	= dstYaml + "gke-1.4.0/"
-	aks140YAMLFolder  	= dstYaml + "aks-1.4.0/"
-	eks140YAMLFolder  	= dstYaml + "eks-1.4.0/"
+	kubeRunnerTmpl      = srcTmpl + "kube_runner.tmpl"
+	rhRunnerTmpl        = srcTmpl + "rh_runner.tmpl"
+	kube160YAMLFolder   = dstYaml + "cis-1.6.0/"
+	kube123YAMLFolder   = dstYaml + "cis-1.23/"
+	kube124YAMLFolder   = dstYaml + "cis-1.24/"
+	kube180YAMLFolder   = dstYaml + "cis-1.8.0/"
+	rh140YAMLFolder     = dstYaml + "rh-1.4.0/"
+	gke140YAMLFolder    = dstYaml + "gke-1.4.0/"
+	aks140YAMLFolder    = dstYaml + "aks-1.4.0/"
+	eks140YAMLFolder    = dstYaml + "eks-1.4.0/"
 	kubeGKEMasterTmpl   = srcTmpl + "kube_master_gke_1_0_0.tmpl"
 	kubeGKEWorkerTmpl   = srcTmpl + "kube_worker_gke_1_0_0.tmpl"
 	kubeGKERemediation  = srcRem + "kubecis_gke_1_0_0.rem"
@@ -88,7 +88,7 @@ const (
 	cmdKubelet          = "kubelet"
 	cmdKubeProxy        = "kube-proxy"
 	pathBaseImageBin    = "baseImageBin"
-	pathConfigPrefix	= "configPrefix"
+	pathConfigPrefix    = "configPrefix"
 	scriptTimeout       = 1 * time.Minute
 )
 
@@ -136,7 +136,7 @@ type Bench struct {
 	kubeCISVer      string
 	dockerCISVer    string
 	taskScanner     *TaskScanner
-	cisYAMLMode	    bool
+	cisYAMLMode     bool
 }
 
 type DockerReplaceOpts struct {
@@ -156,16 +156,16 @@ type KubeCisReplaceOpts struct {
 }
 
 type Check struct {
-    ID          string `yaml:"id"`
-    Remediation string `yaml:"remediation"`
+	ID          string `yaml:"id"`
+	Remediation string `yaml:"remediation"`
 }
 
 type Group struct {
-    Checks []Check `yaml:"checks"`
+	Checks []Check `yaml:"checks"`
 }
 
 type YamlFile struct {
-    Groups []Group `yaml:"groups"`
+	Groups []Group `yaml:"groups"`
 }
 
 func newBench(platform, flavor string) *Bench {
@@ -658,9 +658,9 @@ func (b *Bench) parseBenchMsg(line string) (*benchItem, bool) {
 	}, true
 }
 
-//replace the docker daemon config line, so that can run the script without pid=host
+// replace the docker daemon config line, so that can run the script without pid=host
 func (b *Bench) replaceDockerDaemonCmdline(srcPath, dstPath string, containers []string) error {
-	dat, err := ioutil.ReadFile(srcPath)
+	dat, err := os.ReadFile(srcPath)
 	if err != nil {
 		return err
 	}
@@ -1115,7 +1115,7 @@ func (b *Bench) runScript(script string, pid int) (bool, string, error) {
 		return false, "Session ended", fmt.Errorf("Session ended")
 	}
 
-	file, err := ioutil.TempFile(os.TempDir(), "script")
+	file, err := os.CreateTemp(os.TempDir(), "script")
 	if err != nil {
 		return false, "file system error", err
 	}
@@ -1234,7 +1234,7 @@ func (b *Bench) putBenchReport(id string, bench share.BenchType, items []*benchI
 	}
 }
 
-//the script may use several command like grep netstat, check whether they exist in host
+// the script may use several command like grep netstat, check whether they exist in host
 func (b *Bench) checkRequiredHostProgs(progs []string) error {
 	for _, p := range progs {
 		dat, err := global.SYS.CheckHostProgram(p, 1)
@@ -1337,7 +1337,7 @@ func (b *Bench) getKubeVersion() string {
 }
 
 func (b *Bench) loadRemediationFromYAML(path string) map[string]string {
-    remediationMap := make(map[string]string)
+	remediationMap := make(map[string]string)
 	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			log.WithFields(log.Fields{"error": err}).Error("Error encountered while walking through the path")
@@ -1345,7 +1345,7 @@ func (b *Bench) loadRemediationFromYAML(path string) map[string]string {
 		}
 
 		if !info.IsDir() && filepath.Ext(path) == ".yaml" {
-			fileContent, err := ioutil.ReadFile(path)
+			fileContent, err := os.ReadFile(path)
 			if err != nil {
 				log.WithFields(log.Fields{"error": err}).Error("Error reading file")
 				return err // return the error encountered
@@ -1367,7 +1367,7 @@ func (b *Bench) loadRemediationFromYAML(path string) map[string]string {
 		return nil // no error, return nil
 	})
 
-	if err != nil || remediationMap == nil{
+	if err != nil || remediationMap == nil {
 		// When the filepath walk fail, fill remediationMap with a default version of remediation
 		fallbackRemediation := kube160Remediation
 		remediationMap = b.loadRemediationFromRem(fallbackRemediation)
@@ -1378,7 +1378,7 @@ func (b *Bench) loadRemediationFromYAML(path string) map[string]string {
 
 func (b *Bench) loadRemediationFromRem(path string) map[string]string {
 	remediationMap := make(map[string]string)
-	dat, err := ioutil.ReadFile(path)
+	dat, err := os.ReadFile(path)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Open remediation file fail")
 		return remediationMap
@@ -1395,19 +1395,19 @@ func (b *Bench) loadRemediationFromRem(path string) map[string]string {
 }
 
 func (b *Bench) loadRemediation(path string) map[string]string {
-    var remediationMap map[string]string
+	var remediationMap map[string]string
 
 	if b.cisYAMLMode {
 		remediationMap = b.loadRemediationFromYAML(path)
 	} else {
 		remediationMap = b.loadRemediationFromRem(path)
 	}
-    return remediationMap
+	return remediationMap
 }
 
-//replace the kubernetes cis command
+// replace the kubernetes cis command
 func (b *Bench) replaceKubeCisCmd(srcPath, dstPath string) error {
-	dat, err := ioutil.ReadFile(srcPath)
+	dat, err := os.ReadFile(srcPath)
 	if err != nil {
 		log.WithFields(log.Fields{"src": srcPath, "error": err}).Error("Open template file error")
 		return err
@@ -1529,7 +1529,7 @@ func (b *Bench) logHostCustomCheckResult(list []*benchItem) {
 	logHostAudit(logs, share.CLUSAuditComplianceHostCustomCheckViolation)
 }
 
-//////
+// ////
 func (b *Bench) runFindSecrets(rootPid int, name, id, group string) {
 	if !osutil.IsPidValid(rootPid) {
 		log.WithFields(log.Fields{"pid": rootPid}).Error("Exited")
@@ -1641,13 +1641,13 @@ type TaskScanner struct {
 	caseDone  int
 }
 
-////
+// //
 const scanWorkerMax int = 4 // 16
 const scanTimerTick int = 2 // tick at 2 sec
 const scanTimerSlow int = 5 // long period: 10 sec
 const scanTimerFast int = 1 // shorter period: 2 sec
 
-///
+// /
 func newTaskScanner(b *Bench, maxWorkers int) *TaskScanner {
 	scanTask := &TaskScanner{
 		bench:      b,
@@ -1660,7 +1660,7 @@ func newTaskScanner(b *Bench, maxWorkers int) *TaskScanner {
 	return scanTask
 }
 
-///
+// /
 func (t *TaskScanner) scanSecretLoop() {
 	bFirstScan := true
 	scanTicks := 0
@@ -1706,7 +1706,7 @@ func (t *TaskScanner) scanSecretLoop() {
 	}
 }
 
-///
+// /
 func (t *TaskScanner) nextScanTasks() bool {
 	// was locked at outside of the function
 	// log.WithFields(log.Fields{"curWorkers": t.curWorkers, "len": len(t.queue)}).Debug("SCRT")
@@ -1735,7 +1735,7 @@ func (t *TaskScanner) nextScanTasks() bool {
 	return bAddWorker
 }
 
-///
+// /
 func (t *TaskScanner) addScanTask(rootPid int, name, id, group string) {
 	// log.WithFields(log.Fields{"len": len(t.queue), "id": id, "group": group}).Debug("SCRT")
 	task := &taskScanSecrets{

--- a/agent/probe/fsn.go
+++ b/agent/probe/fsn.go
@@ -3,7 +3,6 @@ package probe
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -761,7 +760,7 @@ type BtrfsLayerData struct {
 func (fsn *FileNotificationCtr) lookupBtrfsLayerFile(rootPath, sublayer string) (string, error) {
 	// go up 2 layers, then find the "layers.json"
 	file := filepath.Join("/proc/1/root", filepath.Dir(filepath.Dir(rootPath)), "btrfs-layers", "layers.json")
-	value, err := ioutil.ReadFile(file)
+	value, err := os.ReadFile(file)
 	if err == nil {
 		var layers []BtrfsLayerData
 		if err = json.Unmarshal(value, &layers); err == nil {

--- a/agent/service.go
+++ b/agent/service.go
@@ -4,13 +4,13 @@ package main
 import "C"
 
 import (
-	"encoding/json"
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"runtime"
 	"strconv"
 	"syscall"
@@ -661,6 +661,7 @@ func (rs *RPCService) GetGroupStats(ctx context.Context, f *share.CLUSWlIDArray)
 
 	return &stats, nil
 }
+
 // --
 
 func (rs *RPCService) cbSessionCount(buf []byte, param interface{}) bool {
@@ -895,7 +896,7 @@ func (rs *RPCService) GetSnifferPcap(req *share.CLUSSnifferDownload, stream shar
 	fileList := getFileList(proc.fileNumber, proc.fileName)
 	if len(fileList) > 0 {
 		for _, fpath := range fileList {
-			if dat, err := ioutil.ReadFile(fpath); err == nil {
+			if dat, err := os.ReadFile(fpath); err == nil {
 				packet := &share.CLUSSnifferPcap{
 					Pcap: dat,
 				}

--- a/agent/workerlet/pathWalker/pathWalker.go
+++ b/agent/workerlet/pathWalker/pathWalker.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -133,7 +133,7 @@ func (tm *taskMain) ProcessRequest(walkType string) error {
 	if err != nil {
 		return err
 	}
-	byteValue, _ := ioutil.ReadAll(jsonFile)
+	byteValue, _ := io.ReadAll(jsonFile)
 	jsonFile.Close()
 
 	// selector
@@ -275,7 +275,7 @@ func (tm *taskMain) WalkPathTask(req workerlet.WalkPathRequest) {
 
 	// outputs
 	if data, err := json.Marshal(res); err == nil {
-		ioutil.WriteFile(filepath.Join(tm.workPath, workerlet.ResultJson), data, 0644)
+		os.WriteFile(filepath.Join(tm.workPath, workerlet.ResultJson), data, 0644)
 	} else {
 		log.WithFields(log.Fields{"error": err}).Error()
 	}
@@ -291,7 +291,7 @@ func (tm *taskMain) WalkPackageTask(req workerlet.WalkGetPackageRequest) {
 	// outputs:
 	output, err := json.Marshal(data)
 	if err == nil {
-		ioutil.WriteFile(filepath.Join(tm.workPath, workerlet.ResultJson), output, 0644)
+		os.WriteFile(filepath.Join(tm.workPath, workerlet.ResultJson), output, 0644)
 	}
 	tm.done <- err
 }
@@ -306,7 +306,7 @@ func (tm *taskMain) ScanSecretTask(req workerlet.WalkSecretRequest) {
 	}
 
 	var envVars []byte
-	if content, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/environ", req.Pid)); err == nil {
+	if content, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", req.Pid)); err == nil {
 		envVars = bytes.Join(bytes.Split(content, []byte{0}), []byte{'\n'})
 	} else {
 		log.WithFields(log.Fields{"pid": req.Pid}).Error("failed to read environment variables")
@@ -317,14 +317,14 @@ func (tm *taskMain) ScanSecretTask(req workerlet.WalkSecretRequest) {
 
 	// outputs: perm
 	if output, err := json.Marshal(perms); err == nil {
-		ioutil.WriteFile(filepath.Join(tm.workPath, workerlet.ResultJson), output, 0644)
+		os.WriteFile(filepath.Join(tm.workPath, workerlet.ResultJson), output, 0644)
 	} else {
 		log.WithFields(log.Fields{"error": err}).Error()
 	}
 
 	// outputs: secret
 	if output, err := json.Marshal(logs); err == nil {
-		ioutil.WriteFile(filepath.Join(tm.workPath, workerlet.ResultJson2), output, 0644)
+		os.WriteFile(filepath.Join(tm.workPath, workerlet.ResultJson2), output, 0644)
 	} else {
 		log.WithFields(log.Fields{"error": err}).Error()
 	}

--- a/agent/workerlet/tasker.go
+++ b/agent/workerlet/tasker.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -75,7 +75,7 @@ func (ts *Tasker) putInputFile(request interface{}) (string, []string, error) {
 		if _, err := os.Stat(workingPath); err != nil { // not existed
 			args = append(args, "-u", uid)
 			os.MkdirAll(workingPath, os.ModePerm)
-			if err = ioutil.WriteFile(filepath.Join(workingPath, RequestJson), data, 0644); err == nil {
+			if err = os.WriteFile(filepath.Join(workingPath, RequestJson), data, 0644); err == nil {
 				return workingPath, args, nil
 			}
 		}
@@ -86,7 +86,7 @@ func (ts *Tasker) putInputFile(request interface{}) (string, []string, error) {
 func (ts *Tasker) openResult(workingFolder, file string) ([]byte, error) {
 	jsonFile, err := os.Open(filepath.Join(workingFolder, file))
 	if err == nil {
-		byteValue, _ := ioutil.ReadAll(jsonFile)
+		byteValue, _ := io.ReadAll(jsonFile)
 		jsonFile.Close()
 		return byteValue, nil
 	}

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -1,8 +1,5 @@
 package cache
 
-// #include "../../defs.h"
-import "C"
-
 import (
 	"fmt"
 	"net"

--- a/controller/cache/cert.go
+++ b/controller/cache/cert.go
@@ -4,7 +4,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 
@@ -50,11 +50,11 @@ func certObjectUpdate(nType cluster.ClusterNotifyType, key string, value []byte)
 			dec.Unmarshal(value, &cert)
 
 			if len(cert.Key) > 0 && len(cert.Cert) > 0 {
-				if err := ioutil.WriteFile(pathInfo.keyPath, []byte(cert.Key), 0600); err == nil {
+				if err := os.WriteFile(pathInfo.keyPath, []byte(cert.Key), 0600); err == nil {
 					certData := []byte(cert.Cert)
 					b := md5.Sum(certData)
 					log.WithFields(log.Fields{"svcName": pathInfo.svcName, "cert": hex.EncodeToString(b[:])}).Info("md5")
-					if err = ioutil.WriteFile(pathInfo.certPath, certData, 0600); err == nil {
+					if err = os.WriteFile(pathInfo.certPath, certData, 0600); err == nil {
 						if localDev.Host.Platform == share.PlatformKubernetes && pathInfo.svcName != share.CLUSRootCAKey {
 							// return value of ResetCABundle() tells us whether remembered cert is different from new cert
 							if admission.ResetCABundle(pathInfo.svcName, certData) {

--- a/controller/cache/federation.go
+++ b/controller/cache/federation.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -139,7 +138,7 @@ func serializeFile(fileName string, dataBase64 string) {
 		_, err := os.Stat(fileName)
 		if err != nil && os.IsNotExist(err) {
 			if data, err := base64.StdEncoding.DecodeString(dataBase64); err == nil {
-				if err = ioutil.WriteFile(fileName, data, 0600); err == nil {
+				if err = os.WriteFile(fileName, data, 0600); err == nil {
 					return
 				} else {
 					log.WithFields(log.Fields{"error": err, "path": fileName}).Error("serialize")

--- a/controller/cache/group.go
+++ b/controller/cache/group.go
@@ -1,8 +1,5 @@
 package cache
 
-// #include "../../defs.h"
-import "C"
-
 import (
 	"encoding/json"
 	"fmt"

--- a/controller/cache/object.go
+++ b/controller/cache/object.go
@@ -1,8 +1,5 @@
 package cache
 
-// #include "../../defs.h"
-import "C"
-
 import (
 	"encoding/json"
 	"fmt"

--- a/controller/kv/cert.go
+++ b/controller/kv/cert.go
@@ -10,7 +10,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"strconv"
@@ -119,11 +118,11 @@ cleanup:
 // If data is not consistent, the data in kv will be used and files in keyPath and certPath will be modified.
 func StoreKeyCertFilesInKV(kvkey string, certPath string, keyPath string) error {
 	log.Info("store key/cert in new kv")
-	certData, err := ioutil.ReadFile(certPath)
+	certData, err := os.ReadFile(certPath)
 	if err != nil {
 		return fmt.Errorf("failed to read ca cert: %w", err)
 	}
-	keyData, err := ioutil.ReadFile(keyPath)
+	keyData, err := os.ReadFile(keyPath)
 	if err != nil {
 		return fmt.Errorf("failed to read ca key: %w", err)
 	}
@@ -490,8 +489,8 @@ func GetFedCaCertPath(masterID string) (string, error) { // returns caCertPath
 	var caCertData []byte
 	var err error
 	caCertPath := fmt.Sprintf("/etc/neuvector/certs/fed.master.%s.cert.pem", masterID)
-	if caCertData, err = ioutil.ReadFile(AdmCACertPath); err == nil {
-		if err = ioutil.WriteFile(caCertPath, caCertData, 0600); err == nil {
+	if caCertData, err = os.ReadFile(AdmCACertPath); err == nil {
+		if err = os.WriteFile(caCertPath, caCertData, 0600); err == nil {
 			return caCertPath, nil
 		} else {
 			log.WithFields(log.Fields{"error": err, "cert": caCertPath}).Error("failed to write")

--- a/controller/kv/cert_test.go
+++ b/controller/kv/cert_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,11 +14,11 @@ import (
 
 func VerifyCert(t *testing.T, cn string, cacertfile string, certfile string, keyfile string) {
 	// Load CA cert
-	cacertdata, err := ioutil.ReadFile(cacertfile)
+	cacertdata, err := os.ReadFile(cacertfile)
 	assert.Nil(t, err)
 
 	// Load CA cert
-	certdata, err := ioutil.ReadFile(certfile)
+	certdata, err := os.ReadFile(certfile)
 	assert.Nil(t, err)
 
 	block, _ := pem.Decode([]byte(certdata))
@@ -71,7 +70,7 @@ func TestSavePrivKeyCert(t *testing.T) {
 	assert.NotNil(t, cert)
 	assert.NotNil(t, key)
 
-	dir, err := ioutil.TempDir("", "test-cert")
+	dir, err := os.MkdirTemp("", "test-cert")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -93,7 +92,7 @@ func TestCASignTLSCert(t *testing.T) {
 	clusHelper = &mockCluster
 
 	// Generate CA
-	dir, err := ioutil.TempDir("", "test-cert")
+	dir, err := os.MkdirTemp("", "test-cert")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -121,7 +120,7 @@ func TestGenTlsCertWithCaAndStoreInKv_SelfSign(t *testing.T) {
 	mockCluster.Init(nil, nil)
 	clusHelper = &mockCluster
 
-	dir, err := ioutil.TempDir("", "test-cert")
+	dir, err := os.MkdirTemp("", "test-cert")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -140,17 +139,17 @@ func TestGenTlsCertWithCaAndStoreInKv_SelfSign(t *testing.T) {
 	VerifyCert(t, "CN", certfile, certfile, keyfile)
 
 	// Run again. The existing certs should be reused.
-	keydata, err := ioutil.ReadFile(keyfile)
+	keydata, err := os.ReadFile(keyfile)
 	assert.Nil(t, err)
-	certdata, err := ioutil.ReadFile(certfile)
+	certdata, err := os.ReadFile(certfile)
 	assert.Nil(t, err)
 
 	err = GenTlsCertWithCaAndStoreInKv("CN", certfile, keyfile, "", "", ValidityPeriod{Year: 1})
 	assert.Nil(t, err)
 
-	keydata2, err := ioutil.ReadFile(keyfile)
+	keydata2, err := os.ReadFile(keyfile)
 	assert.Nil(t, err)
-	certdata2, err := ioutil.ReadFile(certfile)
+	certdata2, err := os.ReadFile(certfile)
 	assert.Nil(t, err)
 
 	assert.Equal(t, keydata, keydata2)
@@ -164,7 +163,7 @@ func TestGenTlsCertWithCaAndStoreInKv_WithCA(t *testing.T) {
 	mockCluster.Init(nil, nil)
 	clusHelper = &mockCluster
 
-	dir, err := ioutil.TempDir("", "test-cert")
+	dir, err := os.MkdirTemp("", "test-cert")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -186,17 +185,17 @@ func TestGenTlsCertWithCaAndStoreInKv_WithCA(t *testing.T) {
 	VerifyCert(t, "CN", cacertfile, certfile, keyfile)
 
 	// Run again. The existing CA should be kept.
-	cakeydata, err := ioutil.ReadFile(cakeyfile)
+	cakeydata, err := os.ReadFile(cakeyfile)
 	assert.Nil(t, err)
-	cacertdata, err := ioutil.ReadFile(cacertfile)
+	cacertdata, err := os.ReadFile(cacertfile)
 	assert.Nil(t, err)
 
 	err = CreateCAFilesAndStoreInKv(cacertfile, cakeyfile)
 	assert.Nil(t, err)
 
-	cakeydata2, err := ioutil.ReadFile(cakeyfile)
+	cakeydata2, err := os.ReadFile(cakeyfile)
 	assert.Nil(t, err)
-	cacertdata2, err := ioutil.ReadFile(cacertfile)
+	cacertdata2, err := os.ReadFile(cacertfile)
 	assert.Nil(t, err)
 
 	assert.Equal(t, cakeydata, cakeydata2)
@@ -244,7 +243,7 @@ func TestExistingCAFiles(t *testing.T) {
 	clusHelper = &mockCluster
 
 	// Generate CA
-	dir, err := ioutil.TempDir("", "test-cert")
+	dir, err := os.MkdirTemp("", "test-cert")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -262,9 +261,9 @@ func TestExistingCAFiles(t *testing.T) {
 	assert.Nil(t, kvcert)
 
 	// 2. Make sure the data is consistent among kv and fs after rerun CreateCAFilesAndStoreInKv().
-	cakeydata, err := ioutil.ReadFile(cakeyfile)
+	cakeydata, err := os.ReadFile(cakeyfile)
 	assert.Nil(t, err)
-	cacertdata, err := ioutil.ReadFile(cacertfile)
+	cacertdata, err := os.ReadFile(cacertfile)
 	assert.Nil(t, err)
 
 	err = CreateCAFilesAndStoreInKv(cacertfile, cakeyfile)

--- a/controller/kv/endpoint.go
+++ b/controller/kv/endpoint.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -316,7 +315,7 @@ func (ep cfgEndpoint) backup(fedRole string) error {
 		log.WithFields(log.Fields{"error": err.Error()}).Error("Failed to walk directory")
 	}
 
-	tmpfile, err := ioutil.TempFile(configBackupDir, prefix)
+	tmpfile, err := os.CreateTemp(configBackupDir, prefix)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Failed to create temp. file")
 		return err

--- a/controller/kv/helper.go
+++ b/controller/kv/helper.go
@@ -7,8 +7,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -2004,8 +2004,8 @@ func (m clusterHelper) PutObjectCert(cn, keyPath, certPath string, cert *share.C
 					b1 := md5.Sum([]byte(cert.Cert))
 					b2 := md5.Sum([]byte(certExisting.Cert))
 					log.WithFields(log.Fields{"cn": cn, "certIn": hex.EncodeToString(b1[:]), "certExisting": hex.EncodeToString(b2[:])}).Info("md5")
-					err1 := ioutil.WriteFile(keyPath, []byte(certExisting.Key), 0600)
-					err2 := ioutil.WriteFile(certPath, []byte(certExisting.Cert), 0600)
+					err1 := os.WriteFile(keyPath, []byte(certExisting.Key), 0600)
+					err2 := os.WriteFile(certPath, []byte(certExisting.Cert), 0600)
 					if err1 == nil && err2 == nil {
 						return nil
 					} else {

--- a/controller/kv/registry.go
+++ b/controller/kv/registry.go
@@ -3,7 +3,6 @@ package kv
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -43,7 +42,7 @@ func writeRegistryImageSummary(name, id string, dat []byte) error {
 		os.MkdirAll(path, 0755)
 	}
 	filename := registryImageSummaryFileName(name, id)
-	if err := ioutil.WriteFile(filename, dat, 0755); err != nil {
+	if err := os.WriteFile(filename, dat, 0755); err != nil {
 		log.WithFields(log.Fields{"error": err, "filename": filename}).Error("Unable to write file")
 		return err
 	}
@@ -56,7 +55,7 @@ func writeRegistryImageReport(name, id string, dat []byte) error {
 		os.MkdirAll(path, 0755)
 	}
 	filename := registryImageReportFileName(name, id)
-	if err := ioutil.WriteFile(filename, dat, 0755); err != nil {
+	if err := os.WriteFile(filename, dat, 0755); err != nil {
 		log.WithFields(log.Fields{"error": err, "filename": filename}).Error("Unable to write file")
 		return err
 	}
@@ -75,7 +74,7 @@ func deleteRegistryImageReport(name, id string) error {
 
 func readRegistryImageSummary(name, id string) ([]byte, error) {
 	filename := registryImageSummaryFileName(name, id)
-	if dat, err := ioutil.ReadFile(filename); err != nil {
+	if dat, err := os.ReadFile(filename); err != nil {
 		return nil, err
 	} else {
 		return dat, nil
@@ -84,7 +83,7 @@ func readRegistryImageSummary(name, id string) ([]byte, error) {
 
 func readRegistryImageReport(name, id string) ([]byte, error) {
 	filename := registryImageReportFileName(name, id)
-	if dat, err := ioutil.ReadFile(filename); err != nil {
+	if dat, err := os.ReadFile(filename); err != nil {
 		return nil, err
 	} else {
 		return dat, nil
@@ -119,7 +118,7 @@ func restoreToCluster(reg, fedRole string) {
 	if !isFedReg || fedRole == api.FedRoleMaster || (fedRole == api.FedRoleJoint && isFedReg) {
 		filepath.Walk(regPath, func(path string, info os.FileInfo, err error) error {
 			if info != nil && strings.HasSuffix(path, summarySuffix) {
-				value, err := ioutil.ReadFile(path)
+				value, err := os.ReadFile(path)
 				if err == nil {
 					var sum share.CLUSRegistryImageSummary
 					if err = json.Unmarshal(value, &sum); err == nil {
@@ -155,7 +154,7 @@ func restoreToCluster(reg, fedRole string) {
 	// 3. Read the report and write both into kv
 	for _, sum := range sums {
 		rptFile := fmt.Sprintf("%s/%s%s", regPath, sum.ImageID, reportSuffix)
-		vReport, vErr := ioutil.ReadFile(rptFile)
+		vReport, vErr := os.ReadFile(rptFile)
 		if vErr == nil {
 			// 3-1. must restore scan/data/image/{reg}/{id} key first !
 			vKey := share.CLUSRegistryImageDataKey(reg, sum.ImageID)
@@ -181,7 +180,7 @@ func restoreRegistry(ch chan<- error, importInfo fedRulesRevInfo) {
 	scanRevs, _, _ := clusHelper.GetFedScanRevisions()
 	if !scanRevs.Restoring {
 		// assign random numbers to RegConfigRev, ScannedRegRevs & ScannedRepoRev on managed clusters so that the first scan data polling is always triggered
-		files, err := ioutil.ReadDir(registryDataDir)
+		files, err := os.ReadDir(registryDataDir)
 		if err != nil {
 			log.WithFields(log.Fields{"fedRole": importInfo.fedRole}).Debug("Failed to read registry directory")
 		} else {

--- a/controller/kv/upgrade.go
+++ b/controller/kv/upgrade.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -1171,8 +1170,8 @@ func restoreKeyCertFromOldKvKey(certSvcNames []string, svcName, cn, keyPath, cer
 	if err := clusHelper.PutObjectCert(cn, keyPath, certPath, cert); err == nil {
 		if cn == share.CLUSRootCAKey && len(cert.Key) > 0 && len(cert.Cert) > 0 {
 			certData := []byte(cert.Cert)
-			err1 := ioutil.WriteFile(keyPath, []byte(cert.Key), 0600)
-			err2 := ioutil.WriteFile(certPath, certData, 0600)
+			err1 := os.WriteFile(keyPath, []byte(cert.Key), 0600)
+			err2 := os.WriteFile(certPath, certData, 0600)
 			if err1 == nil && err2 == nil {
 				return true
 			} else {
@@ -1290,8 +1289,8 @@ func ValidateWebhookCert() {
 						}
 					} else {
 						if cert != nil {
-							err1 := ioutil.WriteFile(certInfo.keyPath, []byte(cert.Key), 0600)
-							err2 := ioutil.WriteFile(certInfo.certPath, []byte(cert.Cert), 0600)
+							err1 := os.WriteFile(certInfo.keyPath, []byte(cert.Key), 0600)
+							err2 := os.WriteFile(certInfo.certPath, []byte(cert.Cert), 0600)
 							log.WithFields(log.Fields{"err1": err1, "err2": err2}).Info()
 						}
 					}
@@ -1314,8 +1313,8 @@ func ValidateWebhookCert() {
 		}
 		if cert, _, _ := clusHelper.GetObjectCertRev(certInfo.cn); !cert.IsEmpty() {
 			certData := []byte(cert.Cert)
-			err1 := ioutil.WriteFile(certInfo.keyPath, []byte(cert.Key), 0600)
-			err2 := ioutil.WriteFile(certInfo.certPath, certData, 0600)
+			err1 := os.WriteFile(certInfo.keyPath, []byte(cert.Key), 0600)
+			err2 := os.WriteFile(certInfo.certPath, certData, 0600)
 			if err1 == nil && err2 == nil {
 				if certInfo.cn != share.CLUSRootCAKey {
 					if orchPlatform == share.PlatformKubernetes {

--- a/controller/nvk8sapi/nvvalidatewebhookcfg/admission/admission.go
+++ b/controller/nvk8sapi/nvvalidatewebhookcfg/admission/admission.go
@@ -2,7 +2,7 @@ package nvsysadmission
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/neuvector/neuvector/controller/api"
@@ -656,7 +656,7 @@ func GetCustomCriteriaTemplates() []*api.RESTAdminCriteriaTemplate {
 	}
 
 	for k, v := range sources {
-		bytesData, err := ioutil.ReadFile(v)
+		bytesData, err := os.ReadFile(v)
 		if err != nil {
 			return templates
 		}

--- a/controller/opa/opaIntegration.go
+++ b/controller/opa/opaIntegration.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -82,7 +82,7 @@ func IsOpaRestarted() bool {
 	}
 	defer resp.Body.Close()
 
-	body, readErr := ioutil.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
 		log.WithFields(log.Fields{"error": readErr}).Error("OPA error on ReadAll")
 		return false
@@ -159,7 +159,7 @@ func addObject(key string, contentType string, data string) bool {
 	}
 	defer resp.Body.Close()
 
-	_, readErr := ioutil.ReadAll(resp.Body)
+	_, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
 		log.WithFields(log.Fields{"key": key, "contentType": contentType, "error": err}).Error("OPA addObject NewRequest")
 		return false
@@ -221,7 +221,7 @@ func DeleteDocument(key string) {
 	}
 	defer resp.Body.Close()
 
-	_, readErr := ioutil.ReadAll(resp.Body)
+	_, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
 		log.WithFields(log.Fields{"key": key, "error": readErr}).Error("OPA delDocument NewRequest")
 		return
@@ -237,7 +237,7 @@ func DeleteDocument(key string) {
 }
 
 func OpaEval(policyPath string, inputFile string) (int, string, error) {
-	bytes, err := ioutil.ReadFile(inputFile)
+	bytes, err := os.ReadFile(inputFile)
 	if err != nil {
 		return -1, "", err
 	}
@@ -266,7 +266,7 @@ func OpaEvalByString(policyPath string, inputData string) (int, string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, readErr := ioutil.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
 		return resp.StatusCode, "", err
 	}
@@ -332,7 +332,7 @@ func GetRiskyRoleRuleIDByName(ruleName string) int {
 	}
 	defer resp.Body.Close()
 
-	body, readErr := ioutil.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
 		log.WithFields(log.Fields{"url": url, "error": getErr}).Error("GetRiskyRoleRuleIDByName error on ReadAll")
 		return 0

--- a/controller/remote_repository/github.go
+++ b/controller/remote_repository/github.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -156,7 +156,7 @@ func (exp GitHubExport) getExistingFileSha() (string, string, error) {
 	}
 
 	var body []byte
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return "", "", fmt.Errorf("error reading response body: %s", err.Error())
 	}

--- a/controller/resource/kubernetes_auth.go
+++ b/controller/resource/kubernetes_auth.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -88,7 +88,7 @@ func discoverAuthzEndpoint(endpoint string) (string, error) {
 		return "", err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
 		return "", err
@@ -232,7 +232,7 @@ func (d *kubernetes) GetPlatformUserGroups(token string) ([]string, error) {
 		return groups, err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
 		return groups, err

--- a/controller/resource/kubernetes_rbac.go
+++ b/controller/resource/kubernetes_rbac.go
@@ -3,7 +3,7 @@ package resource
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -116,7 +116,7 @@ var ocReaderVerbs utils.Set = utils.NewSet(
 )
 
 // Rancher SSO: apiGroup									resources		verbs
-//------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // fedAdmin:    in {"read-only.neuvector.api.io", "*"}	 	"*"				in {"*"}    // "cattle-globalrole-....." clusterrole(with clusterrolebinding)
 // fedReader:   in {"read-only.neuvector.api.io", "*"}	 	"*"				in {"get}   // "cattle-globalrole-....." clusterrole(with clusterrolebinding)
 // admin:       in {"read-only.neuvector.api.io", "*"}	 	"*"				in {"*"}    // clusterrole(with clusterrolebinding)
@@ -1465,7 +1465,7 @@ func GetNvCtrlerServiceAccount(objFunc common.CacheEventFunc) {
 	cacheEventFunc = objFunc
 	nvControllerSA := ctrlerSubjectWanted
 	filePath := "/var/run/secrets/kubernetes.io/serviceaccount/token"
-	if data, err := ioutil.ReadFile(filePath); err == nil {
+	if data, err := os.ReadFile(filePath); err == nil {
 		if sa, err := GetSaFromJwtToken(string(data)); err == nil {
 			nvControllerSA = sa
 		}

--- a/controller/resource/kubernetes_resource.go
+++ b/controller/resource/kubernetes_resource.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"reflect"
@@ -1537,7 +1536,7 @@ func getVersion(url string) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Debug("Read data fail")
 		return "", err

--- a/controller/rest/admission.go
+++ b/controller/rest/admission.go
@@ -3,7 +3,7 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"reflect"
@@ -437,7 +437,7 @@ func handlerPatchAdmissionState(w http.ResponseWriter, r *http.Request, ps httpr
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTAdmissionConfigData
 	err = json.Unmarshal(body, &rconf)
@@ -955,7 +955,7 @@ func handlerAddAdmissionRule(w http.ResponseWriter, r *http.Request, ps httprout
 	}
 
 	var confData api.RESTAdmissionRuleConfigData
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	err := json.Unmarshal(body, &confData)
 	if err != nil || confData.Config == nil {
 		log.WithFields(log.Fields{"error": err}).Error("Request error")
@@ -1116,7 +1116,7 @@ func handlerPatchAdmissionRule(w http.ResponseWriter, r *http.Request, ps httpro
 
 	code := 0
 	var confData api.RESTAdmissionRuleConfigData
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	err := json.Unmarshal(body, &confData)
 	ruleCfg := confData.Config
 	if err != nil || confData.Config == nil {
@@ -1355,7 +1355,7 @@ func handlerAdmCtrlExport(w http.ResponseWriter, r *http.Request, ps httprouter.
 	}
 
 	var rconf api.RESTAdmCtrlRulesExport
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	err := json.Unmarshal(body, &rconf)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Request error")
@@ -1474,7 +1474,7 @@ func importAdmCtrl(scope string, loginDomainRoles access.DomainRole, importTask 
 	log.Debug()
 	defer os.Remove(importTask.TempFilename)
 
-	json_data, _ := ioutil.ReadFile(importTask.TempFilename)
+	json_data, _ := os.ReadFile(importTask.TempFilename)
 	var secRule resource.NvAdmCtrlSecurityRule
 	if err := json.Unmarshal(json_data, &secRule); err != nil || secRule.APIVersion != "neuvector.com/v1" || secRule.Kind != resource.NvAdmCtrlSecurityRuleKind {
 		msg := "Invalid security rule(s)"
@@ -1564,7 +1564,7 @@ func handlerPromoteAdmissionRules(w http.ResponseWriter, r *http.Request, ps htt
 	}
 
 	var promoteData api.RESTAdmCtrlPromoteRequestData
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	err := json.Unmarshal(body, &promoteData)
 	if err != nil || promoteData.Request == nil || len(promoteData.Request.IDs) == 0 {
 		log.WithFields(log.Fields{"error": err}).Error("Request error")

--- a/controller/rest/admwebhook.go
+++ b/controller/rest/admwebhook.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/signal"
@@ -1392,7 +1392,7 @@ func (whsvr *WebhookServer) serveWithTimeStamps(w http.ResponseWriter, r *http.R
 
 	var body []byte
 	if r.Body != nil {
-		if data, err := ioutil.ReadAll(r.Body); err == nil {
+		if data, err := io.ReadAll(r.Body); err == nil {
 			body = data
 		}
 	}
@@ -1555,7 +1555,7 @@ func k8sWebhookRestServer(svcName string, port uint, clientAuth, debug bool) {
 
 	if clientAuth {
 		clientCACert := tlsClientCA
-		caCert, err := ioutil.ReadFile(clientCACert)
+		caCert, err := os.ReadFile(clientCACert)
 		if err != nil {
 			log.WithFields(log.Fields{"svcName": svcName}).Info("Cannot load CA cert for client authentication")
 			log.Fatal(err)

--- a/controller/rest/admwebhook_test.go
+++ b/controller/rest/admwebhook_test.go
@@ -1,19 +1,9 @@
 package rest
 
 import (
-	//	"github.com/neuvector/neuvector/controller/api"
-	//	"github.com/neuvector/neuvector/controller/nvk8sapi/nvvalidatewebhookcfg"
 	"github.com/neuvector/neuvector/controller/nvk8sapi/nvvalidatewebhookcfg/admission"
 	"github.com/neuvector/neuvector/share/utils"
 
-	//	"encoding/json"
-	//	"io/ioutil"
-	//	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	//	appsv1 "k8s.io/api/apps/v1"
-	//	corev1 "k8s.io/api/core/v1"
-	//	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	//	"path/filepath"
-	//	"runtime"
 	"testing"
 )
 
@@ -103,7 +93,7 @@ func TestWalkThruContainersForSkipUpdateLog(t *testing.T) {
 
 	for i := 0; i < 1; i++ {
 		dataFileName := filepath.Join(filepath.Dir(testFileName), "data", "request_update_deployment.json")
-		data, err := ioutil.ReadFile(dataFileName)
+		data, err := os.ReadFile(dataFileName)
 		if err != nil {
 			t.Errorf("Read test data error: %s (%s)\n", dataFileName, err)
 		}

--- a/controller/rest/assessment.go
+++ b/controller/rest/assessment.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -63,7 +63,7 @@ func handlerAssessAdmCtrlRules(w http.ResponseWriter, r *http.Request, ps httpro
 	var whsvr WebhookServer
 	var stamps api.AdmCtlTimeStamps
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	body = _preprocessImportBody(body)
 	yamlParts := strings.Split(string(body), "\n---\n")
 

--- a/controller/rest/auth.go
+++ b/controller/rest/auth.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	mathRand "math/rand"
 	"net/http"
@@ -2148,7 +2148,7 @@ func handlerAuthLogin(w http.ResponseWriter, r *http.Request, ps httprouter.Para
 		remote = r.RemoteAddr
 	} else {
 		// Read body
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 
 		err := json.Unmarshal(body, &auth)
 		if err != nil || auth.Password == nil {
@@ -2371,7 +2371,7 @@ func handlerFedAuthLogin(w http.ResponseWriter, r *http.Request, ps httprouter.P
 
 	// Read body
 	var auth api.RESTFedAuthData
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	err = json.Unmarshal(body, &auth)
 	if err != nil || auth.MasterToken == "" {
 		log.WithFields(log.Fields{"error": err}).Error("Request error")
@@ -2442,7 +2442,7 @@ func handlerAuthLoginServer(w http.ResponseWriter, r *http.Request, ps httproute
 	defer r.Body.Close()
 
 	// Read body
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var data api.RESTAuthData
 	err := json.Unmarshal(body, &data)

--- a/controller/rest/bench.go
+++ b/controller/rest/bench.go
@@ -3,7 +3,7 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -296,7 +296,7 @@ func handlerCustomCheckConfig(w http.ResponseWriter, r *http.Request, ps httprou
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTCustomCheckConfigData
 	err := json.Unmarshal(body, &rconf)

--- a/controller/rest/compliance.go
+++ b/controller/rest/compliance.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"sort"
@@ -219,7 +219,7 @@ func handlerComplianceProfileConfig(w http.ResponseWriter, r *http.Request, ps h
 	}
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTComplianceProfileConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -301,7 +301,7 @@ func handlerComplianceProfileEntryConfig(w http.ResponseWriter, r *http.Request,
 	}
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTComplianceProfileEntryConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -426,7 +426,7 @@ func handlerCompProfileExport(w http.ResponseWriter, r *http.Request, ps httprou
 	}
 
 	var rconf api.RESTCompProfilesExport
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	err := json.Unmarshal(body, &rconf)
 	if err == nil {
 		for _, name := range rconf.Names {
@@ -531,7 +531,7 @@ func importCompProfile(scope string, loginDomainRoles access.DomainRole, importT
 	log.Debug()
 	defer os.Remove(importTask.TempFilename)
 
-	json_data, _ := ioutil.ReadFile(importTask.TempFilename)
+	json_data, _ := os.ReadFile(importTask.TempFilename)
 	var secRuleList resource.NvCompProfileSecurityRuleList
 	var secRule resource.NvCompProfileSecurityRule
 	var secRules []resource.NvCompProfileSecurityRule = []resource.NvCompProfileSecurityRule{}

--- a/controller/rest/configmap.go
+++ b/controller/rest/configmap.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -422,7 +421,7 @@ func updateAdminPass(ruser *api.RESTUser, acc *access.AccessControl) {
 
 	var profile share.CLUSPwdProfile
 	if _, err := os.Stat(pwdprofileconfigmap); err == nil {
-		if profileyaml_data, err := ioutil.ReadFile(pwdprofileconfigmap); err == nil {
+		if profileyaml_data, err := os.ReadFile(pwdprofileconfigmap); err == nil {
 			if json_data, err := yaml.YAMLToJSON(profileyaml_data); err == nil {
 				var rconf api.RESTPwdProfilesDataCfgMap
 				if err := json.Unmarshal(json_data, &rconf); err == nil {
@@ -791,7 +790,7 @@ func handleusercfg(yaml_data []byte, load bool, skip *bool, context *configMapHa
 
 func HandleAdminUserUpdate() {
 	if _, err := os.Stat(authconfigmap); err == nil {
-		if useryaml_data, err := ioutil.ReadFile(authconfigmap); err == nil {
+		if useryaml_data, err := os.ReadFile(authconfigmap); err == nil {
 			json_data, err1 := yaml.YAMLToJSON(useryaml_data)
 			if err1 != nil {
 				log.WithFields(log.Fields{"error": err1}).Error("user config to json convert error")
@@ -866,7 +865,7 @@ func LoadInitCfg(load bool, platform string) {
 		var errMsg string
 		context.subDetail = ""
 		if _, err := os.Stat(configMap.FileName); err == nil {
-			if yaml_data, err := ioutil.ReadFile(configMap.FileName); err == nil {
+			if yaml_data, err := os.ReadFile(configMap.FileName); err == nil {
 				skip = false
 				err = configMap.HandlerFunc(yaml_data, load, &skip, &context)
 				log.WithFields(log.Fields{"cfg": configMap.Type, "skip": skip, "error": err}).Debug()

--- a/controller/rest/conver.go
+++ b/controller/rest/conver.go
@@ -2,7 +2,7 @@ package rest
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -135,7 +135,7 @@ func handlerConverEndpointConfig(w http.ResponseWriter, r *http.Request, ps http
 	}
 
 	// Read body
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTConversationEndpointConfigData
 	err = json.Unmarshal(body, &rconf)
@@ -254,7 +254,7 @@ func handlerConverShow(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 	from := ps.ByName("from")
 	to := ps.ByName("to")
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var data api.RESTConversationQueryData
 	err := json.Unmarshal(body, &data)

--- a/controller/rest/crdsecurityrule.go
+++ b/controller/rest/crdsecurityrule.go
@@ -6,12 +6,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"reflect"
@@ -3186,7 +3186,7 @@ func handlerGroupCfgExport(w http.ResponseWriter, r *http.Request, ps httprouter
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	var rconf api.RESTGroupExport
 
 	err := json.Unmarshal(body, &rconf)

--- a/controller/rest/crdvalidatewebhook.go
+++ b/controller/rest/crdvalidatewebhook.go
@@ -3,7 +3,7 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/signal"
@@ -555,7 +555,7 @@ func (whsvr *WebhookServer) crdserve(w http.ResponseWriter, r *http.Request) {
 
 	var body []byte
 	if r.Body != nil {
-		if data, err := ioutil.ReadAll(r.Body); err == nil {
+		if data, err := io.ReadAll(r.Body); err == nil {
 			body = data
 		}
 	}

--- a/controller/rest/custom_role.go
+++ b/controller/rest/custom_role.go
@@ -3,7 +3,7 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -181,7 +181,7 @@ func handlerRoleCreate(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 	}
 
 	// Read body
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTUserRoleConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -244,7 +244,7 @@ func handlerRoleConfig(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 	}
 
 	// Read body
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTUserRoleConfigData
 	err := json.Unmarshal(body, &rconf)

--- a/controller/rest/debug.go
+++ b/controller/rest/debug.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 
@@ -115,7 +115,7 @@ func handlerControllerProfiling(w http.ResponseWriter, r *http.Request, ps httpr
 
 	id := ps.ByName("id")
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTProfilingData
 	err := json.Unmarshal(body, &rconf)
@@ -166,7 +166,7 @@ func handlerAgentProfiling(w http.ResponseWriter, r *http.Request, ps httprouter
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTProfilingData
 	err := json.Unmarshal(body, &rconf)

--- a/controller/rest/device.go
+++ b/controller/rest/device.go
@@ -2,7 +2,7 @@ package rest
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -393,7 +393,7 @@ func handlerControllerConfig(w http.ResponseWriter, r *http.Request, ps httprout
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTControllerConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -482,7 +482,7 @@ func handlerAgentConfig(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTAgentConfigData
 	err := json.Unmarshal(body, &rconf)

--- a/controller/rest/dlp_rule.go
+++ b/controller/rest/dlp_rule.go
@@ -6,7 +6,7 @@ import "C"
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"regexp"
@@ -517,7 +517,7 @@ func handlerDlpSensorCreate(w http.ResponseWriter, r *http.Request, ps httproute
 	}
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	var rconf api.RESTDlpSensorConfigData
 	err := json.Unmarshal(body, &rconf)
 	if err != nil || rconf.Config == nil {
@@ -606,7 +606,7 @@ func handlerDlpRuleCreate(w http.ResponseWriter, r *http.Request, ps httprouter.
 	}
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	var rconf api.RESTDlpRuleConfigData
 	err := json.Unmarshal(body, &rconf)
 	if err != nil || rconf.Config == nil {
@@ -924,7 +924,7 @@ func handlerDlpSensorConfig(w http.ResponseWriter, r *http.Request, ps httproute
 	name := ps.ByName("name")
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	var rconf api.RESTDlpSensorConfigData
 	err := json.Unmarshal(body, &rconf)
 	if err != nil || rconf.Config == nil {
@@ -1012,7 +1012,7 @@ func handlerDlpRuleConfig(w http.ResponseWriter, r *http.Request, ps httprouter.
 	name := ps.ByName("name")
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	var rconf api.RESTDlpRuleConfigData
 	err := json.Unmarshal(body, &rconf)
 	if err != nil || rconf.Config == nil {
@@ -1110,7 +1110,7 @@ func handlerDlpGroupConfig(w http.ResponseWriter, r *http.Request, ps httprouter
 	name := ps.ByName("name")
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	var rconf api.RESTDlpGroupConfigData
 	err := json.Unmarshal(body, &rconf)
 	if err != nil || rconf.Config == nil {
@@ -1596,7 +1596,7 @@ func handlerDlpExport(w http.ResponseWriter, r *http.Request, ps httprouter.Para
 	}
 
 	var rconf api.RESTDlpSensorExport
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	err := json.Unmarshal(body, &rconf)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Request error")
@@ -1703,7 +1703,7 @@ func importDlp(scope string, loginDomainRoles access.DomainRole, importTask shar
 	log.Debug()
 	defer os.Remove(importTask.TempFilename)
 
-	json_data, _ := ioutil.ReadFile(importTask.TempFilename)
+	json_data, _ := os.ReadFile(importTask.TempFilename)
 	var secRuleList resource.NvDlpSecurityRuleList
 	var secRule resource.NvDlpSecurityRule
 	var secRules []resource.NvDlpSecurityRule

--- a/controller/rest/domain.go
+++ b/controller/rest/domain.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -82,7 +82,7 @@ func handlerDomainConfig(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	}
 
 	// Read body
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTDomainConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -143,7 +143,7 @@ func handlerDomainEntryConfig(w http.ResponseWriter, r *http.Request, ps httprou
 	name, _ = url.PathUnescape(name)
 
 	// Read body
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTDomainEntryConfigData
 	err := json.Unmarshal(body, &rconf)

--- a/controller/rest/eula.go
+++ b/controller/rest/eula.go
@@ -2,7 +2,7 @@ package rest
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
@@ -41,7 +41,7 @@ func handlerEULAConfig(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTEULAData
 	err := json.Unmarshal(body, &rconf)

--- a/controller/rest/file_monitor.go
+++ b/controller/rest/file_monitor.go
@@ -3,7 +3,7 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path/filepath"
 	"reflect"
@@ -136,7 +136,7 @@ func handlerFileMonitorConfig(w http.ResponseWriter, r *http.Request, ps httprou
 
 	group := ps.ByName("name")
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTFileMonitorConfigData
 	err := json.Unmarshal(body, &rconf)

--- a/controller/rest/group.go
+++ b/controller/rest/group.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"reflect"
@@ -568,7 +568,7 @@ func handlerGroupCreate(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 	}
 
 	// Read body
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTGroupConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -670,7 +670,7 @@ func handlerGroupConfig(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 	}
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTGroupConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -962,7 +962,7 @@ func handlerServiceCreate(w http.ResponseWriter, r *http.Request, ps httprouter.
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTServiceConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -1048,7 +1048,7 @@ func handlerServiceBatchConfig(w http.ResponseWriter, r *http.Request, ps httpro
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTServiceBatchConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -1468,7 +1468,7 @@ func handlerServiceBatchConfigNetwork(w http.ResponseWriter, r *http.Request, ps
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTServiceBatchConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -1571,7 +1571,7 @@ func handlerServiceBatchConfigProfile(w http.ResponseWriter, r *http.Request, ps
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTServiceBatchConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -1755,7 +1755,7 @@ func importGroupPolicy(scope string, loginDomainRoles access.DomainRole, importT
 	log.Debug()
 	defer os.Remove(importTask.TempFilename)
 
-	json_data, _ := ioutil.ReadFile(importTask.TempFilename)
+	json_data, _ := os.ReadFile(importTask.TempFilename)
 	var secRuleList resource.NvSecurityRuleList
 	var secRule resource.NvSecurityRule
 	var secRules []resource.NvSecurityRule

--- a/controller/rest/ibmsa.go
+++ b/controller/rest/ibmsa.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	//"math/rand"
 	"mime"
@@ -485,7 +485,7 @@ func handlerPostIBMSAEpSetup(w http.ResponseWriter, r *http.Request, ps httprout
 	var err error
 
 	action := ps.ByName("action")
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	switch action {
 	case "configuration":
 		err = json.Unmarshal(body, &cfg)
@@ -611,7 +611,7 @@ func ibmsaGetToken(cfg *share.CLUSIBMSAConfig) (string, error) {
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.WithFields(log.Fields{"url": cfg.TokenURL, "error": err}).Error("Failed to read IAM token")
 		return "", err
@@ -669,7 +669,7 @@ func ibmsaCreateOccurence(url string, value []byte, cfg *share.CLUSIBMSAConfig) 
 
 	defer resp.Body.Close()
 
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err != nil {
 		log.WithFields(log.Fields{"url": url, "error": err}).Error("Failed to read body")
 		return err
@@ -781,7 +781,7 @@ func ibmsaGetNvNote(accessToken, noteID string, cfg *share.CLUSIBMSAConfig) erro
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.WithFields(log.Fields{"url": url, "error": err}).Error("Failed to read NV note")
 		return err
@@ -931,7 +931,7 @@ func handlerTestOccurrences(w http.ResponseWriter, r *http.Request, ps httproute
 
 	//accountID := ps.ByName("accountID")
 	//providerID := ps.ByName("providerID")
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	err = json.Unmarshal(body, &occur)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("")

--- a/controller/rest/internal.go
+++ b/controller/rest/internal.go
@@ -2,7 +2,7 @@ package rest
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -46,7 +46,7 @@ func handlerAcceptAlert(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 	}
 
 	var rconf api.RESTAcceptedAlerts
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	err := json.Unmarshal(body, &rconf)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Request error")

--- a/controller/rest/license.go
+++ b/controller/rest/license.go
@@ -3,7 +3,7 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
@@ -103,7 +103,7 @@ func handlerLicenseUpdate(w http.ResponseWriter, r *http.Request, ps httprouter.
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var req api.RESTLicenseKey
 	err := json.Unmarshal(body, &req)

--- a/controller/rest/list.go
+++ b/controller/rest/list.go
@@ -1,8 +1,5 @@
 package rest
 
-// #include "../../defs.h"
-import "C"
-
 import (
 	"net/http"
 

--- a/controller/rest/log.go
+++ b/controller/rest/log.go
@@ -1,8 +1,5 @@
 package rest
 
-// #include "../../defs.h"
-import "C"
-
 import (
 	"net/http"
 	"sync"

--- a/controller/rest/policy.go
+++ b/controller/rest/policy.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"reflect"
@@ -1441,7 +1441,7 @@ func handlerPolicyRuleAction(w http.ResponseWriter, r *http.Request, ps httprout
 	}
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	var rconf api.RESTPolicyRuleActionData
 	err := json.Unmarshal(body, &rconf)
 	if err != nil {
@@ -1528,7 +1528,7 @@ func handlerPolicyRuleConfig(w http.ResponseWriter, r *http.Request, ps httprout
 	}
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTPolicyRuleConfigData
 	err = json.Unmarshal(body, &rconf)
@@ -2086,7 +2086,7 @@ func handlerPolicyRulesPromote(w http.ResponseWriter, r *http.Request, ps httpro
 	}
 
 	var promoteData api.RESTPolicyPromoteRequestData
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	err := json.Unmarshal(body, &promoteData)
 	if err != nil || promoteData.Request == nil || len(promoteData.Request.IDs) == 0 {
 		log.WithFields(log.Fields{"error": err}).Error("Request error")

--- a/controller/rest/process.go
+++ b/controller/rest/process.go
@@ -3,7 +3,7 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path/filepath"
 	"reflect"
@@ -221,7 +221,7 @@ func handlerProcessProfileConfig(w http.ResponseWriter, r *http.Request, ps http
 	group := ps.ByName("name")
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTProcessProfileConfigData
 	err := json.Unmarshal(body, &rconf)

--- a/controller/rest/pwd_profile.go
+++ b/controller/rest/pwd_profile.go
@@ -2,7 +2,7 @@ package rest
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -33,7 +33,7 @@ func handlerPwdProfileCreate(w http.ResponseWriter, r *http.Request, ps httprout
 	}
 
 	// Read body
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTPwdProfileData
 	err := json.Unmarshal(body, &rconf)
@@ -215,7 +215,7 @@ func handlerPwdProfileConfig(w http.ResponseWriter, r *http.Request, ps httprout
 	name := ps.ByName("name")
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var errMsg string
 	var rconf api.RESTPwdProfileConfigData

--- a/controller/rest/registry.go
+++ b/controller/rest/registry.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"sort"
@@ -214,7 +214,7 @@ func handlerRegistryCreate(w http.ResponseWriter, r *http.Request, ps httprouter
 	}
 
 	var data api.RESTRegistryConfigData
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	if getRequestApiVersion(r) == ApiVersion2 {
 		var v2data api.RESTRegistryConfigDataV2
@@ -550,7 +550,7 @@ func handlerRegistryConfig(w http.ResponseWriter, r *http.Request, ps httprouter
 	}
 
 	var data api.RESTRegistryConfigData
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	if getRequestApiVersion(r) == ApiVersion2 {
 		var v2data api.RESTRegistryConfigDataV2

--- a/controller/rest/registry_kits.go
+++ b/controller/rest/registry_kits.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sort"
 	"strings"
@@ -161,7 +160,7 @@ func (t *regTracer) SendRequest(method, url string) {
 }
 
 func (t *regTracer) GotResponse(statusCode int, status string, header http.Header, body io.ReadCloser) io.Reader {
-	c, _ := ioutil.ReadAll(body)
+	c, _ := io.ReadAll(body)
 	body.Close()
 
 	t.steps = append(t.steps, &api.RESTRegistryTestStep{
@@ -231,7 +230,7 @@ func handlerRegistryTest(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	}
 
 	var data api.RESTRegistryTestData
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	var err error
 
 	if getRequestApiVersion(r) == ApiVersion2 {

--- a/controller/rest/remote_repository.go
+++ b/controller/rest/remote_repository.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
@@ -25,7 +25,7 @@ func handlerRemoteRepositoryPost(w http.ResponseWriter, r *http.Request, ps http
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	var remoteRepository api.RESTRemoteRepository
 	err := json.Unmarshal(body, &remoteRepository)
 	if err != nil {
@@ -164,7 +164,7 @@ func handlerRemoteRepositoryPatch(w http.ResponseWriter, r *http.Request, ps htt
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	var rconf api.RESTRemoteRepositoryConfigData
 	err := json.Unmarshal(body, &rconf)
 	if err != nil || rconf.Config == nil {

--- a/controller/rest/repository.go
+++ b/controller/rest/repository.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -156,7 +156,7 @@ func handlerScanRepositoryReq(w http.ResponseWriter, r *http.Request, ps httprou
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var data api.RESTScanRepoReqData
 	err := json.Unmarshal(body, &data)
@@ -247,7 +247,7 @@ func handlerScanRepositorySubmit(w http.ResponseWriter, r *http.Request, ps http
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var data api.RESTScanRepoSubmitData
 	err := json.Unmarshal(body, &data)

--- a/controller/rest/response.go
+++ b/controller/rest/response.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"sort"
@@ -667,7 +667,7 @@ func handlerResponseRuleAction(w http.ResponseWriter, r *http.Request, ps httpro
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTResponseRuleActionData
 	err := json.Unmarshal(body, &rconf)
@@ -718,7 +718,7 @@ func handlerResponseRuleConfig(w http.ResponseWriter, r *http.Request, ps httpro
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTResponseRuleConfigData
 	err = json.Unmarshal(body, &rconf)

--- a/controller/rest/scanner.go
+++ b/controller/rest/scanner.go
@@ -2,7 +2,7 @@ package rest
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 
@@ -51,7 +51,7 @@ func handlerScanConfig(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var sconf api.RESTScanConfigData
 	err := json.Unmarshal(body, &sconf)

--- a/controller/rest/server.go
+++ b/controller/rest/server.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -386,7 +386,7 @@ func handlerTokenAuthServerRequest(w http.ResponseWriter, r *http.Request, ps ht
 	}
 
 	// Read body
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var data api.RESTTokenRedirect
 	err := json.Unmarshal(body, &data)
@@ -1006,7 +1006,7 @@ func handlerServerCreate(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	}
 
 	// Read body
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTServerConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -1285,7 +1285,7 @@ func handlerServerConfig(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	name := ps.ByName("name")
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTServerConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -1403,7 +1403,7 @@ func handlerServerRoleGroupsConfig(w http.ResponseWriter, r *http.Request, ps ht
 	role := ps.ByName("role")
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTServerRoleGroupsConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -1543,7 +1543,7 @@ func handlerServerGroupRoleDomainsConfig(w http.ResponseWriter, r *http.Request,
 	group := ps.ByName("group")
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTServerGroupRoleDomainsConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -1747,7 +1747,7 @@ func handlerServerGroupsOrderConfig(w http.ResponseWriter, r *http.Request, ps h
 	name := ps.ByName("name")
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTServerGroupsOrderConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -1903,7 +1903,7 @@ func handlerServerTest(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 	}
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTServerTestData
 	err := json.Unmarshal(body, &rconf)

--- a/controller/rest/sigstore.go
+++ b/controller/rest/sigstore.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -27,7 +27,7 @@ func handlerSigstoreRootOfTrustPost(w http.ResponseWriter, r *http.Request, ps h
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	var rootOfTrust api.REST_SigstoreRootOfTrust_POST
 	err := json.Unmarshal(body, &rootOfTrust)
 	if err != nil {
@@ -148,7 +148,7 @@ func handlerSigstoreRootOfTrustPatchByName(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	var restRootOfTrust api.REST_SigstoreRootOfTrust_PATCH
 	err = json.Unmarshal(body, &restRootOfTrust)
 	if err != nil {
@@ -269,7 +269,7 @@ func handlerSigstoreVerifierPost(w http.ResponseWriter, r *http.Request, ps http
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	var verifier api.REST_SigstoreVerifier
 	err := json.Unmarshal(body, &verifier)
 	if err != nil {
@@ -394,7 +394,7 @@ func handlerSigstoreVerifierPatchByName(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	var restVerifier api.REST_SigstoreVerifier_PATCH
 	err = json.Unmarshal(body, &restVerifier)
 	if err != nil {

--- a/controller/rest/sniffer.go
+++ b/controller/rest/sniffer.go
@@ -3,8 +3,8 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"mime/multipart"
+	"io"
 	"net/http"
 	"net/textproto"
 	"sort"
@@ -183,7 +183,7 @@ func handlerSnifferStart(w http.ResponseWriter, r *http.Request, ps httprouter.P
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var proc api.RESTSnifferArgsData
 	err := json.Unmarshal(body, &proc)

--- a/controller/rest/system.go
+++ b/controller/rest/system.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net"
@@ -390,7 +389,7 @@ func handlerSystemRequest(w http.ResponseWriter, r *http.Request, ps httprouter.
 
 	// Authz is done when action is taken, setting service policies.
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var req api.RESTSystemRequestData
 	err := json.Unmarshal(body, &req)
@@ -626,7 +625,7 @@ func handlerSystemWebhookCreate(w http.ResponseWriter, r *http.Request, ps httpr
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTSystemWebhookConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -757,7 +756,7 @@ func handlerSystemWebhookConfig(w http.ResponseWriter, r *http.Request, ps httpr
 
 	name := ps.ByName("name")
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTSystemWebhookConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -1556,7 +1555,7 @@ func handlerSystemConfigBase(apiVer string, w http.ResponseWriter, r *http.Reque
 	scope := share.ScopeFed
 	dummy := share.CLUSSystemConfig{CfgType: share.FederalCfg}
 	var rconf api.RESTSystemConfigConfigData
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	err := json.Unmarshal(body, &rconf)
 	if err == nil && apiVer == "v2" {
 		if rconf.ConfigV2 != nil {
@@ -2300,7 +2299,7 @@ func _importHandler(w http.ResponseWriter, r *http.Request, tid, importType, tem
 	}
 
 	var tmpfile *os.File
-	if tmpfile, err = ioutil.TempFile(importBackupDir, tempFilePrefix); err == nil {
+	if tmpfile, err = os.CreateTemp(importBackupDir, tempFilePrefix); err == nil {
 		importTask := share.CLUSImportTask{
 			TID:            utils.GetRandomID(tidLength, ""),
 			ImportType:     importType,
@@ -2323,7 +2322,7 @@ func _importHandler(w http.ResponseWriter, r *http.Request, tid, importType, tem
 				lines, err = rawImportRead(r, tmpfile)
 			}
 		} else {
-			body, _ := ioutil.ReadAll(r.Body)
+			body, _ := io.ReadAll(r.Body)
 			body = _preprocessImportBody(body)
 			json_data, err := yaml.YAMLToJSON(body)
 			if err != nil {

--- a/controller/rest/telemetry.go
+++ b/controller/rest/telemetry.go
@@ -1,7 +1,5 @@
 package rest
 
-import "C"
-
 import (
 	"encoding/json"
 	"fmt"

--- a/controller/rest/user.go
+++ b/controller/rest/user.go
@@ -3,7 +3,7 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"net/url"
@@ -98,7 +98,7 @@ func handlerUserCreate(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 	}
 
 	// Read body
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTUserData
 	err := json.Unmarshal(body, &rconf)
@@ -463,7 +463,7 @@ func handlerUserConfig(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 	fullname, _ = url.PathUnescape(fullname)
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTUserConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -720,7 +720,7 @@ func handlerUserPwdConfig(w http.ResponseWriter, r *http.Request, ps httprouter.
 	}
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var errMsg string
 	var rconf api.RESTUserPwdConfigData
@@ -867,7 +867,7 @@ func handlerUserRoleDomainsConfig(w http.ResponseWriter, r *http.Request, ps htt
 	}
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTUserRoleDomainsConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -1188,7 +1188,7 @@ func handlerApikeyCreate(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	}
 
 	// Read body
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTApikeyCreationData
 	err := json.Unmarshal(body, &rconf)

--- a/controller/rest/vulnerability.go
+++ b/controller/rest/vulnerability.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"regexp"
@@ -270,7 +270,7 @@ func handlerVulnerabilityProfileConfig(w http.ResponseWriter, r *http.Request, p
 	}
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTVulnerabilityProfileConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -357,7 +357,7 @@ func handlerVulnerabilityProfileEntryCreate(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTVulnerabilityProfileEntryConfigData
 	err := json.Unmarshal(body, &rconf)
@@ -448,7 +448,7 @@ func handlerVulnerabilityProfileEntryConfig(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTVulnerabilityProfileEntryConfigData
 	err = json.Unmarshal(body, &rconf)
@@ -608,7 +608,7 @@ func handlerVulnProfileExport(w http.ResponseWriter, r *http.Request, ps httprou
 	}
 
 	var rconf api.RESTVulnProfilesExport
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	err := json.Unmarshal(body, &rconf)
 	if err == nil {
 		for _, name := range rconf.Names {
@@ -720,7 +720,7 @@ func importVulnProfile(scope, option string, loginDomainRoles access.DomainRole,
 	log.Debug()
 	defer os.Remove(importTask.TempFilename)
 
-	json_data, _ := ioutil.ReadFile(importTask.TempFilename)
+	json_data, _ := os.ReadFile(importTask.TempFilename)
 	var secRuleList resource.NvVulnProfileSecurityRuleList
 	var secRule resource.NvVulnProfileSecurityRule
 	var secRules []resource.NvVulnProfileSecurityRule

--- a/controller/rest/waf_rule.go
+++ b/controller/rest/waf_rule.go
@@ -1,12 +1,9 @@
 package rest
 
-// #include "../../defs.h"
-import "C"
-
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"regexp"
@@ -412,7 +409,7 @@ func handlerWafSensorCreate(w http.ResponseWriter, r *http.Request, ps httproute
 	}
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	var rconf api.RESTWafSensorConfigData
 	err := json.Unmarshal(body, &rconf)
 	if err != nil || rconf.Config == nil {
@@ -725,7 +722,7 @@ func handlerWafSensorConfig(w http.ResponseWriter, r *http.Request, ps httproute
 	name := ps.ByName("name")
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	var rconf api.RESTWafSensorConfigData
 	err := json.Unmarshal(body, &rconf)
 	if err != nil || rconf.Config == nil {
@@ -833,7 +830,7 @@ func handlerWafGroupConfig(w http.ResponseWriter, r *http.Request, ps httprouter
 	name := ps.ByName("name")
 
 	// Read request
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	var rconf api.RESTWafGroupConfigData
 	err := json.Unmarshal(body, &rconf)
 	if err != nil || rconf.Config == nil {
@@ -1030,7 +1027,7 @@ func handlerWafExport(w http.ResponseWriter, r *http.Request, ps httprouter.Para
 	}
 
 	var rconf api.RESTWafSensorExport
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	err := json.Unmarshal(body, &rconf)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Request error")
@@ -1137,7 +1134,7 @@ func importWaf(scope string, loginDomainRoles access.DomainRole, importTask shar
 	log.Debug()
 	defer os.Remove(importTask.TempFilename)
 
-	json_data, _ := ioutil.ReadFile(importTask.TempFilename)
+	json_data, _ := os.ReadFile(importTask.TempFilename)
 	var secRuleList resource.NvWafSecurityRuleList
 	var secRule resource.NvWafSecurityRule
 	var secRules []resource.NvWafSecurityRule

--- a/controller/rest/workload.go
+++ b/controller/rest/workload.go
@@ -3,7 +3,7 @@ package rest
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"time"
@@ -475,7 +475,7 @@ func handlerWorkloadConfig(w http.ResponseWriter, r *http.Request, ps httprouter
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var rconf api.RESTWorkloadConfigCfgData
 	err = json.Unmarshal(body, &rconf)
@@ -703,7 +703,7 @@ func handlerWorkloadRequest(w http.ResponseWriter, r *http.Request, ps httproute
 		return
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var req api.RESTWorkloadRequestData
 	err = json.Unmarshal(body, &req)

--- a/controller/scan/dockerhub.go
+++ b/controller/scan/dockerhub.go
@@ -3,7 +3,7 @@ package scan
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/neuvector/neuvector/share"
@@ -58,7 +58,7 @@ func (r dockerhub) GetRepoList(org, name string, limit int) ([]*share.CLUSImage,
 	}
 
 	var regQuery dockerhubRegistryQuery
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/scan/gitlab.go
+++ b/controller/scan/gitlab.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -129,7 +129,7 @@ func (r *gitlab) getData(ur string) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/scan/ibmcloud.go
+++ b/controller/scan/ibmcloud.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -120,7 +120,7 @@ func (r *ibmcloud) getImages() ([]ibmImage, error) {
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/scan/jfrog.go
+++ b/controller/scan/jfrog.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -272,7 +272,7 @@ func (r *jfrog) GetAllImages() (map[share.CLUSImage][]string, error) {
 		}
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		smd.scanLog.WithFields(log.Fields{"error": err}).Error("Failed to read aql query result")
 		return nil, err
@@ -381,7 +381,7 @@ func (r *jfrog) getJFrogDirUrl() ([]jfrogDir, error) {
 	defer resp.Body.Close()
 
 	var jfrogDirs []jfrogDir
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		smd.scanLog.WithFields(log.Fields{"error": err}).Error("Failed to read repo dir")
 		return nil, err

--- a/share/auth/oidc/jwks.go
+++ b/share/auth/oidc/jwks.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -179,7 +179,7 @@ func (r *remoteKeySet) updateKeys() ([]jose.JSONWebKey, time.Time, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, time.Time{}, fmt.Errorf("unable to read response body: %v", err)
 	}

--- a/share/auth/oidc/oidc.go
+++ b/share/auth/oidc/oidc.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime"
 	"net/http"
 	"strings"
@@ -36,12 +36,11 @@ const (
 // This method sets the same context key used by the golang.org/x/oauth2 package,
 // so the returned context works for that package too.
 //
-//    myClient := &http.Client{}
-//    ctx := oidc.ClientContext(parentContext, myClient)
+//	myClient := &http.Client{}
+//	ctx := oidc.ClientContext(parentContext, myClient)
 //
-//    // This will use the custom client
-//    provider, err := oidc.NewProvider(ctx, "https://accounts.example.com")
-//
+//	// This will use the custom client
+//	provider, err := oidc.NewProvider(ctx, "https://accounts.example.com")
 func ClientContext(ctx context.Context, client *http.Client) context.Context {
 	return context.WithValue(ctx, oauth2.HTTPClient, client)
 }
@@ -100,7 +99,7 @@ func Discover(ctx context.Context, issuer string) (*Endpoints, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read response body: %v", err)
 	}
@@ -124,14 +123,14 @@ func Discover(ctx context.Context, issuer string) (*Endpoints, error) {
 
 // Claims unmarshals raw fields returned by the server during discovery.
 //
-//    var claims struct {
-//        ScopesSupported []string `json:"scopes_supported"`
-//        ClaimsSupported []string `json:"claims_supported"`
-//    }
+//	var claims struct {
+//	    ScopesSupported []string `json:"scopes_supported"`
+//	    ClaimsSupported []string `json:"claims_supported"`
+//	}
 //
-//    if err := provider.Claims(&claims); err != nil {
-//        // handle unmarshaling error
-//    }
+//	if err := provider.Claims(&claims); err != nil {
+//	    // handle unmarshaling error
+//	}
 //
 // For a list of fields defined by the OpenID Connect spec see:
 // https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
@@ -187,7 +186,7 @@ func UserInfoReq(ctx context.Context, userInfoURL string, tokenSource oauth2.Tok
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -246,18 +245,17 @@ type IDToken struct {
 
 // Claims unmarshals the raw JSON payload of the ID Token into a provided struct.
 //
-//		idToken, err := idTokenVerifier.Verify(rawIDToken)
-//		if err != nil {
-//			// handle error
-//		}
-//		var claims struct {
-//			Email         string `json:"email"`
-//			EmailVerified bool   `json:"email_verified"`
-//		}
-//		if err := idToken.Claims(&claims); err != nil {
-//			// handle error
-//		}
-//
+//	idToken, err := idTokenVerifier.Verify(rawIDToken)
+//	if err != nil {
+//		// handle error
+//	}
+//	var claims struct {
+//		Email         string `json:"email"`
+//		EmailVerified bool   `json:"email_verified"`
+//	}
+//	if err := idToken.Claims(&claims); err != nil {
+//		// handle error
+//	}
 func (i *IDToken) Claims() (map[string]interface{}, error) {
 	if i.claims == nil {
 		return nil, errors.New("oidc: claims not set")

--- a/share/cluster/api/acl.go
+++ b/share/cluster/api/acl.go
@@ -3,7 +3,6 @@ package api
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"time"
 
@@ -676,7 +675,7 @@ func (a *ACL) RulesTranslate(rules io.Reader) (string, error) {
 	parseQueryMeta(resp, qm)
 	qm.RequestTime = rtt
 
-	ruleBytes, err := ioutil.ReadAll(resp.Body)
+	ruleBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("Failed to read translated rule body: %v", err)
 	}
@@ -700,7 +699,7 @@ func (a *ACL) RulesTranslateToken(tokenID string) (string, error) {
 	parseQueryMeta(resp, qm)
 	qm.RequestTime = rtt
 
-	ruleBytes, err := ioutil.ReadAll(resp.Body)
+	ruleBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("Failed to read translated rule body: %v", err)
 	}

--- a/share/cluster/api/api.go
+++ b/share/cluster/api/api.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -558,7 +557,7 @@ func NewClient(config *Config) (*Client, error) {
 	// This is because when TokenFile is set it is read into the Token field.
 	// We want any derived clients to have to re-read the token file.
 	if config.TokenFile != "" {
-		data, err := ioutil.ReadFile(config.TokenFile)
+		data, err := os.ReadFile(config.TokenFile)
 		if err != nil {
 			return nil, fmt.Errorf("Error loading token file: %s", err)
 		}
@@ -839,7 +838,7 @@ func (c *Client) write(endpoint string, in, out interface{}, q *WriteOptions) (*
 		if err := decodeBody(resp, &out); err != nil {
 			return nil, err
 		}
-	} else if _, err := ioutil.ReadAll(resp.Body); err != nil {
+	} else if _, err := io.ReadAll(resp.Body); err != nil {
 		return nil, err
 	}
 	return wm, nil
@@ -903,7 +902,7 @@ func parseQueryMeta(resp *http.Response, q *QueryMeta) error {
 // decodeBody is used to JSON decode a body
 func decodeBody(resp *http.Response, out interface{}) error {
 	// Neuvector: improve memory usage which incurs from manipulating buffering data
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err==nil && data != nil {
 		return json.Unmarshal(data, out)
 	}

--- a/share/cluster/api/debug.go
+++ b/share/cluster/api/debug.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strconv"
 )
 
@@ -31,7 +31,7 @@ func (d *Debug) Heap() ([]byte, error) {
 
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding body: %s", err)
 	}
@@ -54,7 +54,7 @@ func (d *Debug) Profile(seconds int) ([]byte, error) {
 
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding body: %s", err)
 	}
@@ -77,7 +77,7 @@ func (d *Debug) Trace(seconds int) ([]byte, error) {
 
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding body: %s", err)
 	}
@@ -97,7 +97,7 @@ func (d *Debug) Goroutine() ([]byte, error) {
 
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding body: %s", err)
 	}

--- a/share/cluster/consul.go
+++ b/share/cluster/consul.go
@@ -450,7 +450,7 @@ func ConsulGet(url string) (string, bool) {
 	log.Printf("Status of Get %s %d for %s", resp.Status, resp.StatusCode, url)
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		var jsonBody []consulBody
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		err = json.Unmarshal(body, &jsonBody)
 		existingValue, err := b64.StdEncoding.DecodeString(jsonBody[0].Value)
 		if err != nil {
@@ -494,7 +494,7 @@ func GetAll(store string) ([][]byte, []int, bool) {
 		var jsonBody []consulBody
 		valueArr := make([][]byte, 0)
 		indexArr := make([]int, 0)
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		err = json.Unmarshal(body, &jsonBody)
 		for _, body := range jsonBody {
 			existingValue, _ := b64.StdEncoding.DecodeString(body.Value)

--- a/share/cluster/grpc.go
+++ b/share/cluster/grpc.go
@@ -6,8 +6,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"path"
 	"strings"
 	"sync"
@@ -139,7 +139,7 @@ func ReloadInternalCert() error {
 	certCacheLock.Lock()
 	defer certCacheLock.Unlock()
 	var err error
-	caCert, err := ioutil.ReadFile(path.Join(InternalCertDir, InternalCACert))
+	caCert, err := os.ReadFile(path.Join(InternalCertDir, InternalCACert))
 	if err != nil {
 		return err
 	}

--- a/share/container/common.go
+++ b/share/container/common.go
@@ -249,7 +249,7 @@ func (s *DockerDriver) GetContainerLogs(fromDocker bool, id string, start, limit
 			return nil, fmt.Errorf("Get container log from docker fail:%v", err)
 		} else {
 			defer r.Close()
-			if dat, err := ioutil.ReadAll(r); err != nil {
+			if dat, err := io.ReadAll(r); err != nil {
 				return nil, fmt.Errorf("Read container log fail:%v", err)
 			} else {
 				return dat, nil

--- a/share/container/cri_client.go
+++ b/share/container/cri_client.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -260,7 +260,7 @@ func criGetContainerSocketPath(conn *grpc.ClientConn, ctx context.Context, id, e
 
 func criGetSelfID(conn *grpc.ClientConn, ctx context.Context, rid string) (string, error) {
 	var podname string
-	if dat, err := ioutil.ReadFile("/etc/hostname"); err == nil {
+	if dat, err := os.ReadFile("/etc/hostname"); err == nil {
 		podname = strings.TrimSpace(string(dat))
 	}
 
@@ -305,7 +305,7 @@ func criGetStorageDevice(conn *grpc.ClientConn, ctx context.Context) (string, er
 			if fsid := usage.GetFsId(); fsid != nil {
 					dev := strings.TrimSuffix(filepath.Base(fsid.GetMountpoint()), "-images")
 					if dev == "docker" { // find the driver
-						if entries, err := ioutil.ReadDir((filepath.Join("/proc/1/root", fsid.GetMountpoint(), "image"))); err == nil {
+						if entries, err := os.ReadDir((filepath.Join("/proc/1/root", fsid.GetMountpoint(), "image"))); err == nil {
 							dev = "overlay2"  // default
 							for _, dir := range entries {
 								dev = dir.Name()

--- a/share/container/crio.go
+++ b/share/container/crio.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -61,7 +60,7 @@ func getPauseImageRepoDigests(sys *system.SystemTools) (string, error) {
 	}
 
 	for _, filename := range config_files {
-		dat, err := ioutil.ReadFile(filename)
+		dat, err := os.ReadFile(filename)
 		if err != nil {
 			continue
 		}

--- a/share/container/dockerclient/dockerclient.go
+++ b/share/container/dockerclient/dockerclient.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -89,7 +88,7 @@ func (client *DockerClient) doRequest(method string, path string, body []byte, h
 	}
 
 	defer reader.Close()
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +121,7 @@ func (client *DockerClient) doStreamRequest(method string, path string, in io.Re
 	}
 	if resp.StatusCode == 404 {
 		defer resp.Body.Close()
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, ErrNotFound
 		}
@@ -137,7 +136,7 @@ func (client *DockerClient) doStreamRequest(method string, path string, in io.Re
 	}
 	if resp.StatusCode >= 400 {
 		defer resp.Body.Close()
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -697,7 +696,7 @@ func (client *DockerClient) PullImage(name string, auth *AuthConfig) error {
 		return ErrNotFound
 	}
 	if resp.StatusCode >= 400 {
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/share/container/dockerclient/tls.go
+++ b/share/container/dockerclient/tls.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
@@ -13,15 +13,15 @@ import (
 // path is usually what is set by the environment variable `DOCKER_CERT_PATH`,
 // or `$HOME/.docker`.
 func TLSConfigFromCertPath(path string) (*tls.Config, error) {
-	cert, err := ioutil.ReadFile(filepath.Join(path, "cert.pem"))
+	cert, err := os.ReadFile(filepath.Join(path, "cert.pem"))
 	if err != nil {
 		return nil, err
 	}
-	key, err := ioutil.ReadFile(filepath.Join(path, "key.pem"))
+	key, err := os.ReadFile(filepath.Join(path, "key.pem"))
 	if err != nil {
 		return nil, err
 	}
-	ca, err := ioutil.ReadFile(filepath.Join(path, "ca.pem"))
+	ca, err := os.ReadFile(filepath.Join(path, "ca.pem"))
 	if err != nil {
 		return nil, err
 	}

--- a/share/container/stub.go
+++ b/share/container/stub.go
@@ -3,7 +3,6 @@ package container
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -59,9 +58,9 @@ func InitStubRtDriver(sys *system.SystemTools) (Runtime, error) {
 	ppid := os.Getppid()
 
 	id, _, _, _ = sys.GetContainerIDByPID(ppid)
-	if dat, err := ioutil.ReadFile("/etc/hostname"); err == nil {
+	if dat, err := os.ReadFile("/etc/hostname"); err == nil {
 		podname = strings.TrimSpace(string(dat))
-		if dat, err = ioutil.ReadFile("/etc/hosts"); err == nil {
+		if dat, err = os.ReadFile("/etc/hosts"); err == nil {
 			for _, line := range strings.Split(strings.Trim(string(dat), " \t\r\n"), "\n") {
 				line = strings.Replace(strings.Trim(line, " \t"), "\t", " ", -1)
 				if len(line) == 0 || line[0] == ';' || line[0] == '#' {

--- a/share/fsmon/fanotify_linux.go
+++ b/share/fsmon/fanotify_linux.go
@@ -2,7 +2,6 @@ package fsmon
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -79,7 +78,7 @@ func NewFaNotify(endFaChan chan bool, cb PidLookupCallback, sys *system.SystemTo
 }
 
 func (fn *FaNotify) checkConfigPerm() bool {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "fan_test")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "fan_test")
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("FMON: Create temp directory fail")
 		return false

--- a/share/migration/migration_informer.go
+++ b/share/migration/migration_informer.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -72,13 +71,13 @@ func verifyCert(cacert []byte, cert []byte, key []byte) error {
 }
 
 func GetCurrentInternalCerts() (cacert []byte, cert []byte, key []byte, err error) {
-	if cacert, err = ioutil.ReadFile(path.Join(cluster.InternalCertDir, cluster.InternalCACert)); err != nil {
+	if cacert, err = os.ReadFile(path.Join(cluster.InternalCertDir, cluster.InternalCACert)); err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to read cacert: %w", err)
 	}
-	if cert, err = ioutil.ReadFile(path.Join(cluster.InternalCertDir, cluster.InternalCert)); err != nil {
+	if cert, err = os.ReadFile(path.Join(cluster.InternalCertDir, cluster.InternalCert)); err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to read cert: %w", err)
 	}
-	if key, err = ioutil.ReadFile(path.Join(cluster.InternalCertDir, cluster.InternalCertKey)); err != nil {
+	if key, err = os.ReadFile(path.Join(cluster.InternalCertDir, cluster.InternalCertKey)); err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to read key: %w", err)
 	}
 	return
@@ -89,13 +88,13 @@ func ReloadCert(cacert []byte, cert []byte, key []byte) error {
 		return fmt.Errorf("invalid key/cert: %w", err)
 	}
 
-	if err := ioutil.WriteFile(path.Join(cluster.InternalCertDir, cluster.InternalCACert), []byte(cacert), 0600); err != nil {
+	if err := os.WriteFile(path.Join(cluster.InternalCertDir, cluster.InternalCACert), []byte(cacert), 0600); err != nil {
 		return fmt.Errorf("failed to write cacert: %w", err)
 	}
-	if err := ioutil.WriteFile(path.Join(cluster.InternalCertDir, cluster.InternalCert), []byte(cert), 0600); err != nil {
+	if err := os.WriteFile(path.Join(cluster.InternalCertDir, cluster.InternalCert), []byte(cert), 0600); err != nil {
 		return fmt.Errorf("failed to write cert: %w", err)
 	}
-	if err := ioutil.WriteFile(path.Join(cluster.InternalCertDir, cluster.InternalCertKey), []byte(key), 0600); err != nil {
+	if err := os.WriteFile(path.Join(cluster.InternalCertDir, cluster.InternalCertKey), []byte(key), 0600); err != nil {
 		return fmt.Errorf("failed to write key: %w", err)
 	}
 	return nil

--- a/share/orchestration/kubernetes.go
+++ b/share/orchestration/kubernetes.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -161,7 +160,7 @@ func getVersion(tag string, verToGet int, useToken bool) (string, error) {
 		return "", fmt.Errorf("New Request fail - error=%s", err)
 	}
 	if useToken {
-		if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token"); err != nil {
+		if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token"); err != nil {
 			return "", fmt.Errorf("Read File fail - tag=%s, error=%s", tag, err)
 		} else {
 			req.Header.Set("Authorization", "Bearer "+string(data))
@@ -175,7 +174,7 @@ func getVersion(tag string, verToGet int, useToken bool) (string, error) {
 	defer resp.Body.Close()
 
 	var data []byte
-	data, err = ioutil.ReadAll(resp.Body)
+	data, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("Read data fail - error=%s", err)
 	}
@@ -625,7 +624,7 @@ func (d *kubernetes) createCleanupScript(wr io.Writer, hostPorts map[string][]sh
 
 func (d *kubernetes) CleanupHostPorts(hostPorts map[string][]share.CLUSIPAddr) error {
 	if d.flavor == share.FlavorOpenShift {
-		if f, err := ioutil.TempFile("", "ovs"); err != nil {
+		if f, err := os.CreateTemp("", "ovs"); err != nil {
 			log.WithFields(log.Fields{"error": err}).Error("Failed to create file")
 			return err
 		} else {

--- a/share/osutil/file_linux.go
+++ b/share/osutil/file_linux.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -67,7 +66,7 @@ func fileExists(path string) bool {
 
 func extractProcRootPath(pid int, input string, inTest bool) (string, error) {
 	if inTest {
-		// Since we use ioutil.TempDir("", "proc") to mock proc file system
+		// Since we use os.MkdirTemp("", "proc") to mock proc file system
 		// Regular expression to match the pattern /proc/[number]/root/
 		re := regexp.MustCompile(`.*/proc/\d+/root/`)
 		matches := re.FindStringSubmatch(input)
@@ -348,7 +347,7 @@ func CopyDir(src string, dst string) error {
 		return err
 	}
 
-	entries, err := ioutil.ReadDir(src)
+	entries, err := os.ReadDir(src)
 	if err != nil {
 		return err
 	}
@@ -363,7 +362,7 @@ func CopyDir(src string, dst string) error {
 			}
 		} else {
 			// Skip symlinks
-			if entry.Mode()&os.ModeSymlink != 0 {
+			if entry.Type()&os.ModeSymlink != 0 {
 				continue
 			}
 

--- a/share/osutil/file_linux_test.go
+++ b/share/osutil/file_linux_test.go
@@ -1,7 +1,6 @@
 package osutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -480,7 +479,7 @@ func TestGetContainerRealFilePath(t *testing.T) {
 	// 2. abs path for symlink
 	// 3. append another layer on type 1, make it a nest link
 	// 4. circular link
-	tempDir, err := ioutil.TempDir("", "proc")
+	tempDir, err := os.MkdirTemp("", "proc")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/share/osutil/process_linux.go
+++ b/share/osutil/process_linux.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -56,7 +55,7 @@ type SocketInfo struct {
 func GetProcessPIDs(pid int) (ppid, gid, sid int, status, cmd string) {
 	ppid = -1
 	filename := global.SYS.ContainerProcFilePath(pid, "/stat")
-	dat, err := ioutil.ReadFile(filename)
+	dat, err := os.ReadFile(filename)
 	if err != nil {
 		// log.WithFields(log.Fields{"error": err, "file": filename}).Error("")
 		return
@@ -395,7 +394,7 @@ func GetProcessConnection(pid int, clientPort *share.CLUSProtoPort, inodes utils
 func GetProcessUIDs(pid int) (name string, ppid, ruid, euid int) {
 	ppid = -1
 	filename := global.SYS.ContainerProcFilePath(pid, "/status")
-	dat, err := ioutil.ReadFile(filename)
+	dat, err := os.ReadFile(filename)
 	if err != nil {
 		// No log here, too many error when called by escalation eval.
 		// log.WithFields(log.Fields{"error": err, "file": filename}).Error("")

--- a/share/osutil/user_linux.go
+++ b/share/osutil/user_linux.go
@@ -3,7 +3,7 @@ package osutil
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -117,7 +117,7 @@ func GetAllUsers(pid int, users map[int]string) (int, int, error) {
 
 func getUserNsUid(pid int) (int, error) {
 	filename := global.SYS.ContainerProcFilePath(pid, "/uid_map")
-	dat, err := ioutil.ReadFile(filename)
+	dat, err := os.ReadFile(filename)
 	if err != nil {
 		log.WithFields(log.Fields{"err": err, "pid": pid}).Debug("Get uid_map fail")
 		return -1, err

--- a/share/scan/apps.go
+++ b/share/scan/apps.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -426,7 +425,7 @@ func parseJarManifestFile(path string, rc io.Reader) (*AppPackage, error) {
 }
 
 func (s *ScanApps) parseJarPackage(r zip.Reader, tfile, filename, fullpath string, depth int) {
-	tempDir, err := ioutil.TempDir(filepath.Dir(fullpath), "")
+	tempDir, err := os.MkdirTemp(filepath.Dir(fullpath), "")
 	if err == nil {
 		defer os.RemoveAll(tempDir)
 	} else {
@@ -554,7 +553,7 @@ func isPhpComposer(filename string) bool {
 func (s *ScanApps) parsePhpComposerJson(filename string, filepath string) {
 	data := ComposerLock{}
 	//extract json data
-	bytes, err := ioutil.ReadFile(filepath)
+	bytes, err := os.ReadFile(filepath)
 	if err != nil {
 		log.WithFields(log.Fields{"err": err, "file": filename}).Error("failed to read composer.lock file")
 		return
@@ -670,7 +669,7 @@ func (s *ScanApps) parseDotNetPackage(filename, fullpath string) {
 
 	var dotnet dotnetPackage
 
-	if data, err := ioutil.ReadFile(fullpath); err != nil {
+	if data, err := os.ReadFile(fullpath); err != nil {
 		log.WithFields(log.Fields{"err": err, "fullpath": fullpath, "filename": filename}).Error("Failed to read file")
 		return
 	} else if err = json.Unmarshal(data, &dotnet); err != nil {

--- a/share/scan/compliance.go
+++ b/share/scan/compliance.go
@@ -2,7 +2,6 @@ package scan
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -2481,7 +2480,7 @@ func GetK8sCISFolder(platform, flavor string, inProductionK8s bool) string {
 }
 
 func processYAMLFile(path string) error {
-	fileContent, err := ioutil.ReadFile(path)
+	fileContent, err := os.ReadFile(path)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Error reading file")
 		return err

--- a/share/scan/registry/errortransport.go
+++ b/share/scan/registry/errortransport.go
@@ -2,7 +2,7 @@ package registry
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -33,7 +33,7 @@ func (t *ErrorTransport) RoundTrip(request *http.Request) (*http.Response, error
 
 	if resp.StatusCode >= 400 {
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("http: failed to read response body (status=%v, err=%q)", resp.StatusCode, err)
 		}

--- a/share/scan/registry/manifest.go
+++ b/share/scan/registry/manifest.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -110,7 +110,7 @@ func (r *Registry) ManifestRequest(ctx context.Context, repository, reference st
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", nil, err
 	}
@@ -286,7 +286,7 @@ func (r *Registry) ImageConfigSpecV1(ctx context.Context, repository string, ref
 	rd, _, err := r.DownloadLayer(ctx, repository, reference)
 	if err == nil {
 		defer rd.Close()
-		if body, err := ioutil.ReadAll(rd); err == nil {
+		if body, err := io.ReadAll(rd); err == nil {
 			// log.WithFields(log.Fields{"body": string(body[:])}).Debug()
 
 			var ics imageConfigSpec

--- a/share/scan/registry/tokentransport.go
+++ b/share/scan/registry/tokentransport.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -28,7 +28,7 @@ func (t *TokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return resp, err
 	}
 	if authService := isTokenDemand(resp); authService != nil {
-		_, err := ioutil.ReadAll(resp.Body)
+		_, err := io.ReadAll(resp.Body)
 		if err == nil {
 			err = resp.Body.Close()
 		}

--- a/share/scan/scan_utils.go
+++ b/share/scan/scan_utils.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -130,7 +129,7 @@ func (s *ScanUtil) readRunningPackages(id string, pid int, prefix, kernel string
 			}
 			hasPackage = true
 		} else if lib == DpkgStatusDir {
-			dpkgfiles, err := ioutil.ReadDir(path)
+			dpkgfiles, err := os.ReadDir(path)
 			if err != nil {
 				continue
 			}
@@ -547,7 +546,7 @@ func GetAwsFuncPackages(fileName string) ([]*share.ScanAppPackage, error) {
 	defer os.Remove(fileName) // clean up
 
 	apps := NewScanApps(true)
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "scan_lambda")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "scan_lambda")
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Create temp directory fail")
 		return nil, err
@@ -563,7 +562,7 @@ func GetAwsFuncPackages(fileName string) ([]*share.ScanAppPackage, error) {
 			}
 			defer zFile.Close()
 
-			tmpfile, err := ioutil.TempFile(tmpDir, "extract")
+			tmpfile, err := os.CreateTemp(tmpDir, "extract")
 			if err != nil {
 				log.WithFields(log.Fields{"err": err, "filename": file.Name}).Error("write to temp file fail")
 				continue

--- a/share/scan/secrets/secrets.go
+++ b/share/scan/secrets/secrets.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -518,7 +517,7 @@ func InspectFile(fullpath, reportPath string, config Config) ([]share.CLUSSecret
 	}
 
 	// load the content
-	content, err := ioutil.ReadFile(fullpath)
+	content, err := os.ReadFile(fullpath)
 	if err != nil {
 		log.WithFields(log.Fields{"filepath": dir + "/" + filename}).Error()
 		return res, false

--- a/share/system/cgroup_linux.go
+++ b/share/system/cgroup_linux.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -441,7 +440,7 @@ func getCgroupParamKeyValue(t string) (string, uint64, error) {
 // Gets a single uint64 value from the specified cgroup file.
 func getCgroupParamUint(cgroupPath, cgroupFile string) (uint64, error) {
 	fileName := filepath.Join(cgroupPath, cgroupFile)
-	contents, err := ioutil.ReadFile(fileName)
+	contents, err := os.ReadFile(fileName)
 	if err != nil {
 		return 0, err
 	}
@@ -1030,14 +1029,14 @@ func readAufsContainerLayerPaths(rootPid int, id string) (string, string, error)
 		d.Close()
 	}
 
-	if content, err := ioutil.ReadFile(filepath.Join(siPath, "br0")); err == nil {
+	if content, err := os.ReadFile(filepath.Join(siPath, "br0")); err == nil {
 		cPath = string(content)
 		if pos := strings.LastIndex(cPath, "="); pos != -1 {
 			cPath = cPath[:pos]
 		}
 	}
 
-	if content, err := ioutil.ReadFile(filepath.Join(siPath, fmt.Sprintf("br%d", baseIndex))); err == nil {
+	if content, err := os.ReadFile(filepath.Join(siPath, fmt.Sprintf("br%d", baseIndex))); err == nil {
 		iPath = string(content)
 		if pos := strings.LastIndex(iPath, "="); pos != -1 {
 			iPath = iPath[:pos]

--- a/share/system/sysinfo/memory_arm64.go
+++ b/share/system/sysinfo/memory_arm64.go
@@ -11,7 +11,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -42,7 +41,7 @@ func qword(data []byte, index int) uint64 {
 }
 
 func getStructureTable() ([]byte, error) {
-	data, err := ioutil.ReadFile("/sys/firmware/dmi/tables/DMI")
+	data, err := os.ReadFile("/sys/firmware/dmi/tables/DMI")
 	if err != nil {
 		return nil, err
 	}

--- a/share/system/sysinfo/network.go
+++ b/share/system/sysinfo/network.go
@@ -5,7 +5,7 @@
 package sysinfo
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"syscall"
@@ -96,7 +96,7 @@ func getSupported(name string) uint32 {
 
 func (si *SysInfo) getNetworkInfo() {
 	sysClassNet := "/sys/class/net"
-	devices, err := ioutil.ReadDir(sysClassNet)
+	devices, err := os.ReadDir(sysClassNet)
 	if err != nil {
 		return
 	}

--- a/share/system/sysinfo/storage.go
+++ b/share/system/sysinfo/storage.go
@@ -6,7 +6,6 @@ package sysinfo
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -60,7 +59,7 @@ scan:
 
 func (si *SysInfo) getStorageInfo() {
 	sysBlock := "/sys/block"
-	devices, err := ioutil.ReadDir(sysBlock)
+	devices, err := os.ReadDir(sysBlock)
 	if err != nil {
 		return
 	}

--- a/share/system/sysinfo/util.go
+++ b/share/system/sysinfo/util.go
@@ -6,7 +6,6 @@ package sysinfo
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,7 +25,7 @@ func joinLink(root, link, dir string) string {
 // Read one-liner text files, strip newline.
 func slurpFile(path string) string {
 	path = fmt.Sprintf("%s%s", rootPathPrefix, path)
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return ""
 	}
@@ -37,7 +36,7 @@ func slurpFile(path string) string {
 // Write one-liner text files, add newline, ignore errors (best effort).
 func spewFile(path string, data string, perm os.FileMode) {
 	path = fmt.Sprintf("%s%s", rootPathPrefix, path)
-	_ = ioutil.WriteFile(path, []byte(data+"\n"), perm)
+	_ = os.WriteFile(path, []byte(data+"\n"), perm)
 }
 
 func openFile(path string) (*os.File, error) {

--- a/share/system/system_linux.go
+++ b/share/system/system_linux.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -212,7 +211,7 @@ func (s *SystemTools) GetHostname(pid int) string {
 	var hostname string
 
 	s.CallNamespaceFunc(pid, []string{namespace.NSUTS}, func(params interface{}) {
-		if data, err := ioutil.ReadFile("/proc/sys/kernel/hostname"); err != nil {
+		if data, err := os.ReadFile("/proc/sys/kernel/hostname"); err != nil {
 			log.WithFields(log.Fields{"error": err}).Error("Failed to read hostname")
 		} else {
 			hostname = strings.TrimSpace(string(data))
@@ -292,7 +291,7 @@ func (s *SystemTools) GetGlobalAddrs(device_only bool) map[string][]net.IPNet {
 
 func (s *SystemTools) GetLocalProcessStatus(pid int) string {
 	filename := fmt.Sprintf("/proc/%v/stat", pid)
-	dat, err := ioutil.ReadFile(filename)
+	dat, err := os.ReadFile(filename)
 	if err != nil {
 		return ""
 	}
@@ -497,7 +496,7 @@ func (s *SystemTools) NsRunScript(pid int, scripts string) ([]byte, error) {
 	randBytes := make([]byte, 16)
 	rand.Read(randBytes)
 	filename := filepath.Join(os.TempDir(), hex.EncodeToString(randBytes))
-	if err := ioutil.WriteFile(filename, []byte(scripts), 0644); err != nil {
+	if err := os.WriteFile(filename, []byte(scripts), 0644); err != nil {
 		return nil, err
 	}
 	defer os.Remove(filename)
@@ -558,7 +557,7 @@ func (s *SystemTools) GetProcessName(pid int) (string, int, error) {
 	var name string
 	var ppid int
 	filename := s.ContainerProcFilePath(pid, "/status")
-	dat, err := ioutil.ReadFile(filename)
+	dat, err := os.ReadFile(filename)
 	if err != nil {
 		return "", 0, err
 	}
@@ -632,7 +631,7 @@ func (s *SystemTools) ReadContainerFile(filePath string, pid, start, length int)
 	wholePath := s.ContainerFilePath(pid, filePath)
 
 	if start == 0 && length == 0 {
-		return ioutil.ReadFile(wholePath)
+		return os.ReadFile(wholePath)
 	}
 
 	f, err := os.Open(wholePath)

--- a/share/utils/perf.go
+++ b/share/utils/perf.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime/pprof"
@@ -139,7 +138,7 @@ func PerfSnapshot(pid int, memLimit, profileLimit, usage uint64, folder, cid, pr
 		PerfProfile(req, workFolder, prefix)
 
 		// deferred action because PerfProfile will create the tmp_folder
-		ioutil.WriteFile(filepath.Join(workFolder, "data.json"), file, 0644)
+		os.WriteFile(filepath.Join(workFolder, "data.json"), file, 0644)
 
 		//  write the .tar.gzip
 		targetZipFile := filepath.Join(folder, fmt.Sprintf("%ssnapshot.%s.%s.zip", prefix, cid, label))

--- a/share/utils/srslog/srslog.go
+++ b/share/utils/srslog/srslog.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -58,7 +57,7 @@ func DialWithCustomDialer(network, raddr string, timeout time.Duration, priority
 // address raddr on the specified network. It uses certPath to load TLS certificates and configure
 // the secure connection.
 func DialWithTLSCertPath(network, raddr string, timeout time.Duration, priority Priority, tag, certPath string) (*Writer, error) {
-	serverCert, err := ioutil.ReadFile(certPath)
+	serverCert, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}

--- a/share/utils/utils.go
+++ b/share/utils/utils.go
@@ -19,7 +19,6 @@ import (
 	"hash/crc32"
 	"hash/fnv"
 	"io"
-	"io/ioutil"
 	"math/big"
 	mathrand "math/rand"
 	"net"
@@ -203,7 +202,7 @@ func GunzipBytes(buf []byte) []byte {
 		return nil
 	}
 	defer r.Close()
-	uzb, _ := ioutil.ReadAll(r)
+	uzb, _ := io.ReadAll(r)
 	return uzb
 }
 


### PR DESCRIPTION
…ated package io/ioutil calls ReadAll/ReadFile/TempDir/TempFile/WriteFile/NopCloser/ReadDir)

The io/ioutil package is deprecated since golang 1.16. 
Update related calls with methods in io or os packages 
(see https://go.dev/doc/go1.16#ioutil )
```
ioutil.ReadAll -> io.ReadAll
ioutil.ReadFile -> os.ReadFile
ioutil.TempDir -> os.MkdirTemp
ioutil.TempFile -> os.CreateTemp
ioutil.WriteFile -> os.WriteFile
ioutil.NopCloser -> io.NopCloser
ioutil.ReadDir -> os.ReadDir
```
One unique change is in neuvector\neuvector\share\osutil\file_linux.go , line 366
Type() is not supported by DirEntry interface

Also some files have 
`import "C"`
but they don't reference anything from C header file.
Remove the unnecessary C import line from those files.