### PR TITLE
NVSHAS-8973: the value of .workloads[].privileged is incorrect in rke clusters with cri-dockerd runtime

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -1901,8 +1901,21 @@ func startWorkerThread(ctx *Context) {
 					if n != nil {
 						if o == nil { // create
 							if !isNeuvectorContainerName(n.Name) {
-								if len(n.LivenessCmds) > 0 || len(n.ReadinessCmds) > 0 {
-									addK8sPodEvent(*n)
+								var probeCmds [][]string
+								var bPrivileged bool
+								for _, c := range n.Containers {
+									if len(c.LivenessCmds) > 0 {
+										probeCmds = append(probeCmds, c.LivenessCmds)
+									}
+									if len(c.ReadinessCmds) > 0 {
+										probeCmds = append(probeCmds, c.ReadinessCmds)
+									}
+									if c.Privileged {
+										bPrivileged = true
+									}
+								}
+								if len(probeCmds) > 0 || bPrivileged {
+									addK8sPodEvent(*n, probeCmds)
 								}
 							}
 

--- a/controller/cache/group.go
+++ b/controller/cache/group.go
@@ -1352,7 +1352,7 @@ func groupWorkloadJoin(id string, param interface{}) {
 			if bHasGroupProfile {
 				createLearnedGroup(wlc, getNewServicePolicyMode(), getNewServiceProfileBaseline(), false, "", access.NewAdminAccessControl())
 				if localDev.Host.Platform == share.PlatformKubernetes {
-					updateK8sPodEvent(wlc.learnedGroupName, wlc.podName, wlc.workload.Domain)
+					updateK8sPodEvent(wlc.learnedGroupName, wlc.podName, wlc.workload.Domain, id)
 				}
 			}
 			// Members is calculated when group change is handled
@@ -1399,9 +1399,10 @@ func groupWorkloadJoin(id string, param interface{}) {
 	// warning: avoid cacheMutexLock() before calling below function
 	if bHasGroupProfile {
 		if localDev.Host.Platform == share.PlatformKubernetes {
-			if !strings.HasPrefix(wlc.workload.Name, "k8s_POD") { // ignore POD
+			if !strings.HasPrefix(wlc.workload.Name, "k8s_POD") {
+				// app containers
 				cacheMutexLock()
-				updateK8sPodEvent(wlc.learnedGroupName, wlc.podName, wlc.workload.Domain)
+				wl.Privileged = updateK8sPodEvent(wlc.learnedGroupName, wlc.podName, wlc.workload.Domain, id)
 				cacheMutexUnlock()
 			}
 		}

--- a/controller/resource/types.go
+++ b/controller/resource/types.go
@@ -111,6 +111,14 @@ type Service struct {
 	ExternalIPs []net.IP
 }
 
+type Container struct {
+	Id            string
+	Name          string
+	Privileged    bool
+	LivenessCmds  []string
+	ReadinessCmds []string
+}
+
 type Pod struct {
 	UID           string
 	Name          string
@@ -122,8 +130,7 @@ type Pod struct {
 	OwnerUID      string
 	OwnerName     string
 	OwnerType     string
-	LivenessCmds  [][]string
-	ReadinessCmds [][]string
+	Containers    []Container
 	SA            string   // service account of this pod
 	ContainerIDs  []string // all workload id
 	Labels        map[string]string


### PR DESCRIPTION
K8s: the latest runtime will not report the privilege flags of the containers. We need to retrieve this information from k8s pod data.

(1) k8s pod data: collecting container data slices.
(2) Update the privilege flag when the controller receives the first reported workload data.  