### PR TITLE
fix: do not call cancel in all path in newClient()

### DIFF
--- a/share/cluster/grpc.go
+++ b/share/cluster/grpc.go
@@ -529,7 +529,7 @@ func newClient(s *grpcClient, cb GRPCCallback, compress bool) error {
 	var err error
 	var c *GRPCClient
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+
 	if s.unix {
 		c, err = newGRPCClientUnix(ctx, s.key, s.endpoint, cb, compress)
 	} else {
@@ -539,6 +539,7 @@ func newClient(s *grpcClient, cb GRPCCallback, compress bool) error {
 		log.WithFields(log.Fields{
 			"error": err, "ep": s.endpoint,
 		}).Error("Failed to dial to grpc server")
+		cancel()
 		return err
 	}
 	s.client = c


### PR DESCRIPTION
In the previous version, `cancel()` is called when leaving `newClient()`.  However, it should be called in `s.cancel()` instead in most of cases.
This PR fixes the issue.  