### PR TITLE
NVSHAS-9107: goroutine crash at rest.handlerConfigLocalCluster({0x41f…

### DIFF
--- a/controller/rest/federation.go
+++ b/controller/rest/federation.go
@@ -1382,7 +1382,8 @@ func handlerConfigLocalCluster(w http.ResponseWriter, r *http.Request, ps httpro
 	var reqData api.RESTFedConfigData
 	body, _ := io.ReadAll(r.Body)
 	if err := json.Unmarshal(body, &reqData); err != nil || (reqData.Name != nil && *reqData.Name == "") ||
-		!reqData.RestInfo.IsValid() || (reqData.UseProxy != nil && (*reqData.UseProxy != "" && *reqData.UseProxy != "https")) {
+		(reqData.RestInfo != nil && !reqData.RestInfo.IsValid()) ||
+		(reqData.UseProxy != nil && (*reqData.UseProxy != "" && *reqData.UseProxy != "https")) {
 		log.WithFields(log.Fields{"error": err}).Error("Request error")
 		restRespError(w, http.StatusBadRequest, api.RESTErrInvalidRequest)
 		return


### PR DESCRIPTION
…03a0, 0xc0106a49d8}, 0xc0106cc120, {0x5?, 0x0?, 0xc0106c7f80?})