### PR TITLE
NVSHAS-9124: docker: many unexpected healthcheck processes incidents are reported

### DIFF
--- a/agent/group_profile.go
+++ b/agent/group_profile.go
@@ -1089,7 +1089,7 @@ func updateContainerFamilyTrees(name string) {
 			if c.info != nil {
 				bPrivileged = c.info.Privileged
 			}
-			prober.BuildProcessFamilyGroups(c.id, c.pid, false, bPrivileged)
+			prober.BuildProcessFamilyGroups(c.id, c.pid, false, bPrivileged, c.healthCheck)
 		}
 	}
 }

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -56,6 +56,7 @@ type procContainer struct {
 	checkRemovedPort uint
 	fInfo            map[string]*fileInfo
 	bPrivileged      bool
+	healthCheck      []string
 }
 
 type procInternal struct {
@@ -3064,7 +3065,7 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 
 	bCanBeLearned := true
 	bRuncChild := false
-	if ppe.Action != share.PolicyActionViolate && p.bK8sGroupWithProbe(svcGroup) {
+	if ppe.Action != share.PolicyActionViolate && (p.bK8sGroupWithProbe(svcGroup) || len(c.healthCheck) > 0) {
 		// allowing "kubctl exec ...", adpot the binary path to resolve the name
 		bRuncChild = global.RT.IsRuntimeProcess(proc.pname, nil)
 		if !bRuncChild {
@@ -3216,7 +3217,7 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 	return bPass
 }
 
-func (p *Probe) BuildProcessFamilyGroups(id string, rootPid int, bSandboxPod, bPrivileged bool) {
+func (p *Probe) BuildProcessFamilyGroups(id string, rootPid int, bSandboxPod, bPrivileged bool, healthCheck []string) {
 	//log.WithFields(log.Fields{"id": id, "pid": rootPid}).Debug("SHD:")
 	if !p.bProfileEnable {
 		return
@@ -3251,6 +3252,9 @@ func (p *Probe) BuildProcessFamilyGroups(id string, rootPid int, bSandboxPod, bP
 
 	c.rootPid = rootPid
 	c.bPrivileged = bPrivileged
+	if healthCheck != nil {
+		c.healthCheck = healthCheck		// no override
+	}
 	allPids := c.outsider.Union(c.children)
 	allPids.Add(rootPid) // all collections: add rootPid as a pivot point
 	c.outsider.Clear()   // reset

--- a/share/container/docker.go
+++ b/share/container/docker.go
@@ -242,6 +242,12 @@ func (d *dockerDriver) GetContainer(id string) (*ContainerMetaExtra, error) {
 		LogPath:     info.LogPath,
 	}
 
+	if info.Config != nil && info.Config.Healthcheck != nil {
+		// log.WithFields(log.Fields{"health": info.Config.Healthcheck}).Debug()
+		meta.Healthcheck = make([]string, len(info.Config.Healthcheck.Test))
+		copy(meta.Healthcheck, info.Config.Healthcheck.Test)
+	}
+
 	if info, err := d.client.InspectImage(meta.ImageID); err == nil {
 		meta.Author = info.Author
 		meta.ImgCreateAt = info.Created

--- a/share/container/dockerclient/types.go
+++ b/share/container/dockerclient/types.go
@@ -8,6 +8,24 @@ import (
 	"github.com/docker/go-units"
 )
 
+// docker: HealthConfig holds configuration settings for the HEALTHCHECK feature.
+type HealthConfig struct {
+	// Test is the test to perform to check that the container is healthy.
+	// An empty slice means to inherit the default.
+	// The options are:
+	// {} : inherit healthcheck
+	// {"NONE"} : disable healthcheck
+	// {"CMD", args...} : exec arguments directly
+	// {"CMD-SHELL", command} : run command with system's default shell
+	Test []string `json:",omitempty"`
+
+	// Zero means to inherit. Durations are expressed as integer nanoseconds.
+	Interval    time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
+	Timeout     time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
+	StartPeriod time.Duration `json:",omitempty"` // The start period for the container to initialize before the retries starts to count down.
+	Retries int `json:",omitempty"`
+}
+
 type ContainerConfig struct {
 	Hostname        string
 	Domainname      string
@@ -46,6 +64,7 @@ type ContainerConfig struct {
 
 	// Network configuration support
 	NetworkingConfig NetworkingConfig
+	Healthcheck     *HealthConfig
 }
 
 type HostConfig struct {

--- a/share/container/types.go
+++ b/share/container/types.go
@@ -161,6 +161,7 @@ type ContainerMetaExtra struct {
 	MappedPorts map[share.CLUSProtoPort]*share.CLUSMappedPort
 	Networks    utils.Set
 	LogPath     string
+	Healthcheck []string
 }
 
 func ConnectDocker(endpoint string, sys *system.SystemTools) (Runtime, error) {


### PR DESCRIPTION
The health check commands of the docker containers had been treated as false-positive external intruder process incidents .

This PR is going to neglect those health check commands on the docker native systems. First, it identifies the health check commands from the container runtime data. 