### PR TITLE
NVSHAS-6740: Improvement of zero-drift baseline profile

### DIFF
--- a/agent/probe/faccess_linux.go
+++ b/agent/probe/faccess_linux.go
@@ -635,7 +635,7 @@ func (fa *FileAccessCtrl) checkAllowedShieldProcess(id, name, path, svcGroup str
 	ppe := &share.CLUSProcessProfileEntry{Name: name, Path: path, Action: share.PolicyActionAllow, DerivedGroup: svcGroup}
 
 	if res == rule_not_defined {
-		ppe.Action = share.PolicyActionViolate
+		ppe.Action = share.PolicyActionDeny
 	}
 
 	if res == rule_allowed_updateAlert {

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -3136,7 +3136,7 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 		//}
 	}
 
-	// mLog.WithFields(log.Fields{"ppe": ppe, "pid": proc.pid, "id": id}).Debug("SHD:")
+	mLog.WithFields(log.Fields{"ppe": ppe, "pid": proc.pid, "id": id}).Debug("SHD:")
 	// ZeroDrift: allow a family member of the root process
 	if isFamilyProcess(c.children, proc) || bRuncChild {
 		// a family member
@@ -3168,6 +3168,7 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 					mLog.WithFields(log.Fields{"proc": proc, "id": id}).Debug("SHD: rissky session")
 					break
 				}
+
 			}
 
 			bPass = true
@@ -3179,11 +3180,8 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 					ppe.Uuid = share.CLUSReservedUuidAnchorMode
 				}
 			}
-		case share.PolicyActionDeny: // from pmon during Protect mode
-			if ppe.Uuid == share.CLUSReservedUuidNotAlllowed {
-				// not a real deny rule
-				bPass = bImageFile
-			}
+		case share.PolicyActionDeny:
+			ppe.Uuid = share.CLUSReservedUuidNotAlllowed
 		}
 	} else {
 		switch ppe.Action {


### PR DESCRIPTION
Add patch after dev54 merged into main.

The not-listed (learned) process during the Protect mode will be blocked as dangerous processes.