### PR TITLE
NVSHAS-9119: goroutine crash at probe.(*FileNotificationCtr).AddContainer()

### DIFF
--- a/agent/probe/probe.go
+++ b/agent/probe/probe.go
@@ -538,11 +538,10 @@ func New(pc *ProbeConfig) (*Probe, error) {
 		p.FaEndChan <- true
 	}
 
-	if p.bProfileEnable {
-		var ok bool
-		if p.fsnCtr, ok = NewFsnCenter(p, global.RT.GetStorageDriver()); !ok {
-			log.Error("FSN: failed")
-		}
+	// NV Protect is always on even if the the process profile is disabled
+	var ok bool
+	if p.fsnCtr, ok = NewFsnCenter(p, global.RT.GetStorageDriver()); !ok {
+		log.Error("FSN: failed")
 	}
 
 	// build current process maps, host container is established here


### PR DESCRIPTION
The container's file-changed monitor is not initialized when the process profile is disabled. We have a major enhance on the NV Protect on the v5.4.

NV Protect is always on even if the the process profile is disabled.