### PR TITLE
fix: NVSHAS-9108 port 18500 shouldn't be open

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -501,11 +501,6 @@ func main() {
 	log.WithFields(log.Fields{"hostIPs": gInfo.hostIPs}).Info("")
 	log.WithFields(log.Fields{"host": Host}).Info("")
 	log.WithFields(log.Fields{"agent": Agent}).Info("")
-	go func() {
-		if err := healthz.StartHealthzServer(); err != nil {
-			log.WithError(err).Warn("failed to start healthz server")
-		}
-	}()
 
 	var internalCertControllerCancel context.CancelFunc
 	var ctx context.Context


### PR DESCRIPTION
By default port 18500 shouldn't be open for enforcer and allinone.  Also verified that controller, scanner and registry-adapter don't have this issue.  