### PR TITLE
NVSHAS-9080: fed reader user is uanble to access POST /v1/fed/cluster…

### DIFF
--- a/controller/rest/federation.go
+++ b/controller/rest/federation.go
@@ -3244,7 +3244,8 @@ func handlerFedClusterForward(w http.ResponseWriter, r *http.Request, ps httprou
 	regScanTest := false
 	txnID := ""
 	if accCaller.IsFedReader() {
-		if method == http.MethodGet || (method == http.MethodPatch && request == "/v1/auth") {
+		if method == http.MethodGet || (method == http.MethodPatch && request == "/v1/auth") ||
+			(method == http.MethodPost && (request == "/v1/vulasset" || request == "/v1/assetvul")) {
 			// forward is allowed
 			// In fedReader user sessions, controller needs to update cluster state as well. So the acc needs to have write permissions for that purpose.
 			acc = access.NewFedAdminAccessControl()


### PR DESCRIPTION
…/:id/v1/vulasset, GET /v1/fed/cluster/:id/v1/vulasset and POST /v1/fed/cluster/:id/v1/assetvul