### PR TITLE
NVSHAS-9026: dup and missing .NET module name

### DIFF
--- a/share/scan/scan_utils.go
+++ b/share/scan/scan_utils.go
@@ -226,7 +226,7 @@ func (s *ScanUtil) GetAppPackages(path string) ([]AppPackage, []byte, share.Scan
 }
 
 func (s *ScanUtil) getContainerAppPkg(pid int) ([]byte, error) {
-	apps := NewScanApps(true)
+	apps := NewScanApps(false) // no need to scan the same file twice
 	exclDirs := utils.NewSet("bin", "boot", "dev", "proc", "run", "sys", "tmp")
 	rootPath := s.sys.ContainerFilePath(pid, "/")
 	rootLen := len(rootPath)


### PR DESCRIPTION
dotNet package parser:

(1) Reduce the duplicate package dependency from the same package manifest file.
(2) Not allowed repeated searching on an app package scan.
(3) DotNetCore version correction.