### PR TITLE
NVSHAS-9071: some modules are not reported in the container scan only

### DIFF
--- a/share/scan/scan_utils.go
+++ b/share/scan/scan_utils.go
@@ -227,7 +227,7 @@ func (s *ScanUtil) GetAppPackages(path string) ([]AppPackage, []byte, share.Scan
 
 func (s *ScanUtil) getContainerAppPkg(pid int) ([]byte, error) {
 	apps := NewScanApps(false) // no need to scan the same file twice
-	exclDirs := utils.NewSet("bin", "boot", "dev", "proc", "run", "sys", "tmp")
+	exclDirs := utils.NewSet("boot", "dev", "proc", "run", "sys")
 	rootPath := s.sys.ContainerFilePath(pid, "/")
 	rootLen := len(rootPath)
 


### PR DESCRIPTION
Container scans: Remove "/tmp" and "/bin" from the skipped paths.