### PR TITLE
[NVSHAS-8799] Fix compliance profile related api and Support Compliance template with update data format

### DIFF
--- a/agent/nvbench/kubernetes-cis-benchmark/aks-1.4.0/worker/3_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/aks-1.4.0/worker/3_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/var/lib/kubelet/kubeconfig"
@@ -45,9 +45,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -72,9 +72,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -103,9 +103,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"           
           if [ -f "$file" ]; then
@@ -132,9 +132,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -170,9 +170,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
@@ -196,9 +196,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -224,9 +224,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
@@ -255,7 +255,7 @@ groups:
         scored: true
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--streaming-connection-idle-timeout=0' >/dev/null 2>&1; then
@@ -280,7 +280,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--make-iptables-util-chains=true' >/dev/null 2>&1; then
@@ -301,7 +301,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--hostname-override' >/dev/null 2>&1; then
@@ -321,7 +321,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--event-qps' >/dev/null 2>&1; then
@@ -371,9 +371,9 @@ groups:
         profile: Level 2
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--rotate-certificates=false' >/dev/null 2>&1; then
@@ -396,9 +396,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""

--- a/agent/nvbench/kubernetes-cis-benchmark/aks-1.4.0/worker/3_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/aks-1.4.0/worker/3_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/var/lib/kubelet/kubeconfig"
@@ -45,9 +45,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -72,9 +72,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -103,9 +103,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"           
           if [ -f "$file" ]; then
@@ -132,9 +132,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -170,9 +170,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
@@ -196,9 +196,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -224,9 +224,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
@@ -371,9 +371,9 @@ groups:
         profile: Level 2
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--rotate-certificates=false' >/dev/null 2>&1; then
@@ -396,9 +396,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/master/1_control_plane_components.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
@@ -44,9 +44,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -70,9 +70,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
@@ -99,9 +99,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -125,9 +125,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
@@ -154,9 +154,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -180,9 +180,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
@@ -209,9 +209,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -235,9 +235,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -278,9 +278,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -321,9 +321,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -356,9 +356,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -384,9 +384,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/admin.conf"
@@ -414,9 +414,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -440,9 +440,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/scheduler.conf"
@@ -470,9 +470,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -496,9 +496,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/controller-manager.conf"
@@ -526,9 +526,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -552,9 +552,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/pki/"
@@ -584,9 +584,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           files=$(find $file -name "*.crt")
@@ -614,9 +614,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           files=$(find $file -name "*.key")
@@ -646,9 +646,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -666,9 +666,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--token-auth-file' >/dev/null 2>&1; then
@@ -687,9 +687,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--DenyServiceExternalIPs' >/dev/null 2>&1; then
@@ -708,9 +708,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-client-certificate' >/dev/null 2>&1; then
@@ -740,9 +740,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-certificate-authority' >/dev/null 2>&1; then
@@ -764,9 +764,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'AlwaysAllow' >/dev/null 2>&1; then
@@ -785,9 +785,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'Node' >/dev/null 2>&1; then
@@ -806,9 +806,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'RBAC' >/dev/null 2>&1; then
@@ -828,8 +828,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'EventRateLimit' >/dev/null 2>&1; then
@@ -850,8 +850,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysAdmit' >/dev/null 2>&1; then
@@ -871,8 +871,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysPullImages' >/dev/null 2>&1; then
@@ -892,8 +892,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'PodSecurityPolicy' >/dev/null 2>&1; then
@@ -917,8 +917,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'ServiceAccount' >/dev/null 2>&1; then
@@ -939,8 +939,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'NamespaceLifecycle' >/dev/null 2>&1; then
@@ -960,8 +960,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'NodeRestriction' >/dev/null 2>&1; then
@@ -981,9 +981,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--secure-port' >/dev/null 2>&1; then
@@ -1007,7 +1007,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--profiling=false' >/dev/null 2>&1; then
@@ -1025,8 +1025,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-path' >/dev/null 2>&1; then
@@ -1047,8 +1047,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxage' >/dev/null 2>&1; then
@@ -1075,8 +1075,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxbackup' >/dev/null 2>&1; then
@@ -1103,8 +1103,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxsize' >/dev/null 2>&1; then
@@ -1130,7 +1130,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--request-timeout' >/dev/null 2>&1; then
@@ -1151,9 +1151,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--service-account-lookup=false' >/dev/null 2>&1; then
@@ -1172,9 +1172,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
@@ -1197,9 +1197,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
@@ -1231,9 +1231,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -1264,9 +1264,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -1289,9 +1289,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
@@ -1315,9 +1315,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--encryption-provider-config'| grep 'EncryptionConfig' >/dev/null 2>&1; then
@@ -1338,9 +1338,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--encryption-provider-config' >/dev/null 2>&1; then
@@ -1368,9 +1368,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--tls-cipher-suites' >/dev/null 2>&1; then
@@ -1410,7 +1410,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           # Filter out processes like "/bin/tee -a /var/log/kube-controller-manager.log"
@@ -1432,7 +1432,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--profiling=false' >/dev/null 2>&1; then
@@ -1451,9 +1451,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--use-service-account-credentials=true' >/dev/null 2>&1; then
@@ -1472,9 +1472,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
@@ -1497,9 +1497,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
@@ -1522,9 +1522,9 @@ groups:
         profile: Level 2
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--feature-gates' >/dev/null 2>&1; then
@@ -1548,7 +1548,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_MANAGER_CMD" '--bind-address'| grep '127.0.0.1' >/dev/null 2>&1; then
@@ -1568,7 +1568,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_SCHEDULER_CMD" '--profiling=false' >/dev/null 2>&1; then
@@ -1585,7 +1585,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_SCHEDULER_CMD" '--bind-address'| grep '127.0.0.1' >/dev/null 2>&1; then

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/master/1_control_plane_components.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
@@ -44,9 +44,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -70,9 +70,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
@@ -99,9 +99,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -125,9 +125,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
@@ -154,9 +154,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -180,9 +180,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
@@ -209,9 +209,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -235,9 +235,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -278,9 +278,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -321,9 +321,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -356,9 +356,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -384,9 +384,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/admin.conf"
@@ -414,9 +414,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -440,9 +440,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/scheduler.conf"
@@ -470,9 +470,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -496,9 +496,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/controller-manager.conf"
@@ -526,9 +526,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -552,9 +552,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/pki/"
@@ -584,9 +584,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           files=$(find $file -name "*.crt")
@@ -614,9 +614,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           files=$(find $file -name "*.key")
@@ -646,9 +646,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -666,9 +666,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--token-auth-file' >/dev/null 2>&1; then
@@ -687,9 +687,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--DenyServiceExternalIPs' >/dev/null 2>&1; then
@@ -708,9 +708,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-client-certificate' >/dev/null 2>&1; then
@@ -740,9 +740,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-certificate-authority' >/dev/null 2>&1; then
@@ -764,9 +764,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'AlwaysAllow' >/dev/null 2>&1; then
@@ -785,9 +785,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'Node' >/dev/null 2>&1; then
@@ -806,9 +806,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'RBAC' >/dev/null 2>&1; then
@@ -828,8 +828,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'EventRateLimit' >/dev/null 2>&1; then
@@ -850,8 +850,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysAdmit' >/dev/null 2>&1; then
@@ -871,8 +871,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysPullImages' >/dev/null 2>&1; then
@@ -892,8 +892,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'PodSecurityPolicy' >/dev/null 2>&1; then
@@ -917,8 +917,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'ServiceAccount' >/dev/null 2>&1; then
@@ -939,8 +939,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'NamespaceLifecycle' >/dev/null 2>&1; then
@@ -960,8 +960,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'NodeRestriction' >/dev/null 2>&1; then
@@ -981,9 +981,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--secure-port' >/dev/null 2>&1; then
@@ -1025,8 +1025,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-path' >/dev/null 2>&1; then
@@ -1047,8 +1047,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxage' >/dev/null 2>&1; then
@@ -1075,8 +1075,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxbackup' >/dev/null 2>&1; then
@@ -1103,8 +1103,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxsize' >/dev/null 2>&1; then
@@ -1151,9 +1151,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--service-account-lookup=false' >/dev/null 2>&1; then
@@ -1172,9 +1172,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
@@ -1197,9 +1197,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
@@ -1231,9 +1231,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -1264,9 +1264,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -1289,9 +1289,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
@@ -1315,9 +1315,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--encryption-provider-config'| grep 'EncryptionConfig' >/dev/null 2>&1; then
@@ -1338,9 +1338,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--encryption-provider-config' >/dev/null 2>&1; then
@@ -1368,9 +1368,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--tls-cipher-suites' >/dev/null 2>&1; then
@@ -1451,9 +1451,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--use-service-account-credentials=true' >/dev/null 2>&1; then
@@ -1472,9 +1472,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
@@ -1497,9 +1497,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
@@ -1522,9 +1522,9 @@ groups:
         profile: Level 2
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--feature-gates' >/dev/null 2>&1; then

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/master/2_etcd.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/master/2_etcd.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
@@ -50,9 +50,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--client-cert-auth' >/dev/null 2>&1; then
@@ -73,9 +73,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--auto-tls=true' >/dev/null 2>&1; then
@@ -98,9 +98,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
@@ -135,9 +135,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-client-cert-auth=true' >/dev/null 2>&1; then
@@ -158,9 +158,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-auto-tls=true' >/dev/null 2>&1; then
@@ -182,9 +182,9 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--trusted-ca-file' >/dev/null 2>&1; then

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/master/2_etcd.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/master/2_etcd.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
@@ -50,9 +50,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--client-cert-auth' >/dev/null 2>&1; then
@@ -73,9 +73,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--auto-tls=true' >/dev/null 2>&1; then
@@ -98,9 +98,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
@@ -135,9 +135,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-client-cert-auth=true' >/dev/null 2>&1; then
@@ -158,9 +158,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-auto-tls=true' >/dev/null 2>&1; then
@@ -182,9 +182,9 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--trusted-ca-file' >/dev/null 2>&1; then

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/master/3_control_plane_configuration.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/master/3_control_plane_configuration.yaml
@@ -14,7 +14,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -32,8 +32,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-policy-file' >/dev/null 2>&1; then
@@ -53,8 +53,8 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/master/3_control_plane_configuration.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/master/3_control_plane_configuration.yaml
@@ -32,8 +32,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-policy-file' >/dev/null 2>&1; then
@@ -53,8 +53,8 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/master/5_policies.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/master/5_policies.yaml
@@ -14,7 +14,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -31,7 +31,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -45,7 +45,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -59,7 +59,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -72,7 +72,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -89,7 +89,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -103,7 +103,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -117,7 +117,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -135,7 +135,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -150,7 +150,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -166,7 +166,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -181,7 +181,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -196,7 +196,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -211,7 +211,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -226,7 +226,7 @@ groups:
         scored: false
         profile: Level 2
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -242,7 +242,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -257,7 +257,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -272,7 +272,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -288,7 +288,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -302,7 +302,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -316,7 +316,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -333,7 +333,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -348,7 +348,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -366,7 +366,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -380,7 +380,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -398,7 +398,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -415,7 +415,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -430,7 +430,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -448,7 +448,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -463,7 +463,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/worker/4_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           kubeadm=$(append_prefix "$CONFIG_PREFIX" "/etc/systemd/system/kubelet.service.d/kubeadm.conf")
@@ -51,9 +51,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -77,9 +77,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -109,9 +109,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"           
           if [ -f "$file" ]; then
@@ -137,9 +137,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -170,9 +170,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -196,9 +196,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -226,9 +226,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -256,9 +256,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -286,9 +286,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -318,9 +318,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -344,9 +344,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
@@ -370,9 +370,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -398,9 +398,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
@@ -429,7 +429,7 @@ groups:
         scored: true
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--streaming-connection-idle-timeout=0' >/dev/null 2>&1; then
@@ -455,9 +455,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--protect-kernel-defaults=true' >/dev/null 2>&1; then
@@ -480,7 +480,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--make-iptables-util-chains=true' >/dev/null 2>&1; then
@@ -501,7 +501,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--hostname-override' >/dev/null 2>&1; then
@@ -521,7 +521,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--event-qps' >/dev/null 2>&1; then
@@ -551,9 +551,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -587,9 +587,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--rotate-certificates=false' >/dev/null 2>&1; then
@@ -612,9 +612,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
@@ -640,9 +640,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           success=1

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/worker/4_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           kubeadm=$(append_prefix "$CONFIG_PREFIX" "/etc/systemd/system/kubelet.service.d/kubeadm.conf")
@@ -51,9 +51,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -77,9 +77,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -109,9 +109,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"           
           if [ -f "$file" ]; then
@@ -137,9 +137,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -170,9 +170,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -196,9 +196,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -226,9 +226,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -256,9 +256,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -286,9 +286,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -318,9 +318,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -344,9 +344,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
@@ -370,9 +370,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -398,9 +398,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
@@ -455,9 +455,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--protect-kernel-defaults=true' >/dev/null 2>&1; then
@@ -551,9 +551,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -587,9 +587,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--rotate-certificates=false' >/dev/null 2>&1; then
@@ -612,9 +612,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
@@ -640,9 +640,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           success=1

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/1_control_plane_components.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
@@ -44,9 +44,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -70,9 +70,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
@@ -99,9 +99,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -125,9 +125,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
@@ -154,9 +154,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -180,9 +180,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
@@ -209,9 +209,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -235,9 +235,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -278,9 +278,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -321,9 +321,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -356,9 +356,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -384,9 +384,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/admin.conf"
@@ -414,9 +414,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -440,9 +440,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/scheduler.conf"
@@ -470,9 +470,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -496,9 +496,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/controller-manager.conf"
@@ -526,9 +526,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -552,9 +552,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/pki/"
@@ -584,9 +584,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           files=$(find $file -name "*.crt")
@@ -614,9 +614,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           files=$(find $file -name "*.key")
@@ -646,9 +646,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -666,9 +666,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--token-auth-file' >/dev/null 2>&1; then
@@ -687,9 +687,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--DenyServiceExternalIPs' >/dev/null 2>&1; then
@@ -708,9 +708,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-client-certificate' >/dev/null 2>&1; then
@@ -740,9 +740,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-certificate-authority' >/dev/null 2>&1; then
@@ -764,9 +764,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'AlwaysAllow' >/dev/null 2>&1; then
@@ -785,9 +785,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'Node' >/dev/null 2>&1; then
@@ -806,9 +806,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'RBAC' >/dev/null 2>&1; then
@@ -828,8 +828,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'EventRateLimit' >/dev/null 2>&1; then
@@ -850,8 +850,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysAdmit' >/dev/null 2>&1; then
@@ -871,8 +871,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysPullImages' >/dev/null 2>&1; then
@@ -892,8 +892,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'PodSecurityPolicy' >/dev/null 2>&1; then
@@ -917,8 +917,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'ServiceAccount' >/dev/null 2>&1; then
@@ -939,8 +939,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'NamespaceLifecycle' >/dev/null 2>&1; then
@@ -960,8 +960,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'NodeRestriction' >/dev/null 2>&1; then
@@ -981,9 +981,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--secure-port' >/dev/null 2>&1; then
@@ -1007,7 +1007,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--profiling=false' >/dev/null 2>&1; then
@@ -1025,8 +1025,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-path' >/dev/null 2>&1; then
@@ -1047,8 +1047,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxage' >/dev/null 2>&1; then
@@ -1075,8 +1075,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxbackup' >/dev/null 2>&1; then
@@ -1103,8 +1103,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxsize' >/dev/null 2>&1; then
@@ -1130,7 +1130,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--request-timeout' >/dev/null 2>&1; then
@@ -1151,9 +1151,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--service-account-lookup=false' >/dev/null 2>&1; then
@@ -1172,9 +1172,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
@@ -1197,9 +1197,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
@@ -1231,9 +1231,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -1264,9 +1264,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -1289,9 +1289,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
@@ -1315,9 +1315,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--encryption-provider-config'| grep 'EncryptionConfig' >/dev/null 2>&1; then
@@ -1338,9 +1338,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--encryption-provider-config' >/dev/null 2>&1; then
@@ -1368,9 +1368,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--tls-cipher-suites' >/dev/null 2>&1; then
@@ -1410,7 +1410,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           # Filter out processes like "/bin/tee -a /var/log/kube-controller-manager.log"
@@ -1432,7 +1432,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--profiling=false' >/dev/null 2>&1; then
@@ -1451,9 +1451,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--use-service-account-credentials=true' >/dev/null 2>&1; then
@@ -1472,9 +1472,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
@@ -1497,9 +1497,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
@@ -1522,9 +1522,9 @@ groups:
         profile: Level 2
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--feature-gates' >/dev/null 2>&1; then
@@ -1548,7 +1548,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_MANAGER_CMD" '--bind-address'| grep '127.0.0.1' >/dev/null 2>&1; then
@@ -1568,7 +1568,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_SCHEDULER_CMD" '--profiling=false' >/dev/null 2>&1; then
@@ -1585,7 +1585,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_SCHEDULER_CMD" '--bind-address'| grep '127.0.0.1' >/dev/null 2>&1; then

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/1_control_plane_components.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
@@ -44,9 +44,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -70,9 +70,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
@@ -99,9 +99,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -125,9 +125,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
@@ -154,9 +154,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -180,9 +180,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
@@ -209,9 +209,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -235,9 +235,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -278,9 +278,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -321,9 +321,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -356,9 +356,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -384,9 +384,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/admin.conf"
@@ -414,9 +414,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -440,9 +440,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/scheduler.conf"
@@ -470,9 +470,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -496,9 +496,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/controller-manager.conf"
@@ -526,9 +526,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -552,9 +552,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/pki/"
@@ -584,9 +584,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           files=$(find $file -name "*.crt")
@@ -614,9 +614,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           files=$(find $file -name "*.key")
@@ -646,9 +646,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -666,9 +666,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--token-auth-file' >/dev/null 2>&1; then
@@ -687,9 +687,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--DenyServiceExternalIPs' >/dev/null 2>&1; then
@@ -708,9 +708,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-client-certificate' >/dev/null 2>&1; then
@@ -740,9 +740,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-certificate-authority' >/dev/null 2>&1; then
@@ -764,9 +764,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'AlwaysAllow' >/dev/null 2>&1; then
@@ -785,9 +785,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'Node' >/dev/null 2>&1; then
@@ -806,9 +806,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'RBAC' >/dev/null 2>&1; then
@@ -828,8 +828,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'EventRateLimit' >/dev/null 2>&1; then
@@ -850,8 +850,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysAdmit' >/dev/null 2>&1; then
@@ -871,8 +871,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysPullImages' >/dev/null 2>&1; then
@@ -892,8 +892,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'PodSecurityPolicy' >/dev/null 2>&1; then
@@ -917,8 +917,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'ServiceAccount' >/dev/null 2>&1; then
@@ -939,8 +939,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'NamespaceLifecycle' >/dev/null 2>&1; then
@@ -960,8 +960,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'NodeRestriction' >/dev/null 2>&1; then
@@ -981,9 +981,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--secure-port' >/dev/null 2>&1; then
@@ -1025,8 +1025,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-path' >/dev/null 2>&1; then
@@ -1047,8 +1047,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxage' >/dev/null 2>&1; then
@@ -1075,8 +1075,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxbackup' >/dev/null 2>&1; then
@@ -1103,8 +1103,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxsize' >/dev/null 2>&1; then
@@ -1151,9 +1151,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--service-account-lookup=false' >/dev/null 2>&1; then
@@ -1172,9 +1172,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
@@ -1197,9 +1197,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
@@ -1231,9 +1231,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -1264,9 +1264,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -1289,9 +1289,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
@@ -1315,9 +1315,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--encryption-provider-config'| grep 'EncryptionConfig' >/dev/null 2>&1; then
@@ -1338,9 +1338,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--encryption-provider-config' >/dev/null 2>&1; then
@@ -1368,9 +1368,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--tls-cipher-suites' >/dev/null 2>&1; then
@@ -1451,9 +1451,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--use-service-account-credentials=true' >/dev/null 2>&1; then
@@ -1472,9 +1472,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
@@ -1497,9 +1497,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
@@ -1522,9 +1522,9 @@ groups:
         profile: Level 2
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--feature-gates' >/dev/null 2>&1; then

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/2_etcd.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/2_etcd.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
@@ -50,9 +50,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--client-cert-auth' >/dev/null 2>&1; then
@@ -73,9 +73,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--auto-tls=true' >/dev/null 2>&1; then
@@ -98,9 +98,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
@@ -135,9 +135,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-client-cert-auth=true' >/dev/null 2>&1; then
@@ -158,9 +158,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-auto-tls=true' >/dev/null 2>&1; then
@@ -182,9 +182,9 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--trusted-ca-file' >/dev/null 2>&1; then

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/2_etcd.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/2_etcd.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
@@ -50,9 +50,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--client-cert-auth' >/dev/null 2>&1; then
@@ -73,9 +73,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--auto-tls=true' >/dev/null 2>&1; then
@@ -98,9 +98,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
@@ -135,9 +135,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-client-cert-auth=true' >/dev/null 2>&1; then
@@ -158,9 +158,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-auto-tls=true' >/dev/null 2>&1; then
@@ -182,9 +182,9 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--trusted-ca-file' >/dev/null 2>&1; then

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/3_control_plane_configuration.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/3_control_plane_configuration.yaml
@@ -14,7 +14,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -32,8 +32,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-policy-file' >/dev/null 2>&1; then
@@ -53,8 +53,8 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/3_control_plane_configuration.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/3_control_plane_configuration.yaml
@@ -32,8 +32,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-policy-file' >/dev/null 2>&1; then
@@ -53,8 +53,8 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/5_policies.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/5_policies.yaml
@@ -14,7 +14,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -31,7 +31,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -45,7 +45,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -59,7 +59,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -72,7 +72,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -89,7 +89,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -103,7 +103,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -117,7 +117,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -135,7 +135,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -150,7 +150,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -166,7 +166,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -181,7 +181,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -196,7 +196,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -211,7 +211,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -226,7 +226,7 @@ groups:
         scored: false
         profile: Level 2
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -242,7 +242,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -257,7 +257,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -272,7 +272,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -288,7 +288,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -302,7 +302,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -316,7 +316,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -333,7 +333,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -348,7 +348,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -366,7 +366,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -380,7 +380,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -398,7 +398,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -415,7 +415,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -430,7 +430,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -448,7 +448,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -463,7 +463,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/worker/4_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           kubeadm=$(append_prefix "$CONFIG_PREFIX" "/etc/systemd/system/kubelet.service.d/kubeadm.conf")
@@ -51,9 +51,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -77,9 +77,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -109,9 +109,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"           
           if [ -f "$file" ]; then
@@ -137,9 +137,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -170,9 +170,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -196,9 +196,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -226,9 +226,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -256,9 +256,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -286,9 +286,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -318,9 +318,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -344,9 +344,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
@@ -370,9 +370,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -398,9 +398,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
@@ -429,7 +429,7 @@ groups:
         scored: true
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--streaming-connection-idle-timeout=0' >/dev/null 2>&1; then
@@ -455,9 +455,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--protect-kernel-defaults=true' >/dev/null 2>&1; then
@@ -480,7 +480,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--make-iptables-util-chains=true' >/dev/null 2>&1; then
@@ -501,7 +501,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--hostname-override' >/dev/null 2>&1; then
@@ -521,7 +521,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--event-qps' >/dev/null 2>&1; then
@@ -551,9 +551,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -587,9 +587,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--rotate-certificates=false' >/dev/null 2>&1; then
@@ -612,9 +612,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
@@ -640,9 +640,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           success=1

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/worker/4_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           kubeadm=$(append_prefix "$CONFIG_PREFIX" "/etc/systemd/system/kubelet.service.d/kubeadm.conf")
@@ -51,9 +51,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -77,9 +77,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -109,9 +109,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"           
           if [ -f "$file" ]; then
@@ -137,9 +137,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -170,9 +170,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -196,9 +196,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -226,9 +226,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -256,9 +256,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -286,9 +286,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -318,9 +318,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -344,9 +344,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
@@ -370,9 +370,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -398,9 +398,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
@@ -455,9 +455,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--protect-kernel-defaults=true' >/dev/null 2>&1; then
@@ -551,9 +551,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -587,9 +587,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--rotate-certificates=false' >/dev/null 2>&1; then
@@ -612,9 +612,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
@@ -640,9 +640,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           success=1

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/1_control_plane_components.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.manifest")
@@ -51,9 +51,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -77,9 +77,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.manifest")
@@ -113,9 +113,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"    
           if [ -f "$file" ]; then
@@ -139,9 +139,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.manifest")
@@ -175,9 +175,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -201,9 +201,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.manifest")
@@ -237,9 +237,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -263,9 +263,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -306,9 +306,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -349,9 +349,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -384,9 +384,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -413,9 +413,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/admin.conf"
@@ -443,9 +443,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -469,9 +469,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/scheduler.conf"
@@ -499,9 +499,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -525,9 +525,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/controller-manager.conf"
@@ -555,9 +555,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -581,9 +581,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/pki/"
@@ -613,9 +613,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           files=$(find $file -name "*.crt")
@@ -643,9 +643,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           files=$(find $file -name "*.key")
@@ -675,9 +675,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -695,9 +695,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--basic-auth-file' >/dev/null 2>&1; then
@@ -716,9 +716,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--token-auth-file' >/dev/null 2>&1; then
@@ -737,9 +737,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-https=false' >/dev/null 2>&1; then
@@ -758,9 +758,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-client-certificate' >/dev/null 2>&1; then
@@ -790,9 +790,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-certificate-authority' >/dev/null 2>&1; then
@@ -814,9 +814,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'AlwaysAllow' >/dev/null 2>&1; then
@@ -835,9 +835,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'Node' >/dev/null 2>&1; then
@@ -856,9 +856,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'RBAC' >/dev/null 2>&1; then
@@ -878,8 +878,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'EventRateLimit' >/dev/null 2>&1; then
@@ -900,8 +900,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysAdmit' >/dev/null 2>&1; then
@@ -921,8 +921,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysPullImages' >/dev/null 2>&1; then
@@ -942,8 +942,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'PodSecurityPolicy' >/dev/null 2>&1; then
@@ -967,8 +967,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'ServiceAccount' >/dev/null 2>&1; then
@@ -989,8 +989,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'NamespaceLifecycle' >/dev/null 2>&1; then
@@ -1010,8 +1010,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'PodSecurityPolicy' >/dev/null 2>&1; then
@@ -1034,8 +1034,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'NodeRestriction' >/dev/null 2>&1; then
@@ -1055,9 +1055,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--insecure-bind-address' >/dev/null 2>&1; then
@@ -1075,9 +1075,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--insecure-port' >/dev/null 2>&1; then
@@ -1101,9 +1101,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--secure-port' >/dev/null 2>&1; then
@@ -1127,7 +1127,7 @@ groups:
         scored: true
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--profiling=false' >/dev/null 2>&1; then
@@ -1145,8 +1145,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-path' >/dev/null 2>&1; then
@@ -1167,8 +1167,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxage' >/dev/null 2>&1; then
@@ -1195,8 +1195,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxbackup' >/dev/null 2>&1; then
@@ -1223,8 +1223,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxsize' >/dev/null 2>&1; then
@@ -1250,7 +1250,7 @@ groups:
         scored: true
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--request-timeout' >/dev/null 2>&1; then
@@ -1271,9 +1271,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--service-account-lookup=false' >/dev/null 2>&1; then
@@ -1292,9 +1292,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
@@ -1317,9 +1317,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
@@ -1351,9 +1351,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -1384,9 +1384,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -1409,9 +1409,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
@@ -1435,9 +1435,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--encryption-provider-config'| grep 'EncryptionConfig' >/dev/null 2>&1; then
@@ -1458,9 +1458,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--encryption-provider-config' >/dev/null 2>&1; then
@@ -1488,9 +1488,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--tls-cipher-suites' >/dev/null 2>&1; then
@@ -1519,7 +1519,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           # Filter out processes like "/bin/tee -a /var/log/kube-controller-manager.log"
@@ -1541,7 +1541,7 @@ groups:
         scored: true
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--profiling=false' >/dev/null 2>&1; then
@@ -1560,9 +1560,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--use-service-account-credentials=true' >/dev/null 2>&1; then
@@ -1581,9 +1581,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
@@ -1606,9 +1606,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
@@ -1631,9 +1631,9 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--feature-gates' >/dev/null 2>&1; then
@@ -1657,7 +1657,7 @@ groups:
         scored: true
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_MANAGER_CMD" '--bind-address'| grep '127.0.0.1' >/dev/null 2>&1; then
@@ -1677,7 +1677,7 @@ groups:
         scored: true
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_SCHEDULER_CMD" '--profiling=false' >/dev/null 2>&1; then
@@ -1694,7 +1694,7 @@ groups:
         scored: true
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_SCHEDULER_CMD" '--bind-address'| grep '127.0.0.1' >/dev/null 2>&1; then

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/1_control_plane_components.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.manifest")
@@ -51,9 +51,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -77,9 +77,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.manifest")
@@ -113,9 +113,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"    
           if [ -f "$file" ]; then
@@ -139,9 +139,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.manifest")
@@ -175,9 +175,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -201,9 +201,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           config_manifest=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.manifest")
@@ -237,9 +237,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -263,9 +263,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -306,9 +306,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -349,9 +349,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -384,9 +384,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -413,9 +413,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/admin.conf"
@@ -443,9 +443,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -469,9 +469,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/scheduler.conf"
@@ -499,9 +499,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -525,9 +525,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/controller-manager.conf"
@@ -555,9 +555,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -581,9 +581,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/pki/"
@@ -613,9 +613,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           files=$(find $file -name "*.crt")
@@ -643,9 +643,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           files=$(find $file -name "*.key")
@@ -675,9 +675,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -695,9 +695,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--basic-auth-file' >/dev/null 2>&1; then
@@ -716,9 +716,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--token-auth-file' >/dev/null 2>&1; then
@@ -737,9 +737,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-https=false' >/dev/null 2>&1; then
@@ -758,9 +758,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-client-certificate' >/dev/null 2>&1; then
@@ -790,9 +790,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-certificate-authority' >/dev/null 2>&1; then
@@ -814,9 +814,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'AlwaysAllow' >/dev/null 2>&1; then
@@ -835,9 +835,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'Node' >/dev/null 2>&1; then
@@ -856,9 +856,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'RBAC' >/dev/null 2>&1; then
@@ -878,8 +878,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'EventRateLimit' >/dev/null 2>&1; then
@@ -900,8 +900,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysAdmit' >/dev/null 2>&1; then
@@ -921,8 +921,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysPullImages' >/dev/null 2>&1; then
@@ -942,8 +942,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'PodSecurityPolicy' >/dev/null 2>&1; then
@@ -967,8 +967,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'ServiceAccount' >/dev/null 2>&1; then
@@ -989,8 +989,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'NamespaceLifecycle' >/dev/null 2>&1; then
@@ -1010,8 +1010,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'PodSecurityPolicy' >/dev/null 2>&1; then
@@ -1034,8 +1034,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'NodeRestriction' >/dev/null 2>&1; then
@@ -1055,9 +1055,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--insecure-bind-address' >/dev/null 2>&1; then
@@ -1075,9 +1075,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--insecure-port' >/dev/null 2>&1; then
@@ -1101,9 +1101,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--secure-port' >/dev/null 2>&1; then
@@ -1145,8 +1145,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-path' >/dev/null 2>&1; then
@@ -1167,8 +1167,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxage' >/dev/null 2>&1; then
@@ -1195,8 +1195,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxbackup' >/dev/null 2>&1; then
@@ -1223,8 +1223,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxsize' >/dev/null 2>&1; then
@@ -1271,9 +1271,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--service-account-lookup=false' >/dev/null 2>&1; then
@@ -1292,9 +1292,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
@@ -1317,9 +1317,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
@@ -1351,9 +1351,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -1384,9 +1384,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -1409,9 +1409,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
@@ -1435,9 +1435,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--encryption-provider-config'| grep 'EncryptionConfig' >/dev/null 2>&1; then
@@ -1458,9 +1458,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--encryption-provider-config' >/dev/null 2>&1; then
@@ -1488,9 +1488,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--tls-cipher-suites' >/dev/null 2>&1; then
@@ -1560,9 +1560,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--use-service-account-credentials=true' >/dev/null 2>&1; then
@@ -1581,9 +1581,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
@@ -1606,9 +1606,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
@@ -1631,9 +1631,9 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--feature-gates' >/dev/null 2>&1; then

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/2_etcd.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/2_etcd.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
@@ -50,9 +50,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--client-cert-auth' >/dev/null 2>&1; then
@@ -73,9 +73,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--auto-tls=true' >/dev/null 2>&1; then
@@ -98,9 +98,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
@@ -135,9 +135,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-client-cert-auth=true' >/dev/null 2>&1; then
@@ -158,9 +158,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-auto-tls=true' >/dev/null 2>&1; then
@@ -182,9 +182,9 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--trusted-ca-file' >/dev/null 2>&1; then

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/2_etcd.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/2_etcd.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
@@ -50,9 +50,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--client-cert-auth' >/dev/null 2>&1; then
@@ -73,9 +73,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--auto-tls=true' >/dev/null 2>&1; then
@@ -98,9 +98,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
@@ -135,9 +135,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-client-cert-auth=true' >/dev/null 2>&1; then
@@ -158,9 +158,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-auto-tls=true' >/dev/null 2>&1; then
@@ -182,9 +182,9 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--trusted-ca-file' >/dev/null 2>&1; then

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/3_control_plane_configuration.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/3_control_plane_configuration.yaml
@@ -32,8 +32,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-policy-file' >/dev/null 2>&1; then
@@ -53,8 +53,8 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/3_control_plane_configuration.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/3_control_plane_configuration.yaml
@@ -14,7 +14,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -32,8 +32,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-policy-file' >/dev/null 2>&1; then
@@ -53,8 +53,8 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/5_policies.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/5_policies.yaml
@@ -14,7 +14,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -31,7 +31,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -46,7 +46,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -60,7 +60,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -73,7 +73,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -90,7 +90,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -107,7 +107,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -122,7 +122,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -137,7 +137,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -152,7 +152,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -167,7 +167,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -181,7 +181,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -197,7 +197,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -213,7 +213,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -228,7 +228,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -247,7 +247,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -262,7 +262,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -280,7 +280,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -294,7 +294,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -312,7 +312,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -329,7 +329,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -344,7 +344,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -371,7 +371,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -386,7 +386,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/worker/4_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
@@ -45,9 +45,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
@@ -73,9 +73,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -105,9 +105,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -138,9 +138,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -171,9 +171,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -203,9 +203,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -233,9 +233,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -263,9 +263,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -293,9 +293,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -325,9 +325,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -350,9 +350,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
@@ -375,9 +375,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -403,9 +403,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
@@ -458,9 +458,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--protect-kernel-defaults=true' >/dev/null 2>&1; then
@@ -553,9 +553,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -590,9 +590,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--rotate-certificates=false' >/dev/null 2>&1; then
@@ -616,9 +616,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
@@ -645,9 +645,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           success=1

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/worker/4_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
@@ -45,9 +45,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
@@ -73,9 +73,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -105,9 +105,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -138,9 +138,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -171,9 +171,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -203,9 +203,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -233,9 +233,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -263,9 +263,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -293,9 +293,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -325,9 +325,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -350,9 +350,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
@@ -375,9 +375,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -403,9 +403,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
@@ -432,7 +432,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--streaming-connection-idle-timeout=0' >/dev/null 2>&1; then
@@ -458,9 +458,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--protect-kernel-defaults=true' >/dev/null 2>&1; then
@@ -482,7 +482,7 @@ groups:
         scored: true
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--make-iptables-util-chains=true' >/dev/null 2>&1; then
@@ -503,7 +503,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--hostname-override' >/dev/null 2>&1; then
@@ -523,7 +523,7 @@ groups:
         scored: false
         profile: Level 2
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--event-qps' >/dev/null 2>&1; then
@@ -553,9 +553,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -590,9 +590,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--rotate-certificates=false' >/dev/null 2>&1; then
@@ -616,9 +616,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
@@ -645,9 +645,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           success=1

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/1_control_plane_components.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
@@ -44,9 +44,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -70,9 +70,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
@@ -99,9 +99,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -125,9 +125,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
@@ -154,9 +154,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -180,9 +180,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
@@ -209,9 +209,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -235,9 +235,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -278,9 +278,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -321,9 +321,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -356,9 +356,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -384,9 +384,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/admin.conf"
@@ -414,9 +414,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -440,9 +440,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/scheduler.conf"
@@ -470,9 +470,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -496,9 +496,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/controller-manager.conf"
@@ -526,9 +526,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -552,9 +552,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/pki/"
@@ -584,9 +584,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           files=$(find $file -name "*.crt")
@@ -614,9 +614,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           files=$(find $file -name "*.key")
@@ -646,9 +646,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -666,9 +666,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--token-auth-file' >/dev/null 2>&1; then
@@ -687,9 +687,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--DenyServiceExternalIPs' >/dev/null 2>&1; then
@@ -708,9 +708,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-client-certificate' >/dev/null 2>&1; then
@@ -740,9 +740,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-certificate-authority' >/dev/null 2>&1; then
@@ -764,9 +764,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'AlwaysAllow' >/dev/null 2>&1; then
@@ -785,9 +785,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'Node' >/dev/null 2>&1; then
@@ -806,9 +806,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'RBAC' >/dev/null 2>&1; then
@@ -828,8 +828,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'EventRateLimit' >/dev/null 2>&1; then
@@ -850,8 +850,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysAdmit' >/dev/null 2>&1; then
@@ -871,8 +871,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysPullImages' >/dev/null 2>&1; then
@@ -892,8 +892,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'PodSecurityPolicy' >/dev/null 2>&1; then
@@ -917,8 +917,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'ServiceAccount' >/dev/null 2>&1; then
@@ -939,8 +939,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'NamespaceLifecycle' >/dev/null 2>&1; then
@@ -960,8 +960,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'NodeRestriction' >/dev/null 2>&1; then
@@ -980,7 +980,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--profiling=false' >/dev/null 2>&1; then
@@ -998,8 +998,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-path' >/dev/null 2>&1; then
@@ -1020,8 +1020,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxage' >/dev/null 2>&1; then
@@ -1048,8 +1048,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxbackup' >/dev/null 2>&1; then
@@ -1076,8 +1076,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxsize' >/dev/null 2>&1; then
@@ -1103,7 +1103,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--request-timeout' >/dev/null 2>&1; then
@@ -1124,9 +1124,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--service-account-lookup=false' >/dev/null 2>&1; then
@@ -1145,9 +1145,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
@@ -1170,9 +1170,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
@@ -1204,9 +1204,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -1237,9 +1237,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -1262,9 +1262,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
@@ -1288,9 +1288,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--encryption-provider-config'| grep 'EncryptionConfig' >/dev/null 2>&1; then
@@ -1311,9 +1311,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--encryption-provider-config' >/dev/null 2>&1; then
@@ -1341,9 +1341,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--tls-cipher-suites' >/dev/null 2>&1; then
@@ -1383,7 +1383,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           # Filter out processes like "/bin/tee -a /var/log/kube-controller-manager.log"
@@ -1405,7 +1405,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--profiling=false' >/dev/null 2>&1; then
@@ -1424,9 +1424,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--use-service-account-credentials=true' >/dev/null 2>&1; then
@@ -1445,9 +1445,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
@@ -1470,9 +1470,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
@@ -1495,9 +1495,9 @@ groups:
         profile: Level 2
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--feature-gates' >/dev/null 2>&1; then
@@ -1521,7 +1521,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_MANAGER_CMD" '--bind-address'| grep '127.0.0.1' >/dev/null 2>&1; then
@@ -1541,7 +1541,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_SCHEDULER_CMD" '--profiling=false' >/dev/null 2>&1; then
@@ -1558,7 +1558,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_SCHEDULER_CMD" '--bind-address'| grep '127.0.0.1' >/dev/null 2>&1; then

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/1_control_plane_components.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
@@ -44,9 +44,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -70,9 +70,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
@@ -99,9 +99,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -125,9 +125,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
@@ -154,9 +154,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -180,9 +180,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
@@ -209,9 +209,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -235,9 +235,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -278,9 +278,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -321,9 +321,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -356,9 +356,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -384,9 +384,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/admin.conf"
@@ -414,9 +414,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -440,9 +440,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/scheduler.conf"
@@ -470,9 +470,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -496,9 +496,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/controller-manager.conf"
@@ -526,9 +526,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -552,9 +552,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/pki/"
@@ -584,9 +584,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           files=$(find $file -name "*.crt")
@@ -614,9 +614,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           files=$(find $file -name "*.key")
@@ -646,9 +646,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -666,9 +666,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--token-auth-file' >/dev/null 2>&1; then
@@ -687,9 +687,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--DenyServiceExternalIPs' >/dev/null 2>&1; then
@@ -708,9 +708,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-client-certificate' >/dev/null 2>&1; then
@@ -740,9 +740,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--kubelet-certificate-authority' >/dev/null 2>&1; then
@@ -764,9 +764,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'AlwaysAllow' >/dev/null 2>&1; then
@@ -785,9 +785,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'Node' >/dev/null 2>&1; then
@@ -806,9 +806,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'RBAC' >/dev/null 2>&1; then
@@ -828,8 +828,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'EventRateLimit' >/dev/null 2>&1; then
@@ -850,8 +850,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysAdmit' >/dev/null 2>&1; then
@@ -871,8 +871,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysPullImages' >/dev/null 2>&1; then
@@ -892,8 +892,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'PodSecurityPolicy' >/dev/null 2>&1; then
@@ -917,8 +917,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'ServiceAccount' >/dev/null 2>&1; then
@@ -939,8 +939,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'NamespaceLifecycle' >/dev/null 2>&1; then
@@ -960,8 +960,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'NodeRestriction' >/dev/null 2>&1; then
@@ -998,8 +998,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-path' >/dev/null 2>&1; then
@@ -1020,8 +1020,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxage' >/dev/null 2>&1; then
@@ -1048,8 +1048,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxbackup' >/dev/null 2>&1; then
@@ -1076,8 +1076,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxsize' >/dev/null 2>&1; then
@@ -1124,9 +1124,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--service-account-lookup=false' >/dev/null 2>&1; then
@@ -1145,9 +1145,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
@@ -1170,9 +1170,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
@@ -1204,9 +1204,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -1237,9 +1237,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -1262,9 +1262,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
@@ -1288,9 +1288,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if get_argument_value "$CIS_APISERVER_CMD" '--encryption-provider-config'| grep 'EncryptionConfig' >/dev/null 2>&1; then
@@ -1311,9 +1311,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--encryption-provider-config' >/dev/null 2>&1; then
@@ -1341,9 +1341,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--tls-cipher-suites' >/dev/null 2>&1; then
@@ -1424,9 +1424,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--use-service-account-credentials=true' >/dev/null 2>&1; then
@@ -1445,9 +1445,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
@@ -1470,9 +1470,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
@@ -1495,9 +1495,9 @@ groups:
         profile: Level 2
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_MANAGER_CMD" '--feature-gates' >/dev/null 2>&1; then

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/2_etcd.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/2_etcd.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
@@ -50,9 +50,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--client-cert-auth' >/dev/null 2>&1; then
@@ -73,9 +73,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--auto-tls=true' >/dev/null 2>&1; then
@@ -98,9 +98,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
@@ -135,9 +135,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-client-cert-auth=true' >/dev/null 2>&1; then
@@ -158,9 +158,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-auto-tls=true' >/dev/null 2>&1; then
@@ -182,9 +182,9 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--trusted-ca-file' >/dev/null 2>&1; then

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/2_etcd.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/2_etcd.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
@@ -50,9 +50,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--client-cert-auth' >/dev/null 2>&1; then
@@ -73,9 +73,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--auto-tls=true' >/dev/null 2>&1; then
@@ -98,9 +98,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
@@ -135,9 +135,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-client-cert-auth=true' >/dev/null 2>&1; then
@@ -158,9 +158,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-auto-tls=true' >/dev/null 2>&1; then
@@ -182,9 +182,9 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--trusted-ca-file' >/dev/null 2>&1; then

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/3_control_plane_configuration.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/3_control_plane_configuration.yaml
@@ -14,7 +14,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -29,7 +29,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -43,7 +43,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -61,8 +61,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-policy-file' >/dev/null 2>&1; then
@@ -82,8 +82,8 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/3_control_plane_configuration.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/3_control_plane_configuration.yaml
@@ -61,8 +61,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-policy-file' >/dev/null 2>&1; then
@@ -82,8 +82,8 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/5_policies.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/5_policies.yaml
@@ -14,7 +14,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -31,7 +31,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -45,7 +45,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -59,7 +59,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -72,7 +72,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -89,7 +89,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -103,7 +103,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -117,7 +117,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -131,7 +131,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -145,7 +145,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -160,7 +160,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -174,7 +174,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -188,7 +188,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -206,7 +206,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -221,7 +221,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -237,7 +237,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -252,7 +252,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -267,7 +267,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -282,7 +282,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -297,7 +297,7 @@ groups:
         scored: false
         profile: Level 2
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -313,7 +313,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -328,7 +328,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -343,7 +343,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -359,7 +359,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -373,7 +373,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -387,7 +387,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -404,7 +404,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -419,7 +419,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -437,7 +437,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -451,7 +451,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -469,7 +469,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -486,7 +486,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -501,7 +501,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -519,7 +519,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -534,7 +534,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/worker/4_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           kubeadm=$(append_prefix "$CONFIG_PREFIX" "/etc/systemd/system/kubelet.service.d/kubeadm.conf")
@@ -51,9 +51,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -77,9 +77,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -109,9 +109,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"           
           if [ -f "$file" ]; then
@@ -137,9 +137,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -170,9 +170,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -196,9 +196,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -226,9 +226,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -256,9 +256,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -286,9 +286,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -318,9 +318,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -344,9 +344,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
@@ -370,9 +370,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -398,9 +398,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
@@ -525,9 +525,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -561,9 +561,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--rotate-certificates=false' >/dev/null 2>&1; then
@@ -586,9 +586,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
@@ -614,9 +614,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           success=1

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/worker/4_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           kubeadm=$(append_prefix "$CONFIG_PREFIX" "/etc/systemd/system/kubelet.service.d/kubeadm.conf")
@@ -51,9 +51,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -77,9 +77,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -109,9 +109,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"           
           if [ -f "$file" ]; then
@@ -137,9 +137,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -170,9 +170,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -196,9 +196,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -226,9 +226,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -256,9 +256,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -286,9 +286,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -318,9 +318,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -344,9 +344,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
@@ -370,9 +370,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -398,9 +398,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
@@ -429,7 +429,7 @@ groups:
         scored: true
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--streaming-connection-idle-timeout=0' >/dev/null 2>&1; then
@@ -454,7 +454,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--make-iptables-util-chains=true' >/dev/null 2>&1; then
@@ -475,7 +475,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--hostname-override' >/dev/null 2>&1; then
@@ -495,7 +495,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--event-qps' >/dev/null 2>&1; then
@@ -525,9 +525,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -561,9 +561,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--rotate-certificates=false' >/dev/null 2>&1; then
@@ -586,9 +586,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
@@ -614,9 +614,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           success=1
@@ -664,7 +664,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/agent/nvbench/kubernetes-cis-benchmark/eks-1.4.0/worker/3_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/eks-1.4.0/worker/3_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/var/lib/kubelet/kubeconfig"
@@ -45,9 +45,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -72,9 +72,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -103,9 +103,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"           
           if [ -f "$file" ]; then
@@ -132,9 +132,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -170,9 +170,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
@@ -209,9 +209,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -246,9 +246,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
@@ -386,9 +386,9 @@ groups:
         profile: Level 2
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--rotate-certificates=false' >/dev/null 2>&1; then
@@ -413,9 +413,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""

--- a/agent/nvbench/kubernetes-cis-benchmark/eks-1.4.0/worker/3_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/eks-1.4.0/worker/3_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/var/lib/kubelet/kubeconfig"
@@ -45,9 +45,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -72,9 +72,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -103,9 +103,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"           
           if [ -f "$file" ]; then
@@ -132,9 +132,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -170,9 +170,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
@@ -209,9 +209,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -246,9 +246,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
@@ -280,7 +280,7 @@ groups:
         scored: true
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--streaming-connection-idle-timeout=0' >/dev/null 2>&1; then
@@ -319,7 +319,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--make-iptables-util-chains=true' >/dev/null 2>&1; then
@@ -356,7 +356,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--event-qps' >/dev/null 2>&1; then
@@ -386,9 +386,9 @@ groups:
         profile: Level 2
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--rotate-certificates=false' >/dev/null 2>&1; then
@@ -413,9 +413,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -468,7 +468,7 @@ groups:
         scored: false
         profile: Level 2
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/agent/nvbench/kubernetes-cis-benchmark/gke-1.4.0/worker/3_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/gke-1.4.0/worker/3_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/var/lib/kube-proxy/kubeconfig"
@@ -45,9 +45,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -72,9 +72,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -103,9 +103,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"           
           if [ -f "$file" ]; then
@@ -132,9 +132,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -158,9 +158,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
@@ -184,9 +184,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -212,9 +212,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
@@ -339,9 +339,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -375,9 +375,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--rotate-certificates=false' >/dev/null 2>&1; then
@@ -400,9 +400,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""

--- a/agent/nvbench/kubernetes-cis-benchmark/gke-1.4.0/worker/3_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/gke-1.4.0/worker/3_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/var/lib/kube-proxy/kubeconfig"
@@ -45,9 +45,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -72,9 +72,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -103,9 +103,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"           
           if [ -f "$file" ]; then
@@ -132,9 +132,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -158,9 +158,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
@@ -184,9 +184,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -212,9 +212,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
@@ -243,7 +243,7 @@ groups:
         scored: true
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--streaming-connection-idle-timeout=0' >/dev/null 2>&1; then
@@ -268,7 +268,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--make-iptables-util-chains=true' >/dev/null 2>&1; then
@@ -289,7 +289,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--hostname-override' >/dev/null 2>&1; then
@@ -309,7 +309,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--event-qps' >/dev/null 2>&1; then
@@ -339,9 +339,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -375,9 +375,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--rotate-certificates=false' >/dev/null 2>&1; then
@@ -400,9 +400,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""

--- a/agent/nvbench/ocp/rh-1.4.0/master/1_control_plane_components.yaml
+++ b/agent/nvbench/ocp/rh-1.4.0/master/1_control_plane_components.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/kube-apiserver-pod.yaml"
@@ -45,9 +45,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/kube-apiserver-pod.yaml"
@@ -73,9 +73,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/kube-controller-manager-pod.yaml"
@@ -103,9 +103,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/kube-controller-manager-pod.yaml"
@@ -131,9 +131,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/kube-scheduler-pod.yaml"
@@ -161,9 +161,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/kube-scheduler-pod.yaml"
@@ -189,9 +189,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
@@ -219,9 +219,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
@@ -247,9 +247,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           valid_permission=true
@@ -299,9 +299,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           valid_ownership=true
@@ -365,9 +365,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/var/lib/etcd"
@@ -393,9 +393,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -419,9 +419,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubeconfig"
@@ -450,9 +450,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubeconfig"
@@ -478,9 +478,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
@@ -513,9 +513,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
@@ -547,9 +547,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
@@ -582,9 +582,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
@@ -616,9 +616,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           cert_path="/etc/kubernetes/static-pod-certs"
@@ -671,9 +671,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           cert_path="/etc/kubernetes/static-pod-certs"
@@ -711,9 +711,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           cert_path="/etc/kubernetes/static-pod-certs"
@@ -754,9 +754,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           output_kube=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | \
@@ -782,9 +782,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           output_ocp=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-apiserver/configmaps/config | grep --color "basic-auth")
@@ -804,9 +804,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           output_1=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq '.apiServerArguments //empty')
@@ -831,9 +831,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
 
@@ -868,9 +868,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq '.kubeletClientInfo //empty' )
@@ -904,9 +904,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           kubelet_cert_authority=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.apiServerArguments["kubelet-certificate-authority"] // empty')
@@ -929,9 +929,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           # TODO
@@ -953,9 +953,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.apiServerArguments."authorization-mode"' // empty)
@@ -974,8 +974,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           # Verify the APIPriorityAndFairness feature-gate
@@ -1005,8 +1005,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data."config.yaml"' | jq '.apiServerArguments."enable-admission-plugins" //empty')
@@ -1025,8 +1025,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data."config.yaml"' | jq '.apiServerArguments."enable-admission-plugins" //empty')
@@ -1045,8 +1045,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           admission_plugins=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data."config.yaml"' | jq -r '.apiServerArguments."enable-admission-plugins" // empty')
@@ -1067,8 +1067,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           admission_plugins=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data."config.yaml"' | jq -r '.apiServerArguments."enable-admission-plugins" // empty')
@@ -1089,8 +1089,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           admission_plugins=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data."config.yaml"' | jq -r '.apiServerArguments."enable-admission-plugins" // empty')
@@ -1112,8 +1112,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
+          HIPAA: {}
+          PCI: {}
         audit: |
           check="$id  - $description"
           admission_plugins=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data."config.yaml"' | jq -r '.apiServerArguments."enable-admission-plugins" // empty')
@@ -1133,9 +1133,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           admission_plugins=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data."config.yaml"' | jq -r '.apiServerArguments."enable-admission-plugins" // empty')
@@ -1159,9 +1159,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           output_k8s=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/endpoints | jq -r '.subsets[].ports[].port')
@@ -1179,9 +1179,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
 
@@ -1206,8 +1206,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           # TODO
@@ -1228,8 +1228,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           # TODO
@@ -1251,8 +1251,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/apis/operator.openshift.io/v1/kubeapiservers/cluster | jq -r '.spec.observedConfig.apiServerArguments."audit-log-path" // empty')
@@ -1273,7 +1273,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' |  jq -r '.apiServerArguments["audit-log-maxbackup"][]? //empty')
@@ -1292,9 +1292,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           audit_log_maxsize=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.apiServerArguments["audit-log-maxsize"][]?')
@@ -1315,9 +1315,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           min_request_timeout=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.apiServerArguments["min-request-timeout"][]?')
@@ -1339,9 +1339,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -1357,9 +1357,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           config_data=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.serviceAccountPublicKeyFiles //empty')
@@ -1381,9 +1381,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           etcd_certfile=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.apiServerArguments["etcd-certfile"]?')
@@ -1407,9 +1407,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           tls_certfile=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.apiServerArguments."tls-cert-file"[]?')
@@ -1432,9 +1432,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.servingInfo.clientCA //empty')
@@ -1454,9 +1454,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.apiServerArguments["etcd-cafile"] //empty')
@@ -1476,9 +1476,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/apis/operator.openshift.io/v1/openshiftapiservers/cluster -o=jsonpath='{range .items[0].status.conditions[?(@.type=="Encrypted")]}{.reason}{"\n"}{.message}{"\n"}')
@@ -1498,9 +1498,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           # TODO
@@ -1524,7 +1524,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/apis/operator.openshift.io/v1/kubeapiservers/cluster | jq '.spec.unsupportedConfigOverrides //empty')
@@ -1545,7 +1545,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
 
@@ -1569,9 +1569,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.extendedArguments["use-service-account-credentials"][]')
@@ -1590,9 +1590,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.extendedArguments["service-account-private-key-file"][]')
@@ -1612,9 +1612,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.extendedArguments["root-ca-file"][]')
@@ -1633,9 +1633,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           secure_port=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.extendedArguments["secure-port"][] // empty')
@@ -1661,7 +1661,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           liveness_probe=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-scheduler/configmaps/kube-scheduler-pod | jq -r '.data."pod.yaml"' | jq -r '.spec.containers[].livenessProbe.httpGet.path')
@@ -1680,7 +1680,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/agent/nvbench/ocp/rh-1.4.0/master/1_control_plane_components.yaml
+++ b/agent/nvbench/ocp/rh-1.4.0/master/1_control_plane_components.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/kube-apiserver-pod.yaml"
@@ -45,9 +45,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/kube-apiserver-pod.yaml"
@@ -73,9 +73,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/kube-controller-manager-pod.yaml"
@@ -103,9 +103,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/kube-controller-manager-pod.yaml"
@@ -131,9 +131,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/kube-scheduler-pod.yaml"
@@ -161,9 +161,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/kube-scheduler-pod.yaml"
@@ -189,9 +189,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
@@ -219,9 +219,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
@@ -247,9 +247,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           valid_permission=true
@@ -299,9 +299,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           valid_ownership=true
@@ -365,9 +365,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/var/lib/etcd"
@@ -393,9 +393,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -419,9 +419,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubeconfig"
@@ -450,9 +450,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubeconfig"
@@ -478,9 +478,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
@@ -513,9 +513,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/scheduler-kubeconfig/kubeconfig')
@@ -547,9 +547,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
@@ -582,9 +582,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           files=$(find $(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/static-pod-resources") -type f -wholename '*/configmaps/controller-manager-kubeconfig/kubeconfig')
@@ -616,9 +616,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           cert_path="/etc/kubernetes/static-pod-certs"
@@ -671,9 +671,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           cert_path="/etc/kubernetes/static-pod-certs"
@@ -711,9 +711,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           cert_path="/etc/kubernetes/static-pod-certs"
@@ -754,9 +754,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           output_kube=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | \
@@ -782,9 +782,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           output_ocp=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-apiserver/configmaps/config | grep --color "basic-auth")
@@ -804,9 +804,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           output_1=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq '.apiServerArguments //empty')
@@ -831,9 +831,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
 
@@ -868,9 +868,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq '.kubeletClientInfo //empty' )
@@ -904,9 +904,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           kubelet_cert_authority=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.apiServerArguments["kubelet-certificate-authority"] // empty')
@@ -929,9 +929,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           # TODO
@@ -953,9 +953,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.apiServerArguments."authorization-mode"' // empty)
@@ -974,8 +974,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           # Verify the APIPriorityAndFairness feature-gate
@@ -1005,8 +1005,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data."config.yaml"' | jq '.apiServerArguments."enable-admission-plugins" //empty')
@@ -1025,8 +1025,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data."config.yaml"' | jq '.apiServerArguments."enable-admission-plugins" //empty')
@@ -1045,8 +1045,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           admission_plugins=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data."config.yaml"' | jq -r '.apiServerArguments."enable-admission-plugins" // empty')
@@ -1067,8 +1067,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           admission_plugins=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data."config.yaml"' | jq -r '.apiServerArguments."enable-admission-plugins" // empty')
@@ -1089,8 +1089,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           admission_plugins=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data."config.yaml"' | jq -r '.apiServerArguments."enable-admission-plugins" // empty')
@@ -1112,8 +1112,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
+          HIPAA: []
+          PCI: []
         audit: |
           check="$id  - $description"
           admission_plugins=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data."config.yaml"' | jq -r '.apiServerArguments."enable-admission-plugins" // empty')
@@ -1133,9 +1133,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           admission_plugins=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data."config.yaml"' | jq -r '.apiServerArguments."enable-admission-plugins" // empty')
@@ -1159,9 +1159,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           output_k8s=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/endpoints | jq -r '.subsets[].ports[].port')
@@ -1179,9 +1179,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
 
@@ -1206,8 +1206,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           # TODO
@@ -1228,8 +1228,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           # TODO
@@ -1251,8 +1251,8 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/apis/operator.openshift.io/v1/kubeapiservers/cluster | jq -r '.spec.observedConfig.apiServerArguments."audit-log-path" // empty')
@@ -1292,9 +1292,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           audit_log_maxsize=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.apiServerArguments["audit-log-maxsize"][]?')
@@ -1315,9 +1315,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           min_request_timeout=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.apiServerArguments["min-request-timeout"][]?')
@@ -1339,9 +1339,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -1357,9 +1357,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           config_data=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.serviceAccountPublicKeyFiles //empty')
@@ -1381,9 +1381,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           etcd_certfile=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.apiServerArguments["etcd-certfile"]?')
@@ -1407,9 +1407,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           tls_certfile=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.apiServerArguments."tls-cert-file"[]?')
@@ -1432,9 +1432,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.servingInfo.clientCA //empty')
@@ -1454,9 +1454,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-apiserver/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.apiServerArguments["etcd-cafile"] //empty')
@@ -1476,9 +1476,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/apis/operator.openshift.io/v1/openshiftapiservers/cluster -o=jsonpath='{range .items[0].status.conditions[?(@.type=="Encrypted")]}{.reason}{"\n"}{.message}{"\n"}')
@@ -1498,9 +1498,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           # TODO
@@ -1569,9 +1569,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.extendedArguments["use-service-account-credentials"][]')
@@ -1590,9 +1590,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.extendedArguments["service-account-private-key-file"][]')
@@ -1612,9 +1612,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           output=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.extendedArguments["root-ca-file"][]')
@@ -1633,9 +1633,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           secure_port=$(curl -ks -H "Authorization: Bearer $OC_TOKEN" https://kubernetes.default/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config | jq -r '.data["config.yaml"]' | jq -r '.extendedArguments["secure-port"][] // empty')

--- a/agent/nvbench/ocp/rh-1.4.0/master/2_etcd.yaml
+++ b/agent/nvbench/ocp/rh-1.4.0/master/2_etcd.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
@@ -42,9 +42,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
@@ -68,9 +68,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
@@ -95,9 +95,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
@@ -123,9 +123,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
@@ -149,9 +149,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
@@ -175,9 +175,9 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"

--- a/agent/nvbench/ocp/rh-1.4.0/master/2_etcd.yaml
+++ b/agent/nvbench/ocp/rh-1.4.0/master/2_etcd.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
@@ -42,9 +42,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
@@ -68,9 +68,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
@@ -95,9 +95,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
@@ -123,9 +123,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
@@ -149,9 +149,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
@@ -175,9 +175,9 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"

--- a/agent/nvbench/ocp/rh-1.4.0/master/3_control_plane_configuration.yaml
+++ b/agent/nvbench/ocp/rh-1.4.0/master/3_control_plane_configuration.yaml
@@ -14,7 +14,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -42,8 +42,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -75,8 +75,8 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           # TODO

--- a/agent/nvbench/ocp/rh-1.4.0/master/3_control_plane_configuration.yaml
+++ b/agent/nvbench/ocp/rh-1.4.0/master/3_control_plane_configuration.yaml
@@ -42,8 +42,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -75,8 +75,8 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           # TODO

--- a/agent/nvbench/ocp/rh-1.4.0/master/5_policies.yaml
+++ b/agent/nvbench/ocp/rh-1.4.0/master/5_policies.yaml
@@ -14,7 +14,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -33,7 +33,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -53,7 +53,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -70,7 +70,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -84,7 +84,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -98,7 +98,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -119,7 +119,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -136,7 +136,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -153,7 +153,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -170,7 +170,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -187,7 +187,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -203,7 +203,7 @@ groups:
         scored: false
         profile: Level 2
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -225,7 +225,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -243,7 +243,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -264,7 +264,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -282,7 +282,7 @@ groups:
         scored: false
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -303,7 +303,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -316,7 +316,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -336,7 +336,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -351,7 +351,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -370,7 +370,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -389,7 +389,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -406,7 +406,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -423,7 +423,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -443,7 +443,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/agent/nvbench/ocp/rh-1.4.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/ocp/rh-1.4.0/worker/4_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service"
@@ -43,9 +43,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service"
@@ -70,9 +70,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -92,9 +92,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"           
           manual "$check"
@@ -114,9 +114,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -142,9 +142,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -169,9 +169,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet-ca.crt"
@@ -197,9 +197,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet-ca.crt"
@@ -224,9 +224,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/var/lib/kubelet/config.json"
@@ -252,9 +252,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/var/lib/kubelet/config.json"
@@ -281,7 +281,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -307,9 +307,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -333,9 +333,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           # TODO
@@ -357,9 +357,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -380,9 +380,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -404,7 +404,7 @@ groups:
         scored: true
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -433,9 +433,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -456,7 +456,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -479,9 +479,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -504,9 +504,9 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -528,9 +528,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -552,9 +552,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/agent/nvbench/ocp/rh-1.4.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/ocp/rh-1.4.0/worker/4_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service"
@@ -43,9 +43,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service"
@@ -70,9 +70,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -92,9 +92,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"           
           manual "$check"
@@ -114,9 +114,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -142,9 +142,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -169,9 +169,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet-ca.crt"
@@ -197,9 +197,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet-ca.crt"
@@ -224,9 +224,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/var/lib/kubelet/config.json"
@@ -252,9 +252,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/var/lib/kubelet/config.json"
@@ -307,9 +307,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -333,9 +333,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           # TODO
@@ -357,9 +357,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -380,9 +380,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -433,9 +433,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -479,9 +479,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -504,9 +504,9 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -528,9 +528,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
@@ -552,9 +552,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/controller/access/access.go
+++ b/controller/access/access.go
@@ -865,7 +865,7 @@ func CompileUriPermitsMapping() {
 				"v1/list/compliance",
 				"v1/compliance/profile",
 				"v1/compliance/profile/*",
-				"/v1/compliance/available_filter",
+				"v1/compliance/available_filter",
 			},
 			CONST_API_AUDIT_EVENTS: []string{
 				"v1/log/audit",

--- a/controller/access/access.go
+++ b/controller/access/access.go
@@ -865,6 +865,7 @@ func CompileUriPermitsMapping() {
 				"v1/list/compliance",
 				"v1/compliance/profile",
 				"v1/compliance/profile/*",
+				"/v1/compliance/available_filter",
 			},
 			CONST_API_AUDIT_EVENTS: []string{
 				"v1/log/audit",

--- a/controller/access/access_test.go
+++ b/controller/access/access_test.go
@@ -1300,7 +1300,7 @@ func TestCompileApiUrisMappingMapping(t *testing.T) {
 			"v1/list/compliance",
 			"v1/compliance/profile",
 			"v1/compliance/profile/*",
-			"/v1/compliance/available_filter",
+			"v1/compliance/available_filter",
 		},
 		CONST_API_AUDIT_EVENTS: []string{
 			"v1/log/audit",

--- a/controller/access/access_test.go
+++ b/controller/access/access_test.go
@@ -1300,6 +1300,7 @@ func TestCompileApiUrisMappingMapping(t *testing.T) {
 			"v1/list/compliance",
 			"v1/compliance/profile",
 			"v1/compliance/profile/*",
+			"/v1/compliance/available_filter",
 		},
 		CONST_API_AUDIT_EVENTS: []string{
 			"v1/log/audit",

--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -2594,6 +2594,10 @@ type RESTWorkloadInterceptData struct {
 	Intercept *RESTWorkloadIntercept `json:"intercept"`
 }
 
+type RESTAvaiableComplianceFilter struct {
+	AvailableFilter []string `json:"available_filter"`
+}
+
 type RESTBenchCheck struct {
 	TestNum     string                      `json:"test_number"`
 	Category    string                      `json:"category"`
@@ -2668,6 +2672,8 @@ const (
 	ComplianceTemplateGDPR  = "GDPR"
 	ComplianceTemplateHIPAA = "HIPAA"
 	ComplianceTemplateNIST  = "NIST" // NIST SP 800-190
+	ComplianceTemplatePCIv4 = "PCIv4"
+	ComplianceTemplateDISA  = "DISA"
 )
 
 type RESTComplianceProfileEntry struct {

--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -2607,28 +2607,12 @@ type RESTBenchCheck struct {
 	Automated   bool                        `json:"automated"`
 	Description string                      `json:"description"`
 	Remediation string                      `json:"remediation"`
-	Tags        []string                    `json:"tags,omitempty"`
+	Tags        []string                    `json:"tags,omitempty"`    // Tags provide list of compliance that related to the cis test item.
 	TagsV2      map[string]share.TagDetails `json:"tags_v2,omitempty"` // TagsV2 provide compliance details for each compliance tag
-}
-
-type RESTProfileBenchCheck struct {
-	TestNum     string   `json:"test_number"`
-	Category    string   `json:"category"`
-	Type        string   `json:"type"`
-	Profile     string   `json:"profile"`
-	Scored      bool     `json:"scored"`
-	Automated   bool     `json:"automated"`
-	Description string   `json:"description"`
-	Remediation string   `json:"remediation"`
-	Tags        []string `json:"tags"`
 }
 
 type RESTBenchMeta struct {
 	RESTBenchCheck
-}
-
-type RESTProfileBenchMeta struct {
-	RESTProfileBenchCheck
 }
 
 type RESTBenchItem struct {

--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -517,9 +517,9 @@ type RESTEULAData struct {
 }
 
 type RESTList struct {
-	Application  []string               `json:"application,omitempty"`
-	RegistryType []string               `json:"registry_type,omitempty"`
-	Compliance   []RESTProfileBenchMeta `json:"compliance,omitempty"`
+	Application  []string        `json:"application,omitempty"`
+	RegistryType []string        `json:"registry_type,omitempty"`
+	Compliance   []RESTBenchMeta `json:"compliance,omitempty"`
 }
 
 type RESTListData struct {
@@ -2607,7 +2607,8 @@ type RESTBenchCheck struct {
 	Automated   bool                        `json:"automated"`
 	Description string                      `json:"description"`
 	Remediation string                      `json:"remediation"`
-	Tags        map[string]share.TagDetails `json:"tags"`
+	Tags        []string                    `json:"tags,omitempty"`
+	TagsV2      map[string]share.TagDetails `json:"tags_v2,omitempty"` // TagsV2 provide compliance details for each compliance tag
 }
 
 type RESTProfileBenchCheck struct {

--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -2594,22 +2594,16 @@ type RESTWorkloadInterceptData struct {
 	Intercept *RESTWorkloadIntercept `json:"intercept"`
 }
 
-type TagDetail struct {
-	ID          string `yaml:"id" json:"id"`
-	Title       string `yaml:"title" json:"title"`
-	Description string `yaml:"description" json:"description"`
-}
-
 type RESTBenchCheck struct {
-	TestNum     string                   `json:"test_number"`
-	Category    string                   `json:"category"`
-	Type        string                   `json:"type"`
-	Profile     string                   `json:"profile"`
-	Scored      bool                     `json:"scored"`
-	Automated   bool                     `json:"automated"`
-	Description string                   `json:"description"`
-	Remediation string                   `json:"remediation"`
-	Tags        []map[string][]TagDetail `json:"tags,omitempty"`
+	TestNum     string                      `json:"test_number"`
+	Category    string                      `json:"category"`
+	Type        string                      `json:"type"`
+	Profile     string                      `json:"profile"`
+	Scored      bool                        `json:"scored"`
+	Automated   bool                        `json:"automated"`
+	Description string                      `json:"description"`
+	Remediation string                      `json:"remediation"`
+	Tags        map[string]share.TagDetails `json:"tags,omitempty"`
 }
 
 type RESTBenchMeta struct {
@@ -2641,21 +2635,21 @@ type RESTComplianceData struct {
 }
 
 type RESTComplianceAsset struct {
-	Name        string                   `json:"name"`
-	Category    string                   `json:"category"`
-	Type        string                   `json:"type"`
-	Level       string                   `json:"level"`
-	Profile     string                   `json:"profile"`
-	Scored      bool                     `json:"scored"`
-	Description string                   `json:"description"`
-	Message     []string                 `json:"message"`
-	Remediation string                   `json:"remediation"`
-	Group       string                   `json:"group"`
-	Tags        []map[string][]TagDetail `json:"tags,omitempty"`
-	Workloads   []string                 `json:"workloads"`
-	Nodes       []string                 `json:"nodes"`
-	Images      []string                 `json:"images"`
-	Platforms   []string                 `json:"platforms"`
+	Name        string                      `json:"name"`
+	Category    string                      `json:"category"`
+	Type        string                      `json:"type"`
+	Level       string                      `json:"level"`
+	Profile     string                      `json:"profile"`
+	Scored      bool                        `json:"scored"`
+	Description string                      `json:"description"`
+	Message     []string                    `json:"message"`
+	Remediation string                      `json:"remediation"`
+	Group       string                      `json:"group"`
+	Tags        map[string]share.TagDetails `json:"tags,omitempty"`
+	Workloads   []string                    `json:"workloads"`
+	Nodes       []string                    `json:"nodes"`
+	Images      []string                    `json:"images"`
+	Platforms   []string                    `json:"platforms"`
 }
 
 type RESTComplianceAssetData struct {
@@ -2677,8 +2671,8 @@ const (
 )
 
 type RESTComplianceProfileEntry struct {
-	TestNum string   `json:"test_number"`
-	Tags    []string `json:"tags"`
+	TestNum string                      `json:"test_number"`
+	Tags    map[string]share.TagDetails `json:"tags,omitempty"`
 }
 
 type RESTComplianceProfile struct {

--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -517,9 +517,9 @@ type RESTEULAData struct {
 }
 
 type RESTList struct {
-	Application  []string        `json:"application,omitempty"`
-	RegistryType []string        `json:"registry_type,omitempty"`
-	Compliance   []RESTBenchMeta `json:"compliance,omitempty"`
+	Application  []string               `json:"application,omitempty"`
+	RegistryType []string               `json:"registry_type,omitempty"`
+	Compliance   []RESTProfileBenchMeta `json:"compliance,omitempty"`
 }
 
 type RESTListData struct {
@@ -2607,11 +2607,27 @@ type RESTBenchCheck struct {
 	Automated   bool                        `json:"automated"`
 	Description string                      `json:"description"`
 	Remediation string                      `json:"remediation"`
-	Tags        map[string]share.TagDetails `json:"tags,omitempty"`
+	Tags        map[string]share.TagDetails `json:"tags"`
+}
+
+type RESTProfileBenchCheck struct {
+	TestNum     string   `json:"test_number"`
+	Category    string   `json:"category"`
+	Type        string   `json:"type"`
+	Profile     string   `json:"profile"`
+	Scored      bool     `json:"scored"`
+	Automated   bool     `json:"automated"`
+	Description string   `json:"description"`
+	Remediation string   `json:"remediation"`
+	Tags        []string `json:"tags"`
 }
 
 type RESTBenchMeta struct {
 	RESTBenchCheck
+}
+
+type RESTProfileBenchMeta struct {
+	RESTProfileBenchCheck
 }
 
 type RESTBenchItem struct {
@@ -2649,7 +2665,7 @@ type RESTComplianceAsset struct {
 	Message     []string                    `json:"message"`
 	Remediation string                      `json:"remediation"`
 	Group       string                      `json:"group"`
-	Tags        map[string]share.TagDetails `json:"tags,omitempty"`
+	Tags        map[string]share.TagDetails `json:"tags"`
 	Workloads   []string                    `json:"workloads"`
 	Nodes       []string                    `json:"nodes"`
 	Images      []string                    `json:"images"`
@@ -2677,8 +2693,8 @@ const (
 )
 
 type RESTComplianceProfileEntry struct {
-	TestNum string                      `json:"test_number"`
-	Tags    map[string]share.TagDetails `json:"tags,omitempty"`
+	TestNum string   `json:"test_number"`
+	Tags    []string `json:"tags"`
 }
 
 type RESTComplianceProfile struct {

--- a/controller/cache/compliance.go
+++ b/controller/cache/compliance.go
@@ -101,12 +101,12 @@ func buildComplianceFilter(ccp *share.CLUSComplianceProfile) map[string][]string
 	}
 
 	// Add checks that are not in the override list
-	_, metaMap := scanUtils.GetComplianceMeta()
+	_, metaMap := scanUtils.GetComplianceMeta(scanUtils.V1)
 
 	for _, m := range metaMap {
 		if _, ok := filter[m.TestNum]; !ok {
 			var complianceTags []string
-			for compliance, _ := range m.Tags {
+			for _, compliance := range m.Tags {
 				complianceTags = append(complianceTags, compliance)
 			}
 			filter[m.TestNum] = complianceTags

--- a/controller/cache/compliance.go
+++ b/controller/cache/compliance.go
@@ -92,26 +92,30 @@ func filterComplianceLog(audit *api.Audit) *api.Audit {
 	return audit
 }
 
+func buildTagListFromTagDetails(tags map[string]share.TagDetails) []string {
+	var complianceTags []string
+	for _, complianceTagMap := range tags {
+		for tag, _ := range complianceTagMap {
+			complianceTags = append(complianceTags, tag)
+		}
+	}
+	return complianceTags
+}
+
 func buildComplianceFilter(ccp *share.CLUSComplianceProfile) map[string][]string {
 	filter := make(map[string][]string)
 
 	// First create user override entries
 	for _, e := range ccp.Entries {
-		filter[e.TestNum] = e.Tags
+		filter[e.TestNum] = buildTagListFromTagDetails(e.Tags)
 	}
 
 	// Add checks that are not in the override list
 	_, metaMap := scanUtils.GetComplianceMeta()
 	for _, m := range metaMap {
 		if _, ok := filter[m.TestNum]; !ok {
-			var complianceTags []string
-			for _, complianceTagMap := range m.Tags {
-				for tag, _ := range complianceTagMap {
-					complianceTags = append(complianceTags, tag)
-				}
-			}
 
-			filter[m.TestNum] = complianceTags
+			filter[m.TestNum] = buildTagListFromTagDetails(m.Tags)
 		}
 	}
 

--- a/controller/cache/compliance.go
+++ b/controller/cache/compliance.go
@@ -92,30 +92,24 @@ func filterComplianceLog(audit *api.Audit) *api.Audit {
 	return audit
 }
 
-func buildTagListFromTagDetails(tags map[string]share.TagDetails) []string {
-	var complianceTags []string
-	for _, complianceTagMap := range tags {
-		for tag, _ := range complianceTagMap {
-			complianceTags = append(complianceTags, tag)
-		}
-	}
-	return complianceTags
-}
-
 func buildComplianceFilter(ccp *share.CLUSComplianceProfile) map[string][]string {
 	filter := make(map[string][]string)
 
 	// First create user override entries
 	for _, e := range ccp.Entries {
-		filter[e.TestNum] = buildTagListFromTagDetails(e.Tags)
+		filter[e.TestNum] = e.Tags
 	}
 
 	// Add checks that are not in the override list
 	_, metaMap := scanUtils.GetComplianceMeta()
+
 	for _, m := range metaMap {
 		if _, ok := filter[m.TestNum]; !ok {
-
-			filter[m.TestNum] = buildTagListFromTagDetails(m.Tags)
+			var complianceTags []string
+			for compliance, _ := range m.Tags {
+				complianceTags = append(complianceTags, compliance)
+			}
+			filter[m.TestNum] = complianceTags
 		}
 	}
 

--- a/controller/rest/bench.go
+++ b/controller/rest/bench.go
@@ -20,8 +20,6 @@ import (
 	"github.com/neuvector/neuvector/share/utils"
 )
 
-// TODO
-// add image bench in
 func bench2REST(bench share.BenchType, item *share.CLUSBenchItem, cpf *complianceProfileFilter, metaMap map[string]api.RESTBenchMeta, tagVersion string) *api.RESTBenchItem {
 	var r *api.RESTBenchItem
 

--- a/controller/rest/bench.go
+++ b/controller/rest/bench.go
@@ -30,6 +30,21 @@ func bench2REST(bench share.BenchType, item *share.CLUSBenchItem, cpf *complianc
 			Message:        make([]string, 0),
 			Group:          item.Group,
 		}
+
+		// update the Tags with compliance profile
+		if _, ok := cpf.filter[r.TestNum]; ok {
+			filteredTags := make(map[string]share.TagDetails)
+			for _, compliance := range cpf.filter[r.TestNum] {
+				if tagDetails, ok := metaMap[item.TestNum].Tags[compliance]; ok {
+					filteredTags[compliance] = tagDetails
+				} else {
+					filteredTags[compliance] = share.TagDetails{}
+				}
+			}
+			r.Tags = filteredTags
+		} else {
+			r.Tags = map[string]share.TagDetails{}
+		}
 	} else {
 		// Could be custom check
 		r = &api.RESTBenchItem{
@@ -50,6 +65,16 @@ func bench2REST(bench share.BenchType, item *share.CLUSBenchItem, cpf *complianc
 			r.Category = api.BenchCategoryDocker
 		case share.BenchKubeMaster, share.BenchKubeWorker:
 			r.Category = api.BenchCategoryKube
+		}
+
+		if tags, ok := cpf.filter[r.TestNum]; ok {
+			filteredTags := make(map[string]share.TagDetails)
+			for _, compliance := range tags {
+				filteredTags[compliance] = share.TagDetails{}
+			}
+			r.Tags = filteredTags
+		} else {
+			r.Tags = map[string]share.TagDetails{}
 		}
 	}
 
@@ -85,13 +110,6 @@ func bench2REST(bench share.BenchType, item *share.CLUSBenchItem, cpf *complianc
 	if len(r.Message) > 0 {
 		allMessages := strings.Join(r.Message, ", ")
 		r.Description = fmt.Sprintf("%s - %s", r.Description, allMessages)
-	}
-
-	// add tags
-	if _, ok := cpf.filter[r.TestNum]; ok {
-		r.Tags = metaMap[r.TestNum].Tags
-	} else {
-		r.Tags = map[string]share.TagDetails{}
 	}
 
 	return r

--- a/controller/rest/bench.go
+++ b/controller/rest/bench.go
@@ -91,7 +91,7 @@ func bench2REST(bench share.BenchType, item *share.CLUSBenchItem, cpf *complianc
 	if _, ok := cpf.filter[r.TestNum]; ok {
 		r.Tags = metaMap[r.TestNum].Tags
 	} else {
-		r.Tags = make([]map[string][]api.TagDetail, 0)
+		r.Tags = map[string]share.TagDetails{}
 	}
 
 	return r

--- a/controller/rest/bench.go
+++ b/controller/rest/bench.go
@@ -20,7 +20,9 @@ import (
 	"github.com/neuvector/neuvector/share/utils"
 )
 
-func bench2REST(bench share.BenchType, item *share.CLUSBenchItem, cpf *complianceProfileFilter, metaMap map[string]api.RESTBenchMeta) *api.RESTBenchItem {
+// TODO
+// add image bench in
+func bench2REST(bench share.BenchType, item *share.CLUSBenchItem, cpf *complianceProfileFilter, metaMap map[string]api.RESTBenchMeta, tagVersion string) *api.RESTBenchItem {
 	var r *api.RESTBenchItem
 
 	if c, ok := metaMap[item.TestNum]; ok {
@@ -32,19 +34,29 @@ func bench2REST(bench share.BenchType, item *share.CLUSBenchItem, cpf *complianc
 		}
 
 		// update the Tags with compliance profile
-		if _, ok := cpf.filter[r.TestNum]; ok {
-			filteredTags := make(map[string]share.TagDetails)
-			for _, compliance := range cpf.filter[r.TestNum] {
-				if tagDetails, ok := metaMap[item.TestNum].Tags[compliance]; ok {
-					filteredTags[compliance] = tagDetails
-				} else {
-					filteredTags[compliance] = share.TagDetails{}
+		// if tagVersion == V2, return with TagV2: map[string]share.TagDetails{}, otherwise Tag: []string
+		if tagVersion == scanUtils.V2 {
+			if _, ok := cpf.filter[r.TestNum]; ok {
+				filteredTags := make(map[string]share.TagDetails)
+				for _, compliance := range cpf.filter[r.TestNum] {
+					if tagDetails, ok := metaMap[item.TestNum].TagsV2[compliance]; ok {
+						filteredTags[compliance] = tagDetails
+					} else {
+						filteredTags[compliance] = share.TagDetails{}
+					}
 				}
+				r.TagsV2 = filteredTags
+			} else {
+				r.TagsV2 = map[string]share.TagDetails{}
 			}
-			r.Tags = filteredTags
 		} else {
-			r.Tags = map[string]share.TagDetails{}
+			if _, ok := cpf.filter[r.TestNum]; ok {
+				r.Tags = metaMap[r.TestNum].Tags
+			} else {
+				r.Tags = []string{}
+			}
 		}
+
 	} else {
 		// Could be custom check
 		r = &api.RESTBenchItem{
@@ -67,14 +79,22 @@ func bench2REST(bench share.BenchType, item *share.CLUSBenchItem, cpf *complianc
 			r.Category = api.BenchCategoryKube
 		}
 
-		if tags, ok := cpf.filter[r.TestNum]; ok {
-			filteredTags := make(map[string]share.TagDetails)
-			for _, compliance := range tags {
-				filteredTags[compliance] = share.TagDetails{}
+		// update the Tags with compliance profile
+		// if tagVersion == V2, return with TagV2: map[string]share.TagDetails{}, otherwise Tag: []string
+		if tagVersion == scanUtils.V2 {
+			if tags, ok := cpf.filter[r.TestNum]; ok {
+				filteredTags := make(map[string]share.TagDetails)
+				for _, compliance := range tags {
+					filteredTags[compliance] = share.TagDetails{}
+				}
+				r.TagsV2 = filteredTags
+			} else {
+				if _, ok := cpf.filter[r.TestNum]; ok {
+					r.Tags = metaMap[r.TestNum].Tags
+				} else {
+					r.Tags = []string{}
+				}
 			}
-			r.Tags = filteredTags
-		} else {
-			r.Tags = map[string]share.TagDetails{}
 		}
 	}
 
@@ -705,11 +725,11 @@ func _getCISReportFromCluster(bench share.BenchType, id string, readData bool, c
 		Items:          make([]*api.RESTBenchItem, 0),
 	}
 
-	_, metaMap := scanUtils.GetComplianceMeta()
+	_, metaMap := scanUtils.GetComplianceMeta(scanUtils.V1)
 
 	// Add check tags
 	for _, item := range r.Items {
-		if ritem := bench2REST(bench, item, cpf, metaMap); ritem != nil {
+		if ritem := bench2REST(bench, item, cpf, metaMap, scanUtils.V1); ritem != nil {
 			rpt.Items = append(rpt.Items, ritem)
 		}
 	}
@@ -751,6 +771,7 @@ func getKubeCISReportFromCluster(id string, cpf *complianceProfileFilter, acc *a
 	}
 }
 
+// add V2 to support new type
 func decodeCISReport(bench share.BenchType, value []byte, cpf *complianceProfileFilter) *api.RESTBenchReport {
 	var r share.CLUSBenchReport
 
@@ -772,18 +793,20 @@ func decodeCISReport(bench share.BenchType, value []byte, cpf *complianceProfile
 		return nil
 	}
 
+	// add omit empty tag detals
 	rpt := api.RESTBenchReport{
 		RunAtTimeStamp: r.RunAt.Unix(),
 		RunAt:          api.RESTTimeString(r.RunAt),
 		Version:        r.Version,
 		Items:          make([]*api.RESTBenchItem, 0),
 	}
-
-	_, metaMap := scanUtils.GetComplianceMeta()
+	// v2
+	_, metaMap := scanUtils.GetComplianceMeta(scanUtils.V2)
 
 	// Add check tags
 	for _, item := range r.Items {
-		if ritem := bench2REST(bench, item, cpf, metaMap); ritem != nil {
+		if ritem := bench2REST(bench, item, cpf, metaMap, scanUtils.V2); ritem != nil {
+			// rpt.ItemV2
 			rpt.Items = append(rpt.Items, ritem)
 		}
 	}
@@ -813,7 +836,8 @@ func addCompAsset(all map[string]*compAsset, comp *api.RESTBenchItem) *compAsset
 				Message:     comp.Message,
 				Remediation: comp.Remediation,
 				Group:       comp.Group,
-				Tags:        comp.Tags,
+				// with V2
+				Tags: comp.TagsV2,
 			},
 			wls:       utils.NewSet(),
 			nodes:     utils.NewSet(),

--- a/controller/rest/compliance.go
+++ b/controller/rest/compliance.go
@@ -34,8 +34,10 @@ func handlerComplianceList(w http.ResponseWriter, r *http.Request, ps httprouter
 		restRespAccessDenied(w, login)
 		return
 	}
+	// Remove Metas replace with new [] get it dynamically
+	metas, _ := scanUtils.GetComplianceMeta(scanUtils.V1)
 
-	resp := api.RESTListData{List: &api.RESTList{Compliance: scanUtils.GetComplianceProfileMeta()}}
+	resp := api.RESTListData{List: &api.RESTList{Compliance: metas}}
 	restRespSuccess(w, r, &resp, acc, login, nil, "Get compliance meta list")
 }
 
@@ -121,13 +123,13 @@ func handlerGetAvaiableComplianceFilter(w http.ResponseWriter, r *http.Request, 
 	availableFilters := []string{}
 	var complianceFilterMap map[string]int
 	profiles := cacher.GetAllComplianceProfiles(acc)
-	metas, metaMap := scanUtils.GetComplianceMeta()
+	metas, metaMap := scanUtils.GetComplianceMeta(scanUtils.V1)
 	complianceFilterMap = scanUtils.GetComplianceFilterMap(metas, complianceFilterMap)
 
 	for _, profile := range profiles {
 		for _, entry := range profile.Entries {
 			// Remove the exisiting one before user profile update.
-			for compliance, _ := range metaMap[entry.TestNum].Tags {
+			for _, compliance := range metaMap[entry.TestNum].Tags {
 				complianceFilterMap[compliance]--
 			}
 
@@ -194,7 +196,7 @@ func handlerComplianceProfileShow(w http.ResponseWriter, r *http.Request, ps htt
 }
 
 func configComplianceProfileEntry(ccp *share.CLUSComplianceProfile, re *api.RESTComplianceProfileEntry) error {
-	_, metaMap := scanUtils.GetComplianceMeta()
+	_, metaMap := scanUtils.GetComplianceMeta(scanUtils.V1)
 	if _, ok := metaMap[re.TestNum]; !ok {
 		return errors.New("Unknonwn compliance ID")
 	}

--- a/controller/rest/compliance.go
+++ b/controller/rest/compliance.go
@@ -121,10 +121,9 @@ func handlerGetAvaiableComplianceFilter(w http.ResponseWriter, r *http.Request, 
 	}
 
 	availableFilters := []string{}
-	var complianceFilterMap map[string]int
 	profiles := cacher.GetAllComplianceProfiles(acc)
-	metas, metaMap := scanUtils.GetComplianceMeta(scanUtils.V1)
-	complianceFilterMap = scanUtils.GetComplianceFilterMap(metas, complianceFilterMap)
+	_, metaMap := scanUtils.GetComplianceMeta(scanUtils.V1)
+	complianceFilterMap := scanUtils.GetComplianceFilterMap()
 
 	for _, profile := range profiles {
 		for _, entry := range profile.Entries {

--- a/controller/rest/compliance_test.go
+++ b/controller/rest/compliance_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/neuvector/neuvector/controller/api"
 	"github.com/neuvector/neuvector/controller/kv"
-	"github.com/neuvector/neuvector/share"
 )
 
 func TestComplianceProfileConfig(t *testing.T) {
@@ -65,14 +64,8 @@ func TestComplianceProfileConfig(t *testing.T) {
 		Name: "default",
 		Entries: &[]*api.RESTComplianceProfileEntry{
 			&api.RESTComplianceProfileEntry{TestNum: "D.1.1.1"},
-			&api.RESTComplianceProfileEntry{TestNum: "D.1.2.1", Tags: map[string]share.TagDetails{
-				"PCI": share.TagDetails{},
-			}},
-			&api.RESTComplianceProfileEntry{TestNum: "D.1.2.2", Tags: map[string]share.TagDetails{
-				"HIPAA": share.TagDetails{},
-				"PCI":   share.TagDetails{},
-				"GDPR":  share.TagDetails{},
-			}},
+			&api.RESTComplianceProfileEntry{TestNum: "D.1.2.1", Tags: []string{"PCI"}},
+			&api.RESTComplianceProfileEntry{TestNum: "D.1.2.2", Tags: []string{"PCI", "HIPAA", "PCI"}},
 		},
 	}
 	data = api.RESTComplianceProfileConfigData{Config: &cfg}
@@ -110,20 +103,10 @@ func TestComplianceProfileConfig(t *testing.T) {
 	cfg = api.RESTComplianceProfileConfig{
 		Name: "default",
 		Entries: &[]*api.RESTComplianceProfileEntry{
-			&api.RESTComplianceProfileEntry{TestNum: "D.1.1.1", Tags: map[string]share.TagDetails{
-				"PCI": share.TagDetails{},
-			}},
-			&api.RESTComplianceProfileEntry{TestNum: "D.1.2.1", Tags: map[string]share.TagDetails{
-				"HIPAA": share.TagDetails{},
-				"PCI":   share.TagDetails{},
-			}},
-			&api.RESTComplianceProfileEntry{TestNum: "D.1.1.1", Tags: map[string]share.TagDetails{
-				"NIST": share.TagDetails{},
-				"PCI":  share.TagDetails{},
-			}},
-			&api.RESTComplianceProfileEntry{TestNum: "D.1.2.1", Tags: map[string]share.TagDetails{
-				"GDPR": share.TagDetails{},
-			}},
+			&api.RESTComplianceProfileEntry{TestNum: "D.1.1.1", Tags: []string{"PCI"}},
+			&api.RESTComplianceProfileEntry{TestNum: "D.1.2.1", Tags: []string{"PCI", "HIPAA"}},
+			&api.RESTComplianceProfileEntry{TestNum: "D.1.1.1", Tags: []string{"NIST", "PCI"}},
+			&api.RESTComplianceProfileEntry{TestNum: "D.1.2.1", Tags: []string{"GDPR"}},
 		},
 	}
 	data = api.RESTComplianceProfileConfigData{Config: &cfg}
@@ -145,9 +128,7 @@ func TestComplianceProfileConfig(t *testing.T) {
 	}
 
 	// Add an entry
-	e := api.RESTComplianceProfileEntry{TestNum: "K.1.2.1", Tags: map[string]share.TagDetails{
-		"NIST": share.TagDetails{},
-	}}
+	e := api.RESTComplianceProfileEntry{TestNum: "K.1.2.1", Tags: []string{"NIST"}}
 	edata := api.RESTComplianceProfileEntryConfigData{Config: &e}
 	body, _ = json.Marshal(edata)
 
@@ -162,11 +143,7 @@ func TestComplianceProfileConfig(t *testing.T) {
 	}
 
 	// Modify the entry
-	e = api.RESTComplianceProfileEntry{TestNum: "K.1.2.1", Tags: map[string]share.TagDetails{
-		"PCI":  share.TagDetails{},
-		"GDPR": share.TagDetails{},
-		"NIST": share.TagDetails{},
-	}}
+	e = api.RESTComplianceProfileEntry{TestNum: "K.1.2.1", Tags: []string{"PCI", "GDPR", "NIST"}}
 	edata = api.RESTComplianceProfileEntryConfigData{Config: &e}
 	body, _ = json.Marshal(edata)
 
@@ -186,7 +163,7 @@ func TestComplianceProfileConfig(t *testing.T) {
 	}
 
 	// Make the entry empty
-	e = api.RESTComplianceProfileEntry{TestNum: "K.1.2.1", Tags: map[string]share.TagDetails{}}
+	e = api.RESTComplianceProfileEntry{TestNum: "K.1.2.1", Tags: []string{}}
 	edata = api.RESTComplianceProfileEntryConfigData{Config: &e}
 	body, _ = json.Marshal(edata)
 
@@ -262,9 +239,7 @@ func TestComplianceProfileNegative(t *testing.T) {
 		cfg := api.RESTComplianceProfileConfig{
 			Name: "default",
 			Entries: &[]*api.RESTComplianceProfileEntry{
-				&api.RESTComplianceProfileEntry{TestNum: "D.1.2.1", Tags: map[string]share.TagDetails{
-					"PCPI": share.TagDetails{},
-				}},
+				&api.RESTComplianceProfileEntry{TestNum: "D.1.2.1", Tags: []string{"PCPI"}},
 			},
 		}
 		data := api.RESTComplianceProfileConfigData{Config: &cfg}
@@ -277,9 +252,7 @@ func TestComplianceProfileNegative(t *testing.T) {
 	}
 
 	{
-		e := api.RESTComplianceProfileEntry{TestNum: "K.1.2.1", Tags: map[string]share.TagDetails{
-			"NISTY": share.TagDetails{},
-		}}
+		e := api.RESTComplianceProfileEntry{TestNum: "K.1.2.1", Tags: []string{"NISTY"}}
 		edata := api.RESTComplianceProfileEntryConfigData{Config: &e}
 		body, _ := json.Marshal(edata)
 

--- a/controller/rest/compliance_test.go
+++ b/controller/rest/compliance_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/neuvector/neuvector/controller/api"
 	"github.com/neuvector/neuvector/controller/kv"
+	"github.com/neuvector/neuvector/share"
 )
 
 func TestComplianceProfileConfig(t *testing.T) {
@@ -64,8 +65,14 @@ func TestComplianceProfileConfig(t *testing.T) {
 		Name: "default",
 		Entries: &[]*api.RESTComplianceProfileEntry{
 			&api.RESTComplianceProfileEntry{TestNum: "D.1.1.1"},
-			&api.RESTComplianceProfileEntry{TestNum: "D.1.2.1", Tags: []string{"PCI"}},
-			&api.RESTComplianceProfileEntry{TestNum: "D.1.2.2", Tags: []string{"PCI", "HIPAA", "PCI"}},
+			&api.RESTComplianceProfileEntry{TestNum: "D.1.2.1", Tags: map[string]share.TagDetails{
+				"PCI": share.TagDetails{},
+			}},
+			&api.RESTComplianceProfileEntry{TestNum: "D.1.2.2", Tags: map[string]share.TagDetails{
+				"HIPAA": share.TagDetails{},
+				"PCI":   share.TagDetails{},
+				"GDPR":  share.TagDetails{},
+			}},
 		},
 	}
 	data = api.RESTComplianceProfileConfigData{Config: &cfg}
@@ -103,10 +110,20 @@ func TestComplianceProfileConfig(t *testing.T) {
 	cfg = api.RESTComplianceProfileConfig{
 		Name: "default",
 		Entries: &[]*api.RESTComplianceProfileEntry{
-			&api.RESTComplianceProfileEntry{TestNum: "D.1.1.1", Tags: []string{"PCI"}},
-			&api.RESTComplianceProfileEntry{TestNum: "D.1.2.1", Tags: []string{"PCI", "HIPAA"}},
-			&api.RESTComplianceProfileEntry{TestNum: "D.1.1.1", Tags: []string{"NIST", "PCI"}},
-			&api.RESTComplianceProfileEntry{TestNum: "D.1.2.1", Tags: []string{"GDPR"}},
+			&api.RESTComplianceProfileEntry{TestNum: "D.1.1.1", Tags: map[string]share.TagDetails{
+				"PCI": share.TagDetails{},
+			}},
+			&api.RESTComplianceProfileEntry{TestNum: "D.1.2.1", Tags: map[string]share.TagDetails{
+				"HIPAA": share.TagDetails{},
+				"PCI":   share.TagDetails{},
+			}},
+			&api.RESTComplianceProfileEntry{TestNum: "D.1.1.1", Tags: map[string]share.TagDetails{
+				"NIST": share.TagDetails{},
+				"PCI":  share.TagDetails{},
+			}},
+			&api.RESTComplianceProfileEntry{TestNum: "D.1.2.1", Tags: map[string]share.TagDetails{
+				"GDPR": share.TagDetails{},
+			}},
 		},
 	}
 	data = api.RESTComplianceProfileConfigData{Config: &cfg}
@@ -128,7 +145,9 @@ func TestComplianceProfileConfig(t *testing.T) {
 	}
 
 	// Add an entry
-	e := api.RESTComplianceProfileEntry{TestNum: "K.1.2.1", Tags: []string{"NIST"}}
+	e := api.RESTComplianceProfileEntry{TestNum: "K.1.2.1", Tags: map[string]share.TagDetails{
+		"NIST": share.TagDetails{},
+	}}
 	edata := api.RESTComplianceProfileEntryConfigData{Config: &e}
 	body, _ = json.Marshal(edata)
 
@@ -143,7 +162,11 @@ func TestComplianceProfileConfig(t *testing.T) {
 	}
 
 	// Modify the entry
-	e = api.RESTComplianceProfileEntry{TestNum: "K.1.2.1", Tags: []string{"PCI", "GDPR", "NIST"}}
+	e = api.RESTComplianceProfileEntry{TestNum: "K.1.2.1", Tags: map[string]share.TagDetails{
+		"PCI":  share.TagDetails{},
+		"GDPR": share.TagDetails{},
+		"NIST": share.TagDetails{},
+	}}
 	edata = api.RESTComplianceProfileEntryConfigData{Config: &e}
 	body, _ = json.Marshal(edata)
 
@@ -163,7 +186,7 @@ func TestComplianceProfileConfig(t *testing.T) {
 	}
 
 	// Make the entry empty
-	e = api.RESTComplianceProfileEntry{TestNum: "K.1.2.1", Tags: []string{}}
+	e = api.RESTComplianceProfileEntry{TestNum: "K.1.2.1", Tags: map[string]share.TagDetails{}}
 	edata = api.RESTComplianceProfileEntryConfigData{Config: &e}
 	body, _ = json.Marshal(edata)
 
@@ -239,7 +262,9 @@ func TestComplianceProfileNegative(t *testing.T) {
 		cfg := api.RESTComplianceProfileConfig{
 			Name: "default",
 			Entries: &[]*api.RESTComplianceProfileEntry{
-				&api.RESTComplianceProfileEntry{TestNum: "D.1.2.1", Tags: []string{"PCPI"}},
+				&api.RESTComplianceProfileEntry{TestNum: "D.1.2.1", Tags: map[string]share.TagDetails{
+					"PCPI": share.TagDetails{},
+				}},
 			},
 		}
 		data := api.RESTComplianceProfileConfigData{Config: &cfg}
@@ -252,7 +277,9 @@ func TestComplianceProfileNegative(t *testing.T) {
 	}
 
 	{
-		e := api.RESTComplianceProfileEntry{TestNum: "K.1.2.1", Tags: []string{"NISTY"}}
+		e := api.RESTComplianceProfileEntry{TestNum: "K.1.2.1", Tags: map[string]share.TagDetails{
+			"NISTY": share.TagDetails{},
+		}}
 		edata := api.RESTComplianceProfileEntryConfigData{Config: &e}
 		body, _ := json.Marshal(edata)
 

--- a/controller/rest/crdsecurityrule.go
+++ b/controller/rest/crdsecurityrule.go
@@ -2803,24 +2803,6 @@ func (h *nvCrdHandler) parseCurCrdVulnProfileContent(vulnProfileSecRule *resourc
 	return crdCfgRet, 0, "", recordName
 }
 
-func MergeComplianceTags(baseComplianeTag, crdComplianceTag map[string]share.TagDetails) map[string]share.TagDetails {
-	merge := baseComplianeTag
-
-	for compliance, complianceDetails := range crdComplianceTag {
-		if _, ok := merge[compliance]; ok {
-			for id, detail := range complianceDetails {
-				if _, exist := merge[compliance][id]; !exist {
-					merge[compliance][id] = detail
-				}
-			}
-		} else {
-			merge[compliance] = complianceDetails
-		}
-	}
-
-	return merge
-}
-
 // for CRD compliance profile import
 func (h *nvCrdHandler) parseCurCrdCompProfileContent(compProfileSecRule *resource.NvCompProfileSecurityRule,
 	reviewType share.TReviewType, reviewTypeDisplay string) (*resource.NvSecurityParse, int, string, string) {
@@ -2848,7 +2830,10 @@ func (h *nvCrdHandler) parseCurCrdCompProfileContent(compProfileSecRule *resourc
 			entriesMap := make(map[string]*api.RESTComplianceProfileEntry, len(specTemplates.Entries))
 			for _, crdEntry := range specTemplates.Entries {
 				if entry, ok := entriesMap[crdEntry.TestNum]; ok {
-					entriesMap[crdEntry.TestNum].Tags = MergeComplianceTags(entry.Tags, crdEntry.Tags)
+					tags1 := utils.NewSetFromStringSlice(entry.Tags)
+					tags2 := utils.NewSetFromStringSlice(crdEntry.Tags)
+					tags1 = tags1.Union(tags2)
+					entriesMap[crdEntry.TestNum].Tags = tags1.ToStringSlice()
 				} else {
 					entriesMap[crdEntry.TestNum] = crdEntry
 				}

--- a/controller/rest/crdsecurityrule_test.go
+++ b/controller/rest/crdsecurityrule_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/neuvector/neuvector/controller/resource"
 	"github.com/neuvector/neuvector/share"
 	"sigs.k8s.io/yaml"
@@ -280,89 +279,4 @@ func TestParseCrdSecurityRule(t *testing.T) {
 	}
 
 	postTest()
-}
-
-var mockBaseComplianceTags = map[string]share.TagDetails{
-	"HIPPA": share.TagDetails{
-		"HIPPA-1": share.TagDetail{
-			ID:          "HIPPA-1",
-			Title:       "Mock title for HIPPA-1",
-			Description: "Mock description for HIPPA-1",
-		},
-		"HIPPA-2": share.TagDetail{
-			ID:          "HIPPA-2",
-			Title:       "Mock title for HIPPA-2",
-			Description: "Mock description for HIPPA-2",
-		},
-	},
-	"PCI": share.TagDetails{
-		"PCI-1": share.TagDetail{
-			ID:          "PCI-1",
-			Title:       "Mock title for PCI-1",
-			Description: "Mock description for PCI-1",
-		},
-	},
-}
-
-var mockCRDComplianceTags = map[string]share.TagDetails{
-	"HIPPA": share.TagDetails{
-		"HIPPA-1": share.TagDetail{
-			ID:          "HIPPA-1",
-			Title:       "Mock title for HIPPA-1",
-			Description: "Mock description for HIPPA-1",
-		},
-		"HIPPA-3": share.TagDetail{
-			ID:          "HIPPA-3",
-			Title:       "Mock title for HIPPA-3",
-			Description: "Mock description for HIPPA-3",
-		},
-	},
-	"PCIv4": share.TagDetails{
-		"PCIv4-1": share.TagDetail{
-			ID:          "PCIv4-1",
-			Title:       "Mock title for PCIv4-1",
-			Description: "Mock description for PCIv4-1",
-		},
-	},
-}
-
-var mockExpectedComplianceTags = map[string]share.TagDetails{
-	"HIPPA": share.TagDetails{
-		"HIPPA-1": share.TagDetail{
-			ID:          "HIPPA-1",
-			Title:       "Mock title for HIPPA-1",
-			Description: "Mock description for HIPPA-1",
-		},
-		"HIPPA-2": share.TagDetail{
-			ID:          "HIPPA-2",
-			Title:       "Mock title for HIPPA-2",
-			Description: "Mock description for HIPPA-2",
-		},
-		"HIPPA-3": share.TagDetail{
-			ID:          "HIPPA-3",
-			Title:       "Mock title for HIPPA-3",
-			Description: "Mock description for HIPPA-3",
-		},
-	},
-	"PCI": share.TagDetails{
-		"PCI-1": share.TagDetail{
-			ID:          "PCI-1",
-			Title:       "Mock title for PCI-1",
-			Description: "Mock description for PCI-1",
-		},
-	},
-	"PCIv4": share.TagDetails{
-		"PCIv4-1": share.TagDetail{
-			ID:          "PCIv4-1",
-			Title:       "Mock title for PCIv4-1",
-			Description: "Mock description for PCIv4-1",
-		},
-	},
-}
-
-func TestMergeComplianceTags(t *testing.T) {
-	mergeComplianceTag := MergeComplianceTags(mockBaseComplianceTags, mockCRDComplianceTags)
-	if diff := cmp.Diff(mergeComplianceTag, mockExpectedComplianceTags); diff != "" {
-		t.Errorf("mergeComplianceTag mismatch (-want +got):\n%s", diff)
-	}
 }

--- a/controller/rest/crdsecurityrule_test.go
+++ b/controller/rest/crdsecurityrule_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/neuvector/neuvector/controller/resource"
 	"github.com/neuvector/neuvector/share"
 	"sigs.k8s.io/yaml"
@@ -279,4 +280,89 @@ func TestParseCrdSecurityRule(t *testing.T) {
 	}
 
 	postTest()
+}
+
+var mockBaseComplianceTags = map[string]share.TagDetails{
+	"HIPPA": share.TagDetails{
+		"HIPPA-1": share.TagDetail{
+			ID:          "HIPPA-1",
+			Title:       "Mock title for HIPPA-1",
+			Description: "Mock description for HIPPA-1",
+		},
+		"HIPPA-2": share.TagDetail{
+			ID:          "HIPPA-2",
+			Title:       "Mock title for HIPPA-2",
+			Description: "Mock description for HIPPA-2",
+		},
+	},
+	"PCI": share.TagDetails{
+		"PCI-1": share.TagDetail{
+			ID:          "PCI-1",
+			Title:       "Mock title for PCI-1",
+			Description: "Mock description for PCI-1",
+		},
+	},
+}
+
+var mockCRDComplianceTags = map[string]share.TagDetails{
+	"HIPPA": share.TagDetails{
+		"HIPPA-1": share.TagDetail{
+			ID:          "HIPPA-1",
+			Title:       "Mock title for HIPPA-1",
+			Description: "Mock description for HIPPA-1",
+		},
+		"HIPPA-3": share.TagDetail{
+			ID:          "HIPPA-3",
+			Title:       "Mock title for HIPPA-3",
+			Description: "Mock description for HIPPA-3",
+		},
+	},
+	"PCIv4": share.TagDetails{
+		"PCIv4-1": share.TagDetail{
+			ID:          "PCIv4-1",
+			Title:       "Mock title for PCIv4-1",
+			Description: "Mock description for PCIv4-1",
+		},
+	},
+}
+
+var mockExpectedComplianceTags = map[string]share.TagDetails{
+	"HIPPA": share.TagDetails{
+		"HIPPA-1": share.TagDetail{
+			ID:          "HIPPA-1",
+			Title:       "Mock title for HIPPA-1",
+			Description: "Mock description for HIPPA-1",
+		},
+		"HIPPA-2": share.TagDetail{
+			ID:          "HIPPA-2",
+			Title:       "Mock title for HIPPA-2",
+			Description: "Mock description for HIPPA-2",
+		},
+		"HIPPA-3": share.TagDetail{
+			ID:          "HIPPA-3",
+			Title:       "Mock title for HIPPA-3",
+			Description: "Mock description for HIPPA-3",
+		},
+	},
+	"PCI": share.TagDetails{
+		"PCI-1": share.TagDetail{
+			ID:          "PCI-1",
+			Title:       "Mock title for PCI-1",
+			Description: "Mock description for PCI-1",
+		},
+	},
+	"PCIv4": share.TagDetails{
+		"PCIv4-1": share.TagDetail{
+			ID:          "PCIv4-1",
+			Title:       "Mock title for PCIv4-1",
+			Description: "Mock description for PCIv4-1",
+		},
+	},
+}
+
+func TestMergeComplianceTags(t *testing.T) {
+	mergeComplianceTag := MergeComplianceTags(mockBaseComplianceTags, mockCRDComplianceTags)
+	if diff := cmp.Diff(mergeComplianceTag, mockExpectedComplianceTags); diff != "" {
+		t.Errorf("mergeComplianceTag mismatch (-want +got):\n%s", diff)
+	}
 }

--- a/controller/rest/mock_test.go
+++ b/controller/rest/mock_test.go
@@ -403,26 +403,22 @@ func (m *mockCache) GetProcessProfile(group string, acc *access.AccessControl) (
 func (m *mockCache) GetComplianceProfile(name string, acc *access.AccessControl) (*api.RESTComplianceProfile, map[string][]string, error) {
 	if cp, ok := m.cps[name]; ok {
 		filter := make(map[string][]string)
-		existingTags := make(map[string]map[string]bool)
 		// First create user override entries
 		for _, e := range cp.Entries {
-			var compliances []string
-			for compliance := range e.Tags {
-				compliances = append(compliances, compliance)
-				existingTags[e.TestNum][compliance] = true
-			}
-			filter[e.TestNum] = compliances
+			filter[e.TestNum] = e.Tags
 		}
 
 		// Add checks that are not in the override list
 		_, metaMap := scanUtils.InitComplianceMeta("", "", "")
 		for _, m := range metaMap {
 			if _, ok := filter[m.TestNum]; !ok {
-				for compliance := range m.Tags {
-					if _, ok := existingTags[m.TestNum][compliance]; !ok {
-						filter[m.TestNum] = append(filter[m.TestNum], compliance)
+				var tags []string
+				for _, tagMap := range m.Tags {
+					for complianceTag, _ := range tagMap {
+						tags = append(tags, complianceTag)
 					}
 				}
+				filter[m.TestNum] = tags
 			}
 		}
 

--- a/controller/rest/mock_test.go
+++ b/controller/rest/mock_test.go
@@ -403,22 +403,26 @@ func (m *mockCache) GetProcessProfile(group string, acc *access.AccessControl) (
 func (m *mockCache) GetComplianceProfile(name string, acc *access.AccessControl) (*api.RESTComplianceProfile, map[string][]string, error) {
 	if cp, ok := m.cps[name]; ok {
 		filter := make(map[string][]string)
+		existingTags := make(map[string]map[string]bool)
 		// First create user override entries
 		for _, e := range cp.Entries {
-			filter[e.TestNum] = e.Tags
+			var compliances []string
+			for compliance := range e.Tags {
+				compliances = append(compliances, compliance)
+				existingTags[e.TestNum][compliance] = true
+			}
+			filter[e.TestNum] = compliances
 		}
 
 		// Add checks that are not in the override list
 		_, metaMap := scanUtils.InitComplianceMeta("", "", "")
 		for _, m := range metaMap {
 			if _, ok := filter[m.TestNum]; !ok {
-				var tags []string
-				for _, tagMap := range m.Tags {
-					for complianceTag, _ := range tagMap {
-						tags = append(tags, complianceTag)
+				for compliance := range m.Tags {
+					if _, ok := existingTags[m.TestNum][compliance]; !ok {
+						filter[m.TestNum] = append(filter[m.TestNum], compliance)
 					}
 				}
-				filter[m.TestNum] = tags
 			}
 		}
 

--- a/controller/rest/mock_test.go
+++ b/controller/rest/mock_test.go
@@ -409,14 +409,13 @@ func (m *mockCache) GetComplianceProfile(name string, acc *access.AccessControl)
 		}
 
 		// Add checks that are not in the override list
-		_, metaMap := scanUtils.InitComplianceMeta("", "", "")
+		scanUtils.InitComplianceMeta("", "", "")
+		_, metaMap := scanUtils.GetComplianceMeta(scanUtils.V1)
 		for _, m := range metaMap {
 			if _, ok := filter[m.TestNum]; !ok {
 				var tags []string
-				for _, tagMap := range m.Tags {
-					for complianceTag, _ := range tagMap {
-						tags = append(tags, complianceTag)
-					}
+				for _, complianceTag := range m.Tags {
+					tags = append(tags, complianceTag)
 				}
 				filter[m.TestNum] = tags
 			}

--- a/controller/rest/mock_test.go
+++ b/controller/rest/mock_test.go
@@ -563,6 +563,7 @@ func initTest() {
 	router.GET("/v1/scan/registry/:name", handlerRegistryShow)
 	router.DELETE("/v1/scan/registry/:name", handlerRegistryDelete)
 
+	router.GET("/v1/compliance/available_filter", handlerGetAvaiableComplianceFilter)
 	router.GET("/v1/compliance/profile", handlerComplianceProfileList)
 	router.GET("/v1/compliance/profile/:name", handlerComplianceProfileShow)
 	router.PATCH("/v1/compliance/profile/:name", handlerComplianceProfileConfig)

--- a/controller/rest/rest.go
+++ b/controller/rest/rest.go
@@ -1823,6 +1823,7 @@ func StartRESTServer(isNewCluster bool, isLead bool) {
 	r.GET("/v1/custom_check/:group", handlerCustomCheckShow)
 	r.GET("/v1/custom_check", handlerCustomCheckList)
 	r.PATCH("/v1/custom_check/:group", handlerCustomCheckConfig)
+	r.GET("/v1/compliance/available_filter", handlerGetAvaiableComplianceFilter)
 	r.GET("/v1/compliance/profile", handlerComplianceProfileList) // Only default is accepted, so not POST/DELETE
 	r.GET("/v1/compliance/profile/:name", handlerComplianceProfileShow)
 	r.PATCH("/v1/compliance/profile/:name", handlerComplianceProfileConfig)

--- a/controller/rest/rest.go
+++ b/controller/rest/rest.go
@@ -1823,8 +1823,8 @@ func StartRESTServer(isNewCluster bool, isLead bool) {
 	r.GET("/v1/custom_check/:group", handlerCustomCheckShow)
 	r.GET("/v1/custom_check", handlerCustomCheckList)
 	r.PATCH("/v1/custom_check/:group", handlerCustomCheckConfig)
-	r.GET("/v1/compliance/available_filter", handlerGetAvaiableComplianceFilter)
-	r.GET("/v1/compliance/profile", handlerComplianceProfileList) // Only default is accepted, so not POST/DELETE
+	r.GET("/v1/compliance/available_filter", handlerGetAvaiableComplianceFilter) // Skip API document, use internally
+	r.GET("/v1/compliance/profile", handlerComplianceProfileList)                // Only default is accepted, so not POST/DELETE
 	r.GET("/v1/compliance/profile/:name", handlerComplianceProfileShow)
 	r.PATCH("/v1/compliance/profile/:name", handlerComplianceProfileConfig)
 	r.PATCH("/v1/compliance/profile/:name/entry/:check", handlerComplianceProfileEntryConfig)

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -1111,6 +1111,8 @@ type CLUSGroupMetric struct {
 type CLUSWlMetric struct {
 	WlID        string `json:"wlid"`
 	WlSessCurIn uint32 `json:"wl_sess_cur_in"`
+	WlSessIn1   uint32 `json:"wl_sess_in1"`
+	WlByteIn1   uint64 `json:"wl_byte_in1"`
 	WlSessIn12  uint32 `json:"wl_sess_in12"`
 	WlByteIn12  uint64 `json:"wl_byte_in12"`
 }
@@ -1597,9 +1599,18 @@ type CLUSAuditLog struct {
 
 const SnifferIdAgentField = 12
 
+type TagDetail struct {
+	ID              string `yaml:"id" json:"id"`
+	Title           string `yaml:"title" json:"title"`
+	Description     string `yaml:"description" json:"description"`
+	CIS_Sub_Control string `yaml:"cis-sub-control"`
+}
+
+type TagDetails map[string]TagDetail
+
 type CLUSComplianceProfileEntry struct {
-	TestNum string   `json:"test_num"`
-	Tags    []string `json:"tags"`
+	TestNum string                `json:"test_num"`
+	Tags    map[string]TagDetails `json:"tags,omitempty"`
 }
 
 type CLUSComplianceProfile struct {

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -1111,8 +1111,6 @@ type CLUSGroupMetric struct {
 type CLUSWlMetric struct {
 	WlID        string `json:"wlid"`
 	WlSessCurIn uint32 `json:"wl_sess_cur_in"`
-	WlSessIn1   uint32 `json:"wl_sess_in1"`
-	WlByteIn1   uint64 `json:"wl_byte_in1"`
 	WlSessIn12  uint32 `json:"wl_sess_in12"`
 	WlByteIn12  uint64 `json:"wl_byte_in12"`
 }

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -1606,24 +1606,7 @@ type TagDetail struct {
 	CIS_Sub_Control string `yaml:"cis-sub-control"`
 }
 
-// TagDetails maps compliance item IDs to their corresponding details.
-//
-// The map uses the compliance item ID as the key, with the value being a struct
-// containing the following fields:
-// - CIS_Sub_Control: A string representing the CIS sub-control identifier.
-// - description: A string providing a detailed description of the compliance item.
-// - id: A string representing the unique identifier of the compliance item.
-// - title: A string providing a short title or summary of the compliance item.
-//
-// Example:
-//
-//	"compliance_item_id_123": {
-//	    "CIS_Sub_Control": "1.1",
-//	    "description": "Ensure mounting of cramfs filesystems is disabled",
-//	    "id": "compliance_item_id_123",
-//	    "title": "Disable cramfs filesystem"
-//	},
-type TagDetails map[string]TagDetail
+type TagDetails []TagDetail
 
 type CLUSComplianceProfileEntry struct {
 	TestNum string   `json:"test_num"`

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -1606,11 +1606,28 @@ type TagDetail struct {
 	CIS_Sub_Control string `yaml:"cis-sub-control"`
 }
 
+// TagDetails maps compliance item IDs to their corresponding details.
+//
+// The map uses the compliance item ID as the key, with the value being a struct
+// containing the following fields:
+// - CIS_Sub_Control: A string representing the CIS sub-control identifier.
+// - description: A string providing a detailed description of the compliance item.
+// - id: A string representing the unique identifier of the compliance item.
+// - title: A string providing a short title or summary of the compliance item.
+//
+// Example:
+//
+//	"compliance_item_id_123": {
+//	    "CIS_Sub_Control": "1.1",
+//	    "description": "Ensure mounting of cramfs filesystems is disabled",
+//	    "id": "compliance_item_id_123",
+//	    "title": "Disable cramfs filesystem"
+//	},
 type TagDetails map[string]TagDetail
 
 type CLUSComplianceProfileEntry struct {
-	TestNum string                `json:"test_num"`
-	Tags    map[string]TagDetails `json:"tags,omitempty"`
+	TestNum string   `json:"test_num"`
+	Tags    []string `json:"tags"`
 }
 
 type CLUSComplianceProfile struct {

--- a/share/scan/compliance.go
+++ b/share/scan/compliance.go
@@ -2814,6 +2814,18 @@ type PrimeCISBenchmarkConfig struct {
 	CISChecksWithTags []CISCheckWithTags `yaml:"checks"`
 }
 
+func GetComplianceFilterMap(metas []api.RESTBenchMeta, complianceFilterMap map[string]int) map[string]int {
+	if complianceFilterMap == nil {
+		complianceFilterMap = make(map[string]int)
+		for _, meta := range metas {
+			for compliance, _ := range meta.Tags {
+				complianceFilterMap[compliance]++
+			}
+		}
+	}
+	return complianceFilterMap
+}
+
 func InitComplianceMeta(platform, flavor, cloudPlatform string) ([]api.RESTBenchMeta, map[string]api.RESTBenchMeta) {
 	// Ensuring initialization happens only once
 	once.Do(func() {
@@ -2822,7 +2834,8 @@ func InitComplianceMeta(platform, flavor, cloudPlatform string) ([]api.RESTBench
 		// Check the current k8s version, then read the correct folder
 		GetCISFolder(platform, flavor, cloudPlatform)
 		GetK8sCISMeta(remediationFolder, cisItems)
-		PrepareBenchMeta(cisItems, &complianceMetas, complianceMetaMap, &isUpdateComplianceMetaMap)
+		PrepareBenchMeta(cisItems, complianceMetaMap, &isUpdateComplianceMetaMap)
+		PrepareBenchMeta(dockerImageCISItems, complianceMetaMap, &isUpdateComplianceMetaMap)
 	})
 
 	if isUpdateComplianceMetaMap {
@@ -2850,7 +2863,7 @@ func GetComplianceMeta() ([]api.RESTBenchMeta, map[string]api.RESTBenchMeta) {
 func InitImageBenchMeta() ([]api.RESTBenchMeta, map[string]api.RESTBenchMeta) {
 	// Ensuring initialization happens only once
 	once.Do(func() {
-		PrepareBenchMeta(dockerImageCISItems, &imageBenchMetas, imageBenchMetaMap, &isUpdateImageBenchMetaMap)
+		PrepareBenchMeta(dockerImageCISItems, imageBenchMetaMap, &isUpdateImageBenchMetaMap)
 	})
 
 	if isUpdateImageBenchMetaMap {
@@ -3038,7 +3051,7 @@ func GetK8sCISMeta(remediationFolder string, cis_bench_items map[string]api.REST
 	}
 }
 
-func PrepareBenchMeta(items map[string]api.RESTBenchCheck, metas *[]api.RESTBenchMeta, metaMap map[string]api.RESTBenchMeta, updateFlag *bool) {
+func PrepareBenchMeta(items map[string]api.RESTBenchCheck, metaMap map[string]api.RESTBenchMeta, updateFlag *bool) {
 	for _, item := range items {
 		metaMap[item.TestNum] = api.RESTBenchMeta{RESTBenchCheck: item}
 	}

--- a/share/scan/compliance.go
+++ b/share/scan/compliance.go
@@ -32,6 +32,7 @@ var (
 	defaultCISVersion         = "cis-1.8.0"
 	catchDescription          = regexp.MustCompile(`^(.*?) \([^)]*\)$`)
 	complianceMetas           []api.RESTBenchMeta
+	complianceProfileMetas    []api.RESTProfileBenchMeta
 	complianceMetaMap         = make(map[string]api.RESTBenchMeta)
 	imageBenchMetas           []api.RESTBenchMeta
 	imageBenchMetaMap         = make(map[string]api.RESTBenchMeta)
@@ -2840,6 +2841,7 @@ func InitComplianceMeta(platform, flavor, cloudPlatform string) ([]api.RESTBench
 
 	if isUpdateComplianceMetaMap {
 		updateMetasFromMap(&complianceMetas, complianceMetaMap, &isUpdateComplianceMetaMap)
+		updateProfileMetasFromMap(&complianceProfileMetas, complianceMetaMap)
 	}
 
 	return complianceMetas, complianceMetaMap
@@ -2855,9 +2857,19 @@ func GetComplianceMeta() ([]api.RESTBenchMeta, map[string]api.RESTBenchMeta) {
 
 	if isUpdateComplianceMetaMap {
 		updateMetasFromMap(&complianceMetas, complianceMetaMap, &isUpdateComplianceMetaMap)
+		updateProfileMetasFromMap(&complianceProfileMetas, complianceMetaMap)
 	}
 
 	return complianceMetas, complianceMetaMap
+}
+
+func GetComplianceProfileMeta() []api.RESTProfileBenchMeta {
+	if isUpdateComplianceMetaMap {
+		updateMetasFromMap(&complianceMetas, complianceMetaMap, &isUpdateComplianceMetaMap)
+		updateProfileMetasFromMap(&complianceProfileMetas, complianceMetaMap)
+	}
+
+	return complianceProfileMetas
 }
 
 func InitImageBenchMeta() ([]api.RESTBenchMeta, map[string]api.RESTBenchMeta) {
@@ -2903,6 +2915,30 @@ func updateMetasFromMap(slice *[]api.RESTBenchMeta, metaMap map[string]api.RESTB
 	}
 	sort.Slice(*slice, func(i, j int) bool { return (*slice)[i].TestNum < (*slice)[j].TestNum })
 	*updateFlag = false
+}
+
+func updateProfileMetasFromMap(slice *[]api.RESTProfileBenchMeta, metaMap map[string]api.RESTBenchMeta) {
+	*slice = make([]api.RESTProfileBenchMeta, 0, len(metaMap))
+	for _, item := range metaMap {
+		var tags []string
+		for compliance, _ := range item.RESTBenchCheck.Tags {
+			tags = append(tags, compliance)
+		}
+		*slice = append(*slice, api.RESTProfileBenchMeta{
+			RESTProfileBenchCheck: api.RESTProfileBenchCheck{
+				TestNum:     item.RESTBenchCheck.TestNum,
+				Type:        item.RESTBenchCheck.Type,
+				Category:    item.RESTBenchCheck.Category,
+				Scored:      item.RESTBenchCheck.Scored,
+				Profile:     item.RESTBenchCheck.Profile,
+				Automated:   item.RESTBenchCheck.Automated,
+				Description: item.RESTBenchCheck.Description,
+				Remediation: item.RESTBenchCheck.Remediation,
+				Tags:        tags,
+			},
+		})
+	}
+	sort.Slice(*slice, func(i, j int) bool { return (*slice)[i].TestNum < (*slice)[j].TestNum })
 }
 
 func PrepareBackup() {

--- a/share/scan/compliance.go
+++ b/share/scan/compliance.go
@@ -18,31 +18,44 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	V1 = "v1"
+	V2 = "v2"
+)
+
 var (
-	dstPrefix                 = "/usr/local/bin/scripts/cis_yamls/"
-	primeConfigPrefix         = "/etc/neuvector/prime/compliance/"
-	kube160                   = "cis-1.6.0"
-	kube123                   = "cis-1.23"
-	kube124                   = "cis-1.24"
-	kube180                   = "cis-1.8.0"
-	rh140                     = "rh-1.4.0"
-	gke140                    = "gke-1.4.0"
-	aks140                    = "aks-1.4.0"
-	eks140                    = "eks-1.4.0"
-	defaultCISVersion         = "cis-1.8.0"
-	catchDescription          = regexp.MustCompile(`^(.*?) \([^)]*\)$`)
-	complianceMetas           []api.RESTBenchMeta
-	complianceProfileMetas    []api.RESTProfileBenchMeta
-	complianceMetaMap         = make(map[string]api.RESTBenchMeta)
-	imageBenchMetas           []api.RESTBenchMeta
-	imageBenchMetaMap         = make(map[string]api.RESTBenchMeta)
+	dstPrefix         = "/usr/local/bin/scripts/cis_yamls/"
+	primeConfigPrefix = "/etc/neuvector/prime/compliance/"
+	kube160           = "cis-1.6.0"
+	kube123           = "cis-1.23"
+	kube124           = "cis-1.24"
+	kube180           = "cis-1.8.0"
+	rh140             = "rh-1.4.0"
+	gke140            = "gke-1.4.0"
+	aks140            = "aks-1.4.0"
+	eks140            = "eks-1.4.0"
+	defaultCISVersion = "cis-1.8.0"
+	catchDescription  = regexp.MustCompile(`^(.*?) \([^)]*\)$`)
+
+	// V2 Return the Tags map[string]share.TagDetails
+	complianceMetasV2   []api.RESTBenchMeta
+	complianceMetaMapV2 = make(map[string]api.RESTBenchMeta)
+	// Return the Tags []string
+	complianceMetas   []api.RESTBenchMeta
+	complianceMetaMap = make(map[string]api.RESTBenchMeta)
+	// image bench only return Tags []string
+	imageBenchMetas   []api.RESTBenchMeta
+	imageBenchMetaMap = make(map[string]api.RESTBenchMeta)
+
 	once                      sync.Once
 	backupCISItems            = make(map[string]api.RESTBenchCheck)
 	backupDockerImageCISItems = make(map[string]api.RESTBenchCheck)
 	cisVersion                string
 	remediationFolder         string
-	isUpdateImageBenchMetaMap = false
-	isUpdateComplianceMetaMap = false
+
+	// RWlock for compliance / imagebench metamap
+	complianceRWMutex sync.RWMutex
+	imageBenchRWMutex sync.RWMutex
 )
 
 var dockerImageCISItems = map[string]api.RESTBenchCheck{
@@ -113,7 +126,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure only trusted users are allowed to control Docker daemon",
 		Remediation: "You should remove any untrusted users from the docker group using command sudo gpasswd -d <your-user> docker or add trusted users to the docker group using command sudo usermod -aG docker <your-user>. You should not create a mapping of sensitive directories from the host to container volumes.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -128,7 +141,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for the Docker daemon",
 		Remediation: "Install auditd. Add -w /usr/bin/dockerd -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -142,7 +155,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /run/containerd",
 		Remediation: "Install auditd. Add -a exit,always -F path=/run/containerd -F perm=war -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -156,7 +169,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /var/lib/docker",
 		Remediation: "Install auditd. Add -w /var/lib/docker -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -170,7 +183,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /etc/docker",
 		Remediation: "Install auditd. Add -w /etc/docker -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -184,7 +197,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - docker.service",
 		Remediation: "Install auditd. Add -w $(get_service_file docker.service) -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -198,7 +211,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - containerd.sock",
 		Remediation: "Install auditd. Add -w $(get_service_file containerd.socket) -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -212,7 +225,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - docker.socket",
 		Remediation: "Install auditd. Add -w $(get_service_file docker.socket) -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -226,7 +239,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /etc/default/docker",
 		Remediation: "Install auditd. Add -w /etc/default/docker -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -240,7 +253,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Dockerfiles and directories - /etc/docker/daemon.json",
 		Remediation: "Install auditd. Add -w /etc/docker/daemon.json -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -254,7 +267,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Dockerfiles and directories - /etc/containerd/config.toml",
 		Remediation: "Install auditd. Add -w /etc/containerd/config.toml -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -268,7 +281,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /etc/sysconfig/docker",
 		Remediation: "Install auditd. Add -w /etc/sysconfig/docker -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -282,7 +295,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /usr/bin/containerd",
 		Remediation: "Install auditd. Add -w /usr/bin/containerd -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -296,7 +309,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /usr/bin/containerd-shim",
 		Remediation: "Install auditd. Add -w /usr/bin/containerd-shim -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -310,7 +323,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /usr/bin/containerd-shim-runc-v1",
 		Remediation: "Install auditd. Add -w /usr/bin/containerd-shim-runc-v1 -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -324,7 +337,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /usr/bin/containerd-shim-runc-v2",
 		Remediation: "Install auditd. Add -w /usr/bin/containerd-shim-runc-v2 -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -338,7 +351,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /usr/bin/runc",
 		Remediation: "Install auditd. Add -w /usr/bin/runc -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -412,7 +425,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure insecure registries are not used",
 		Remediation: "You should ensure that no insecure registries are in use.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -436,7 +449,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure TLS authentication for Docker daemon is configured",
 		Remediation: "Follow the steps mentioned in the Docker documentation or other references. By default, TLS authentication is not configured.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -511,7 +524,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure containers are restricted from acquiring new privileges",
 		Remediation: "You should run the Docker daemon using command: dockerd --no-new-privileges",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -565,7 +578,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that docker.service file ownership is set to root:root",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -580,7 +593,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that docker.service file permissions are appropriately set",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -595,7 +608,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that docker.socket file ownership is set to root:root",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -610,7 +623,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that docker.socket file permissions are set to 644 or more restrictive",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -625,7 +638,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that /etc/docker directory ownership is set to root:root",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -640,7 +653,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that /etc/docker directory permissions are set to 755 or more restrictive",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -655,7 +668,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that registry certificate file ownership is set to root:root",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -670,7 +683,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that registry certificate file permissions are set to 444 or more restrictive",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -685,7 +698,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that TLS CA certificate file ownership is set to root:root",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -700,7 +713,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that TLS CA certificate file permissions are set to 444 or more restrictive",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -715,7 +728,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that Docker server certificate file ownership is set to root:root",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -730,7 +743,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that Docker server certificate file permissions are set to 444 or more restrictive",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -745,7 +758,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that Docker server certificate key file ownership is set to root:root",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -760,7 +773,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that Docker server certificate key file permissions are set to 400",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -775,7 +788,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that Docker socket file ownership is set to root:docker",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -790,7 +803,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that Docker socket file permissions are set to 660 or more restrictive",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -805,7 +818,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that daemon.json file ownership is set to root:root",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -820,7 +833,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that daemon.json file permissions are set to 644 or more restrictive",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -835,7 +848,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that /etc/default/docker file ownership is set to root:root",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -850,7 +863,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the /etc/sysconfig/docker file ownership is set to root:root",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -865,7 +878,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that /etc/sysconfig/docker file permissions are set to 644 or more restrictive",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -880,7 +893,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that /etc/default/docker file permissions are set to 644 or more restrictive",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1065,7 +1078,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that privileged containers are not used",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1079,7 +1092,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure sensitive host system directories are not mounted on containers",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1093,7 +1106,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure sshd is not run within containers",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1107,7 +1120,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure privileged ports are not mapped within containers",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1131,7 +1144,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure the host's network namespace is not shared",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1165,7 +1178,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the container's root filesystem is mounted as read only",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1199,7 +1212,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure the host's process namespace is not shared",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1213,7 +1226,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure the host's IPC namespace is not shared",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1227,7 +1240,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that host devices are not directly exposed to containers",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1261,7 +1274,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure the host's UTS namespace is not shared",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1315,7 +1328,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the container is restricted from acquiring additional privileges",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1369,7 +1382,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the host's user namespaces are not shared",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1383,7 +1396,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the Docker socket is not mounted inside any containers",
 		Remediation: "",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1397,7 +1410,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod 644 /etc/kubernetes/manifests/kube-apiserver.yaml",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1412,7 +1425,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the API server pod specification file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown root:root /etc/kubernetes/manifests/kube-apiserver.yaml",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1427,7 +1440,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod 644 /etc/kubernetes/manifests/kube-controller-manager.yaml",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1442,7 +1455,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the controller manager pod specification file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown root:root /etc/kubernetes/manifests/kube-controller-manager.yaml",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1457,7 +1470,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod 644 /etc/kubernetes/manifests/kube-scheduler.yaml",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1472,7 +1485,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the scheduler pod specification file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown root:root /etc/kubernetes/manifests/kube-scheduler.yaml",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1487,7 +1500,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod 644 /etc/kubernetes/manifests/etcd.yaml",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1502,7 +1515,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the etcd pod specification file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown root:root /etc/kubernetes/manifests/etcd.yaml",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1517,7 +1530,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod 644 <path/to/cni/files>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1532,7 +1545,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the Container Network Interface file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown root:root <path/to/cni/files>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1547,7 +1560,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the etcd data directory permissions are set to 700 or more restrictive",
 		Remediation: "On the etcd server node, get the etcd data directory, passed as an argument --data-dir, from the below command: ps -ef | grep etcd Run the below command (based on the etcd data directory found above). For example, chmod 700 /var/lib/etcd",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1562,7 +1575,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the etcd data directory ownership is set to etcd:etcd",
 		Remediation: "On the etcd server node, get the etcd data directory, passed as an argument --data-dir, from the below command: ps -ef | grep etcd Run the below command (based on the etcd data directory found above). For example, chown etcd:etcd /var/lib/etcd",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1577,7 +1590,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admin.conf file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod 644 /etc/kubernetes/admin.conf",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1592,7 +1605,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admin.conf file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown root:root /etc/kubernetes/admin.conf",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1607,7 +1620,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod 644 /etc/kubernetes/scheduler.conf",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1622,7 +1635,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the scheduler.conf file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown root:root /etc/kubernetes/scheduler.conf",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1637,7 +1650,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod 644 /etc/kubernetes/controller-manager.conf",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1652,7 +1665,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the controller-manager.conf file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown root:root /etc/kubernetes/controller-manager.conf",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1667,7 +1680,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown -R root:root /etc/kubernetes/pki/",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1682,7 +1695,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod -R 644 /etc/kubernetes/pki/*.crt",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1697,7 +1710,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the Kubernetes PKI key file permissions are set to 600",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod -R 600 /etc/kubernetes/pki/*.key",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1712,7 +1725,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --anonymous-auth argument is set to false",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the below parameter. --anonymous-auth=false",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1727,7 +1740,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --basic-auth-file argument is not set",
 		Remediation: "Follow the documentation and configure alternate mechanisms for authentication. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and remove the --basic-auth-file=<filename> parameter.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1742,7 +1755,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --token-auth-file parameter is not set",
 		Remediation: "Follow the documentation and configure alternate mechanisms for authentication. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and remove the --token-auth-file=<filename> parameter.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1757,7 +1770,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --kubelet-https argument is set to true",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and remove the --kubelet-https parameter.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1772,7 +1785,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate",
 		Remediation: "Follow the Kubernetes documentation and set up the TLS connection between the apiserver and kubelets. Then, edit API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the kubelet client certificate and key parameters as below. --kubelet-client-certificate=<path/to/client-certificate-file> --kubelet-client-key=<path/to/client-key-file>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1787,7 +1800,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --kubelet-certificate-authority argument is set as appropriate",
 		Remediation: "Follow the Kubernetes documentation and setup the TLS connection between the apiserver and kubelets. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the -- kubelet-certificate-authority parameter to the path to the cert file for the certificate authority. --kubelet-certificate-authority=<ca-string>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1802,7 +1815,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --authorization-mode argument is not set to AlwaysAllow",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --authorization-mode parameter to values other than AlwaysAllow . One such example could be as below. --authorization-mode=RBAC",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1817,7 +1830,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --authorization-mode argument includes Node",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --authorization-mode parameter to a value that includes Node . --authorization-mode=Node,RBAC",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1832,7 +1845,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --authorization-mode argument includes RBAC",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --authorization-mode parameter to a value that includes RBAC, for example:--authorization-mode=Node,RBAC",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1847,7 +1860,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admission control plugin EventRateLimit is set",
 		Remediation: "Follow the Kubernetes documentation and set the desired limits in a configuration file. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml and set the below parameters.  --enable-admission-plugins=...,EventRateLimit,... --admission-control-config-file=<path/to/configuration/file>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1861,7 +1874,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admission control plugin AlwaysAdmit is not set",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and either remove the --enable-admission-plugins parameter, or set it to a value that does not include AlwaysAdmit.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1875,7 +1888,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admission control plugin AlwaysPullImages is set",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --enable-admission-plugins parameter to include AlwaysPullImages.  --enable-admission-plugins=...,AlwaysPullImages,...",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1889,7 +1902,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --enable-admission-plugins parameter to include SecurityContextDeny, unless PodSecurityPolicy is already in place.  --enable-admission-plugins=...,SecurityContextDeny,...",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1903,7 +1916,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admission control plugin ServiceAccount is set",
 		Remediation: "Follow the documentation and create ServiceAccount objects as per your environment. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and ensure that the --disable-admission-plugins parameter is set to a value that does not include ServiceAccount.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1917,7 +1930,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admission control plugin NamespaceLifecycle is set",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --disable-admission-plugins parameter to ensure it does not include NamespaceLifecycle.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1931,7 +1944,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admission control plugin PodSecurityPolicy is set",
 		Remediation: "Follow the documentation and create Pod Security Policy objects as per your environment. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --enable-admission-plugins parameter to a value that includes PodSecurityPolicy: --enable-admission-plugins=...,PodSecurityPolicy,... Then restart the API Server.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1945,7 +1958,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admission control plugin NodeRestriction is set",
 		Remediation: "Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --enable-admission-plugins parameter to a value that includes NodeRestriction. --enable-admission-plugins=...,NodeRestriction,...",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 		},
@@ -1959,7 +1972,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --insecure-bind-address argument is not set",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and remove the --insecure-bind-address parameter.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1974,7 +1987,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --insecure-port argument is set to 0",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the below parameter. --insecure-port=0",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -1989,7 +2002,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --secure-port argument is not set to 0",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and either remove the --secure-port parameter or set it to a different (non-zero) desired port.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2014,7 +2027,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --audit-log-path argument is set",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --audit-log-path parameter to a suitable path and file where you would like audit logs to be written, for example: --audit-log-path=/var/log/apiserver/audit.log",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -2028,7 +2041,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --audit-log-maxage parameter to 30 or as an appropriate number of days: --audit-log-maxage=30",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -2042,7 +2055,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --audit-log-maxbackup parameter to 10 or to an appropriate value. --audit-log-maxbackup=10",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -2056,7 +2069,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --audit-log-maxsize parameter to an appropriate size in MB. For example, to set it as 100 MB: --audit-log-maxsize=100",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -2080,7 +2093,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --service-account-lookup argument is set to true",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the below parameter. --service-account-lookup=true",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2095,7 +2108,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --service-account-key-file argument is set as appropriate",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --service-account-key-file parameter to the public key file for service accounts: --service-account-key-file=<filename>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2110,7 +2123,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate",
 		Remediation: "Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the etcd certificate and key file parameters.  --etcd-certfile=<path/to/client-certificate-file> --etcd-keyfile=<path/to/client-key-file>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2125,7 +2138,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate",
 		Remediation: "Follow the Kubernetes documentation and set up the TLS connection on the apiserver. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the TLS certificate and private key file parameters. --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key-file=<path/to/tls-key-file>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2140,7 +2153,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --client-ca-file argument is set as appropriate",
 		Remediation: "Follow the Kubernetes documentation and set up the TLS connection on the apiserver. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the client certificate authority file. --client-ca-file=<path/to/client-ca-file>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2155,7 +2168,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --etcd-cafile argument is set as appropriate",
 		Remediation: "Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the etcd certificate authority file parameter. --etcd-cafile=<path/to/ca-file>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2170,7 +2183,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --encryption-provider-config argument is set as appropriate",
 		Remediation: "Follow the Kubernetes documentation and configure a EncryptionConfig file. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --encryption-provider-config parameter to the path of that file: --encryption-provider-config=</path/to/EncryptionConfig/File>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2185,7 +2198,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that encryption providers are appropriately configured",
 		Remediation: "Follow the Kubernetes documentation and configure a EncryptionConfig file. In this file, choose aescbc, kms or secretbox as the encryption provider.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2200,7 +2213,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the below parameter as follows, or to a subset of these values. --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM _SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM _SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM _SHA384",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2235,7 +2248,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --use-service-account-credentials argument is set to true",
 		Remediation: "Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml on the master node to set the below parameter. --use-service-account-credentials=true",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2250,7 +2263,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --service-account-private-key-file argument is set as appropriate",
 		Remediation: "Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml on the master node and set the --service-account-private- key-file parameter to the private key file for service accounts. --service-account-private-key-file=<filename>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2265,7 +2278,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --root-ca-file argument is set as appropriate",
 		Remediation: "Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml on the master node and set the --root-ca-file parameter to the certificate bundle file`. --root-ca-file=<path/to/file>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2280,7 +2293,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the RotateKubeletServerCertificate argument is set to true",
 		Remediation: "Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml on the master node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true. --feature-gates=RotateKubeletServerCertificate=true",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2325,7 +2338,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --cert-file and --key-file arguments are set as appropriate",
 		Remediation: "Follow the etcd service documentation and configure TLS encryption. Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and set the below parameters.  --cert-file=</path/to/ca-file> --key-file=</path/to/key-file>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2340,7 +2353,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --client-cert-auth argument is set to true",
 		Remediation: "Edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and set the below parameter. --client-cert-auth=\"true\"",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2355,7 +2368,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --auto-tls argument is not set to true",
 		Remediation: "Edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and either remove the --auto-tls parameter or set it to false. --auto-tls=false",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2370,7 +2383,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate",
 		Remediation: "Follow the etcd service documentation and configure peer TLS encryption as appropriate for your etcd cluster. Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and set the below parameters.  --peer-cert-file=</path/to/peer-cert-file> --peer-key-file=</path/to/peer-key-file>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2385,7 +2398,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --peer-client-cert-auth argument is set to true",
 		Remediation: "Edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and set the below parameter. --peer-client-cert-auth=true",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2400,7 +2413,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --peer-auto-tls argument is not set to true",
 		Remediation: "Edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and either remove the --peer-auto-tls parameter or set it to false. --peer-auto-tls=false",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2415,7 +2428,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that a unique Certificate Authority is used for etcd",
 		Remediation: "Follow the etcd documentation and create a dedicated certificate authority setup for the etcd service. Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and set the below parameter. --trusted-ca-file=</path/to/ca-file>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2440,7 +2453,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that a minimal audit policy is created",
 		Remediation: "Create an audit policy file for your cluster.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -2454,7 +2467,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the audit policy covers key security concerns",
 		Remediation: "Consider modification of the audit policy in use on the cluster to include these items, at a minimum.",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
@@ -2468,7 +2481,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the kubelet service file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the each worker node. For example, chmod 644 /etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2483,7 +2496,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the kubelet service file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the each worker node. For example, chown root:root /etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2498,7 +2511,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the proxy kubeconfig file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the each worker node. For example, chmod 644 <proxy kubeconfig file",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2513,7 +2526,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the proxy kubeconfig file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the each worker node. For example, chown root:root <proxy kubeconfig file>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2528,7 +2541,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the kubelet.conf file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the each worker node. For example, chmod 644 /etc/kubernetes/kubelet.conf",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2543,7 +2556,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the kubelet.conf file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the each worker node. For example, chown root:root /etc/kubernetes/kubelet.conf",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2558,7 +2571,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive",
 		Remediation: "Run the following command to modify the file permissions of the --client-ca-file chmod 644 <filename>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2573,7 +2586,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the client certificate authorities file ownership is set to root:root",
 		Remediation: "Run the following command to modify the ownership of the --client-ca-file. chown root:root <filename>",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2588,7 +2601,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the kubelet configuration file has permissions set to 644 or more restrictive",
 		Remediation: "Run the following command (using the config file location identied in the Audit step) chmod 644 /var/lib/kubelet/config.yaml",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2603,7 +2616,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the kubelet configuration file ownership is set to root:root",
 		Remediation: "Run the following command (using the config file location identied in the Audit step) chown root:root /etc/kubernetes/kubelet.conf",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2618,7 +2631,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the anonymous-auth argument is set to false",
 		Remediation: "If using a Kubelet config file, edit the file to set authentication: anonymous: enabled to false. If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable. --anonymous-auth=false Based on your system, restart the kubelet service. For example:  systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2633,7 +2646,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the --authorization-mode argument is not set to AlwaysAllow",
 		Remediation: "If using a Kubelet config file, edit the file to set authorization: mode to Webhook. If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable. --authorization-mode=Webhook Based on your system, restart the kubelet service. For example:  systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2648,7 +2661,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the --client-ca-file argument is set as appropriate",
 		Remediation: "If using a Kubelet config file, edit the file to set authentication: x509: clientCAFile to the location of the client CA file. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable. --client-ca-file=<path/to/client-ca-file> Based on your system, restart the kubelet service. For example:  systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2663,7 +2676,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the --read-only-port argument is set to 0",
 		Remediation: "If using a Kubelet config file, edit the file to set readOnlyPort to 0. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable. --read-only-port=0 Based on your system, restart the kubelet service. For example:  systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2688,7 +2701,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --protect-kernel-defaults argument is set to true",
 		Remediation: "If using a Kubelet config file, edit the file to set protectKernelDefaults: true. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable. --protect-kernel-defaults=true Based on your system, restart the kubelet service. For example:  systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2733,7 +2746,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate",
 		Remediation: "If using a Kubelet config file, edit the file to set tlsCertFile to the location of the certificate file to use to identify this Kubelet, and tlsPrivateKeyFile to the location of the corresponding private key file. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameters in KUBELET_CERTIFICATE_ARGS variable.  --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key- file=<path/to/tls-key-file> Based on your system, restart the kubelet service. For example:  systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2748,7 +2761,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --rotate-certificates argument is not set to false",
 		Remediation: "If using a Kubelet config file, edit the file to add the line rotateCertificates: true or remove it altogether to use the default value. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS variable. Based on your system, restart the kubelet service. For example: systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2763,7 +2776,7 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the RotateKubeletServerCertificate argument is set to true",
 		Remediation: "On the master edit /var/lib/kubelet/kubeadm-flags.env and set the parameter KUBELET_CERTIFICATE_ARGS --feature-gates=RotateKubeletServerCertificate=true or as an alternative, and suggested as a last resort, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable. --feature-gates=RotateKubeletServerCertificate=true Based on your system, restart the kubelet service. For example:  systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
@@ -2778,12 +2791,31 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers",
 		Remediation: "If using a Kubelet config file, edit the file to set TLSCipherSuites: to TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256 or to a subset of these values. If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the --tls-cipher-suites parameter as follows, or to a subset of these values. --tls-cipher- suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM _SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM _SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM _SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256 Based on your system, restart the kubelet service. For example:  systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: map[string]share.TagDetails{
+		TagsV2: map[string]share.TagDetails{
 			"HIPAA": share.TagDetails{},
 			"PCI":   share.TagDetails{},
 			"GDPR":  share.TagDetails{},
 		},
 	},
+}
+
+type UpdateConfigParams struct {
+	Metas     *[]api.RESTBenchMeta
+	MetaMap   map[string]api.RESTBenchMeta
+	MetasV2   *[]api.RESTBenchMeta
+	MetaMapV2 map[string]api.RESTBenchMeta
+}
+
+type Config struct {
+	Version string
+}
+
+type Option func(*Config)
+
+func WithVersion(version string) Option {
+	return func(c *Config) {
+		c.Version = version
+	}
 }
 
 type CISCheck struct {
@@ -2819,7 +2851,7 @@ func GetComplianceFilterMap(metas []api.RESTBenchMeta, complianceFilterMap map[s
 	if complianceFilterMap == nil {
 		complianceFilterMap = make(map[string]int)
 		for _, meta := range metas {
-			for compliance, _ := range meta.Tags {
+			for _, compliance := range meta.Tags {
 				complianceFilterMap[compliance]++
 			}
 		}
@@ -2827,105 +2859,81 @@ func GetComplianceFilterMap(metas []api.RESTBenchMeta, complianceFilterMap map[s
 	return complianceFilterMap
 }
 
-func InitComplianceMeta(platform, flavor, cloudPlatform string) ([]api.RESTBenchMeta, map[string]api.RESTBenchMeta) {
+func InitComplianceMeta(platform, flavor, cloudPlatform string) {
+	complianceRWMutex.Lock()
+	defer complianceRWMutex.Unlock()
+
+	// For fast rollback to original setting when fail
+	PrepareBackup()
+	// Check the current k8s version, then read the correct folder
+	GetCISFolder(platform, flavor, cloudPlatform)
+	GetK8sCISMeta(remediationFolder, cisItems)
+	PrepareBenchMeta(cisItems, complianceMetaMapV2)
+	PrepareBenchMeta(dockerImageCISItems, complianceMetaMapV2)
+	updateComplianceMetasFromMap(&complianceMetas, complianceMetaMap, &complianceMetasV2, complianceMetaMapV2)
+}
+
+// version V2 Return the Tags map[string]share.TagDetails
+// version V1 Return the Tags []string for backward compatible
+func GetComplianceMeta(version string) ([]api.RESTBenchMeta, map[string]api.RESTBenchMeta) {
 	// Ensuring initialization happens only once
 	once.Do(func() {
-		// For fast rollback to original setting when fail
-		PrepareBackup()
-		// Check the current k8s version, then read the correct folder
-		GetCISFolder(platform, flavor, cloudPlatform)
-		GetK8sCISMeta(remediationFolder, cisItems)
-		PrepareBenchMeta(cisItems, complianceMetaMap, &isUpdateComplianceMetaMap)
-		PrepareBenchMeta(dockerImageCISItems, complianceMetaMap, &isUpdateComplianceMetaMap)
+		complianceRWMutex.Lock()
+		defer complianceRWMutex.Unlock()
+		if complianceMetas == nil || complianceMetaMap == nil {
+			// if this is still nil, wait for the InitComplianceMeta
+			// scanUtils.InitComplianceMeta() is called in controller\controller.go before cache/rest call GetComplianceMeta => we can assume the platform / flavor is correct at this point
+			InitComplianceMeta("", "", "")
+		}
 	})
 
-	if isUpdateComplianceMetaMap {
-		updateMetasFromMap(&complianceMetas, complianceMetaMap, &isUpdateComplianceMetaMap)
-		updateProfileMetasFromMap(&complianceProfileMetas, complianceMetaMap)
+	complianceRWMutex.RLock()
+	defer complianceRWMutex.RUnlock()
+
+	switch version {
+	case "v1":
+		return complianceMetas, complianceMetaMap
+	case "v2":
+		return complianceMetasV2, complianceMetaMapV2
+	default:
+		return complianceMetas, complianceMetaMap
 	}
-
-	return complianceMetas, complianceMetaMap
-}
-
-func GetComplianceMeta() ([]api.RESTBenchMeta, map[string]api.RESTBenchMeta) {
-
-	if complianceMetas == nil || complianceMetaMap == nil {
-		// if this is still nil, wait for the InitComplianceMeta
-		// scanUtils.InitComplianceMeta() is called in controller\controller.go before cache/rest call GetComplianceMeta => we can assume the platform / flavor is correct at this point
-		return InitComplianceMeta("", "", "")
-	}
-
-	if isUpdateComplianceMetaMap {
-		updateMetasFromMap(&complianceMetas, complianceMetaMap, &isUpdateComplianceMetaMap)
-		updateProfileMetasFromMap(&complianceProfileMetas, complianceMetaMap)
-	}
-
-	return complianceMetas, complianceMetaMap
-}
-
-func GetComplianceProfileMeta() []api.RESTProfileBenchMeta {
-	if isUpdateComplianceMetaMap {
-		updateMetasFromMap(&complianceMetas, complianceMetaMap, &isUpdateComplianceMetaMap)
-		updateProfileMetasFromMap(&complianceProfileMetas, complianceMetaMap)
-	}
-
-	return complianceProfileMetas
 }
 
 func InitImageBenchMeta() ([]api.RESTBenchMeta, map[string]api.RESTBenchMeta) {
-	// Ensuring initialization happens only once
+	PrepareBenchMeta(dockerImageCISItems, imageBenchMetaMap)
+	updatImageBenchMetasFromMap(&imageBenchMetas, imageBenchMetaMap)
+	return imageBenchMetas, imageBenchMetaMap
+}
+
+// Image just return v1
+func GetImageBenchMeta() ([]api.RESTBenchMeta, map[string]api.RESTBenchMeta) {
 	once.Do(func() {
-		PrepareBenchMeta(dockerImageCISItems, imageBenchMetaMap, &isUpdateImageBenchMetaMap)
+		imageBenchRWMutex.Lock()
+		defer imageBenchRWMutex.Unlock()
+		if imageBenchMetas == nil || imageBenchMetaMap == nil {
+			// if this is still nil, wait for the InitComplianceMeta
+			InitImageBenchMeta()
+		}
 	})
 
-	if isUpdateImageBenchMetaMap {
-		updateMetasFromMap(&imageBenchMetas, imageBenchMetaMap, &isUpdateImageBenchMetaMap)
-	}
-
+	imageBenchRWMutex.RLock()
+	defer imageBenchRWMutex.RUnlock()
 	return imageBenchMetas, imageBenchMetaMap
 }
 
-func GetImageBenchMeta() ([]api.RESTBenchMeta, map[string]api.RESTBenchMeta) {
-
-	if imageBenchMetas == nil || imageBenchMetaMap == nil {
-		// if this is still nil, wait for the InitComplianceMeta
-		return InitImageBenchMeta()
-	}
-
-	if isUpdateImageBenchMetaMap {
-		updateMetasFromMap(&imageBenchMetas, imageBenchMetaMap, &isUpdateImageBenchMetaMap)
-	}
-
-	return imageBenchMetas, imageBenchMetaMap
-}
-
-func GetImageBencheMeta() ([]api.RESTBenchMeta, map[string]api.RESTBenchMeta) {
-
-	if imageBenchMetas == nil || imageBenchMetaMap == nil {
-		// if this is still nil, wait for the InitComplianceMeta
-		return InitImageBenchMeta()
-	}
-	return imageBenchMetas, imageBenchMetaMap
-}
-
-func updateMetasFromMap(slice *[]api.RESTBenchMeta, metaMap map[string]api.RESTBenchMeta, updateFlag *bool) {
-	*slice = make([]api.RESTBenchMeta, 0, len(metaMap))
-	for _, item := range metaMap {
-		*slice = append(*slice, item)
-	}
-	sort.Slice(*slice, func(i, j int) bool { return (*slice)[i].TestNum < (*slice)[j].TestNum })
-	*updateFlag = false
-}
-
-func updateProfileMetasFromMap(slice *[]api.RESTProfileBenchMeta, metaMap map[string]api.RESTBenchMeta) {
-	*slice = make([]api.RESTProfileBenchMeta, 0, len(metaMap))
-	for _, item := range metaMap {
+func updateComplianceMetasFromMap(metas *[]api.RESTBenchMeta, metaMap map[string]api.RESTBenchMeta, metasV2 *[]api.RESTBenchMeta, metaMapV2 map[string]api.RESTBenchMeta) {
+	*metas = make([]api.RESTBenchMeta, 0, len(metaMapV2))
+	*metasV2 = make([]api.RESTBenchMeta, 0, len(metaMapV2))
+	var benchMeta api.RESTBenchMeta
+	for id, item := range metaMapV2 {
+		*metasV2 = append(*metasV2, item)
 		var tags []string
-		for compliance, _ := range item.RESTBenchCheck.Tags {
+		for compliance, _ := range item.RESTBenchCheck.TagsV2 {
 			tags = append(tags, compliance)
 		}
-		*slice = append(*slice, api.RESTProfileBenchMeta{
-			RESTProfileBenchCheck: api.RESTProfileBenchCheck{
+		benchMeta = api.RESTBenchMeta{
+			RESTBenchCheck: api.RESTBenchCheck{
 				TestNum:     item.RESTBenchCheck.TestNum,
 				Type:        item.RESTBenchCheck.Type,
 				Category:    item.RESTBenchCheck.Category,
@@ -2936,7 +2944,20 @@ func updateProfileMetasFromMap(slice *[]api.RESTProfileBenchMeta, metaMap map[st
 				Remediation: item.RESTBenchCheck.Remediation,
 				Tags:        tags,
 			},
-		})
+		}
+		*metas = append(*metas, benchMeta)
+		metaMap[id] = benchMeta
+	}
+
+	// sort the metas, metasV2
+	sort.Slice(*metas, func(i, j int) bool { return (*metas)[i].TestNum < (*metas)[j].TestNum })
+	sort.Slice(*metasV2, func(i, j int) bool { return (*metasV2)[i].TestNum < (*metasV2)[j].TestNum })
+}
+
+func updatImageBenchMetasFromMap(slice *[]api.RESTBenchMeta, metaMap map[string]api.RESTBenchMeta) {
+	*slice = make([]api.RESTBenchMeta, 0, len(metaMap))
+	for _, item := range metaMap {
+		*slice = append(*slice, item)
 	}
 	sort.Slice(*slice, func(i, j int) bool { return (*slice)[i].TestNum < (*slice)[j].TestNum })
 }
@@ -2961,23 +2982,23 @@ func DeepCopyRESTBenchCheck(orig api.RESTBenchCheck) api.RESTBenchCheck {
 		Automated:   orig.Automated,
 		Description: orig.Description,
 		Remediation: orig.Remediation,
-		Tags:        nil,
+		TagsV2:      nil,
 	}
 
 	// Deep copy the Tags map
-	if orig.Tags != nil {
-		copy.Tags = make(map[string]share.TagDetails)
-		for compliance, detailsMap := range orig.Tags {
-			copiedDetailsMap := make(share.TagDetails)
-			for key, detail := range detailsMap {
-				copiedDetailsMap[key] = share.TagDetail{
+	if orig.TagsV2 != nil {
+		copy.TagsV2 = make(map[string]share.TagDetails)
+		for compliance, detailsMap := range orig.TagsV2 {
+			copiedDetails := share.TagDetails{}
+			for _, detail := range detailsMap {
+				copiedDetails = append(copiedDetails, share.TagDetail{
 					ID:              detail.ID,
 					Title:           detail.Title,
 					Description:     detail.Description,
 					CIS_Sub_Control: detail.CIS_Sub_Control,
-				}
+				})
 			}
-			copy.Tags[compliance] = copiedDetailsMap
+			copy.TagsV2[compliance] = copiedDetails
 		}
 	}
 
@@ -3034,6 +3055,7 @@ func GetCISFolder(platform, flavor, cloudPlatform string) {
 	remediationFolder = fmt.Sprintf("%s%s/", dstPrefix, cisVersion)
 }
 
+// Read the compliance Tags with map[string]share.TagDetails, then parse it into []string whenever it updated
 func processCISBenchmarkYAML(path string, cis_bench_items map[string]api.RESTBenchCheck) error {
 	fileContent, err := os.ReadFile(path)
 	if err != nil {
@@ -3059,7 +3081,7 @@ func processCISBenchmarkYAML(path string, cis_bench_items map[string]api.RESTBen
 				Automated:   check.Automated,
 				Description: catchDescription.ReplaceAllString(check.Description, "$1"),
 				Remediation: check.Remediation,
-				Tags:        check.Tags,
+				TagsV2:      check.Tags,
 			}
 		}
 	}
@@ -3087,14 +3109,15 @@ func GetK8sCISMeta(remediationFolder string, cis_bench_items map[string]api.REST
 	}
 }
 
-func PrepareBenchMeta(items map[string]api.RESTBenchCheck, metaMap map[string]api.RESTBenchMeta, updateFlag *bool) {
+func PrepareBenchMeta(items map[string]api.RESTBenchCheck, metaMap map[string]api.RESTBenchMeta) {
 	for _, item := range items {
 		metaMap[item.TestNum] = api.RESTBenchMeta{RESTBenchCheck: item}
 	}
-	*updateFlag = true
 }
 
-func updateWithPrimeConfig(primeConfig string, metaMap map[string]api.RESTBenchMeta, updateFlag *bool) {
+func updateComplianceWithPrimeConfig(primeConfig string, params *UpdateConfigParams) {
+	complianceRWMutex.Lock()
+	defer complianceRWMutex.Unlock()
 	fileContent, err := os.ReadFile(primeConfig)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Error reading file")
@@ -3108,29 +3131,69 @@ func updateWithPrimeConfig(primeConfig string, metaMap map[string]api.RESTBenchM
 	}
 
 	for _, check := range primeCISBenchmarkConfig.CISChecksWithTags {
-		if metaData, exists := metaMap[check.ID]; exists {
+		if metaData, exists := params.MetaMapV2[check.ID]; exists {
 			primeMetaData := metaData
 
-			if primeMetaData.Tags == nil {
-				primeMetaData.Tags = make(map[string]share.TagDetails)
+			if primeMetaData.TagsV2 == nil {
+				primeMetaData.TagsV2 = make(map[string]share.TagDetails)
 			}
 
 			for compliance, complianceDetails := range check.Tags {
-				primeMetaData.Tags[compliance] = complianceDetails
+				primeMetaData.TagsV2[compliance] = complianceDetails
 			}
 
-			metaMap[check.ID] = primeMetaData
+			params.MetaMapV2[check.ID] = primeMetaData
 		} else {
 			log.WithFields(log.Fields{"check.Id": check.ID}).Info("check.ID is not in metaMap: ")
 			break
 		}
 	}
-	*updateFlag = true
+	updateComplianceMetasFromMap(params.Metas, params.MetaMap, params.MetasV2, params.MetaMapV2)
 }
 
-func LoadConfig(primeConfig string, metaMap map[string]api.RESTBenchMeta, updateFlag *bool) {
+func updateImageBenchWithPrimeConfig(primeConfig string, params *UpdateConfigParams) {
+	imageBenchRWMutex.Lock()
+	defer imageBenchRWMutex.Unlock()
+	fileContent, err := os.ReadFile(primeConfig)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("Error reading file")
+	}
+
+	var primeCISBenchmarkConfig PrimeCISBenchmarkConfig
+	err = yaml.Unmarshal(fileContent, &primeCISBenchmarkConfig)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("Error unmarshalling YAML file")
+		return
+	}
+
+	for _, check := range primeCISBenchmarkConfig.CISChecksWithTags {
+		if metaData, exists := params.MetaMap[check.ID]; exists {
+			primeMetaData := metaData
+
+			if primeMetaData.Tags == nil {
+				primeMetaData.Tags = []string{}
+			}
+
+			for compliance, _ := range check.Tags {
+				primeMetaData.Tags = append(primeMetaData.Tags, compliance)
+			}
+
+			params.MetaMap[check.ID] = primeMetaData
+		} else {
+			log.WithFields(log.Fields{"check.Id": check.ID}).Info("check.ID is not in ImageBenchMetaMap: ")
+			break
+		}
+	}
+	updatImageBenchMetasFromMap(params.Metas, params.MetaMap)
+}
+
+func LoadConfig(primeConfig string, params *UpdateConfigParams, updateCompliance bool) {
 	if _, err := os.Stat(primeConfig); err == nil {
-		updateWithPrimeConfig(primeConfig, metaMap, updateFlag)
+		if updateCompliance {
+			updateComplianceWithPrimeConfig(primeConfig, params)
+		} else {
+			updateImageBenchWithPrimeConfig(primeConfig, params)
+		}
 		return
 	}
 
@@ -3164,10 +3227,18 @@ func LoadConfig(primeConfig string, metaMap map[string]api.RESTBenchMeta, update
 				}
 				switch {
 				case event.Op&fsnotify.Create == fsnotify.Create && event.Name == primeConfig:
-					updateWithPrimeConfig(primeConfig, metaMap, updateFlag)
+					if updateCompliance {
+						updateComplianceWithPrimeConfig(primeConfig, params)
+					} else {
+						updateImageBenchWithPrimeConfig(primeConfig, params)
+					}
 					return
 				case event.Op&fsnotify.Write == fsnotify.Write && event.Name == primeConfig:
-					updateWithPrimeConfig(primeConfig, metaMap, updateFlag)
+					if updateCompliance {
+						updateComplianceWithPrimeConfig(primeConfig, params)
+					} else {
+						updateImageBenchWithPrimeConfig(primeConfig, params)
+					}
 					return
 				}
 			case err, ok := <-watcher.Errors:
@@ -3192,7 +3263,19 @@ func UpdateComplianceConfigs() {
 	// update prime cis docker image configs
 	primeDockerImageConfig := fmt.Sprintf("%s%s.yaml", primeConfigPrefix, "cis-docker-image")
 
-	go LoadConfig(primeCISConfig, complianceMetaMap, &isUpdateComplianceMetaMap)
-	go LoadConfig(primeDockerConfig, complianceMetaMap, &isUpdateComplianceMetaMap)
-	go LoadConfig(primeDockerImageConfig, imageBenchMetaMap, &isUpdateImageBenchMetaMap)
+	complianceMetaConfig := &UpdateConfigParams{
+		Metas:     &complianceMetas,
+		MetaMap:   complianceMetaMap,
+		MetasV2:   &complianceMetasV2,
+		MetaMapV2: complianceMetaMapV2,
+	}
+	imageBenchMetaConfig := &UpdateConfigParams{
+		Metas:   &imageBenchMetas,
+		MetaMap: imageBenchMetaMap,
+	}
+
+	go LoadConfig(primeCISConfig, complianceMetaConfig, true)
+	go LoadConfig(primeDockerConfig, complianceMetaConfig, true)
+	go LoadConfig(primeDockerImageConfig, complianceMetaConfig, true)
+	go LoadConfig(primeDockerImageConfig, imageBenchMetaConfig, false)
 }

--- a/share/scan/compliance.go
+++ b/share/scan/compliance.go
@@ -37,7 +37,7 @@ var (
 	imageBenchMetaMap         = make(map[string]api.RESTBenchMeta)
 	once                      sync.Once
 	backupCISItems            = make(map[string]api.RESTBenchCheck)
-	BackupDockerImageCISItems = make(map[string]api.RESTBenchCheck)
+	backupDockerImageCISItems = make(map[string]api.RESTBenchCheck)
 	cisVersion                string
 	remediationFolder         string
 	isUpdateImageBenchMetaMap = false
@@ -112,10 +112,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure only trusted users are allowed to control Docker daemon",
 		Remediation: "You should remove any untrusted users from the docker group using command sudo gpasswd -d <your-user> docker or add trusted users to the docker group using command sudo usermod -aG docker <your-user>. You should not create a mapping of sensitive directories from the host to container volumes.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.1.1.3": api.RESTBenchCheck{
@@ -127,9 +127,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for the Docker daemon",
 		Remediation: "Install auditd. Add -w /usr/bin/dockerd -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.1.1.4": api.RESTBenchCheck{
@@ -141,9 +141,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /run/containerd",
 		Remediation: "Install auditd. Add -a exit,always -F path=/run/containerd -F perm=war -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.1.1.5": api.RESTBenchCheck{
@@ -155,9 +155,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /var/lib/docker",
 		Remediation: "Install auditd. Add -w /var/lib/docker -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.1.1.6": api.RESTBenchCheck{
@@ -169,9 +169,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /etc/docker",
 		Remediation: "Install auditd. Add -w /etc/docker -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.1.1.7": api.RESTBenchCheck{
@@ -183,9 +183,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - docker.service",
 		Remediation: "Install auditd. Add -w $(get_service_file docker.service) -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.1.1.8": api.RESTBenchCheck{
@@ -197,9 +197,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - containerd.sock",
 		Remediation: "Install auditd. Add -w $(get_service_file containerd.socket) -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.1.1.9": api.RESTBenchCheck{
@@ -211,9 +211,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - docker.socket",
 		Remediation: "Install auditd. Add -w $(get_service_file docker.socket) -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.1.1.10": api.RESTBenchCheck{
@@ -225,9 +225,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /etc/default/docker",
 		Remediation: "Install auditd. Add -w /etc/default/docker -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.1.1.11": api.RESTBenchCheck{
@@ -239,9 +239,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Dockerfiles and directories - /etc/docker/daemon.json",
 		Remediation: "Install auditd. Add -w /etc/docker/daemon.json -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.1.1.12": api.RESTBenchCheck{
@@ -253,9 +253,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Dockerfiles and directories - /etc/containerd/config.toml",
 		Remediation: "Install auditd. Add -w /etc/containerd/config.toml -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.1.1.13": api.RESTBenchCheck{
@@ -267,9 +267,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /etc/sysconfig/docker",
 		Remediation: "Install auditd. Add -w /etc/sysconfig/docker -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.1.1.14": api.RESTBenchCheck{
@@ -281,9 +281,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /usr/bin/containerd",
 		Remediation: "Install auditd. Add -w /usr/bin/containerd -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.1.1.15": api.RESTBenchCheck{
@@ -295,9 +295,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /usr/bin/containerd-shim",
 		Remediation: "Install auditd. Add -w /usr/bin/containerd-shim -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.1.1.16": api.RESTBenchCheck{
@@ -309,9 +309,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /usr/bin/containerd-shim-runc-v1",
 		Remediation: "Install auditd. Add -w /usr/bin/containerd-shim-runc-v1 -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.1.1.17": api.RESTBenchCheck{
@@ -323,9 +323,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /usr/bin/containerd-shim-runc-v2",
 		Remediation: "Install auditd. Add -w /usr/bin/containerd-shim-runc-v2 -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.1.1.18": api.RESTBenchCheck{
@@ -337,9 +337,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure auditing is configured for Docker files and directories - /usr/bin/runc",
 		Remediation: "Install auditd. Add -w /usr/bin/runc -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.1.2.1": api.RESTBenchCheck{
@@ -411,9 +411,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure insecure registries are not used",
 		Remediation: "You should ensure that no insecure registries are in use.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"D.2.6": api.RESTBenchCheck{
@@ -435,10 +435,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure TLS authentication for Docker daemon is configured",
 		Remediation: "Follow the steps mentioned in the Docker documentation or other references. By default, TLS authentication is not configured.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.2.8": api.RESTBenchCheck{
@@ -510,9 +510,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure containers are restricted from acquiring new privileges",
 		Remediation: "You should run the Docker daemon using command: dockerd --no-new-privileges",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"D.2.15": api.RESTBenchCheck{
@@ -564,10 +564,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that docker.service file ownership is set to root:root",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.2": api.RESTBenchCheck{
@@ -579,10 +579,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that docker.service file permissions are appropriately set",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.3": api.RESTBenchCheck{
@@ -594,10 +594,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that docker.socket file ownership is set to root:root",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.4": api.RESTBenchCheck{
@@ -609,10 +609,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that docker.socket file permissions are set to 644 or more restrictive",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.5": api.RESTBenchCheck{
@@ -624,10 +624,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that /etc/docker directory ownership is set to root:root",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.6": api.RESTBenchCheck{
@@ -639,10 +639,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that /etc/docker directory permissions are set to 755 or more restrictive",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.7": api.RESTBenchCheck{
@@ -654,10 +654,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that registry certificate file ownership is set to root:root",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.8": api.RESTBenchCheck{
@@ -669,10 +669,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that registry certificate file permissions are set to 444 or more restrictive",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.9": api.RESTBenchCheck{
@@ -684,10 +684,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that TLS CA certificate file ownership is set to root:root",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.10": api.RESTBenchCheck{
@@ -699,10 +699,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that TLS CA certificate file permissions are set to 444 or more restrictive",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.11": api.RESTBenchCheck{
@@ -714,10 +714,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that Docker server certificate file ownership is set to root:root",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.12": api.RESTBenchCheck{
@@ -729,10 +729,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that Docker server certificate file permissions are set to 444 or more restrictive",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.13": api.RESTBenchCheck{
@@ -744,10 +744,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that Docker server certificate key file ownership is set to root:root",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.14": api.RESTBenchCheck{
@@ -759,10 +759,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that Docker server certificate key file permissions are set to 400",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.15": api.RESTBenchCheck{
@@ -774,10 +774,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that Docker socket file ownership is set to root:docker",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.16": api.RESTBenchCheck{
@@ -789,10 +789,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that Docker socket file permissions are set to 660 or more restrictive",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.17": api.RESTBenchCheck{
@@ -804,10 +804,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that daemon.json file ownership is set to root:root",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.18": api.RESTBenchCheck{
@@ -819,10 +819,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that daemon.json file permissions are set to 644 or more restrictive",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.19": api.RESTBenchCheck{
@@ -834,10 +834,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that /etc/default/docker file ownership is set to root:root",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.20": api.RESTBenchCheck{
@@ -849,10 +849,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the /etc/sysconfig/docker file ownership is set to root:root",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.21": api.RESTBenchCheck{
@@ -864,10 +864,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that /etc/sysconfig/docker file permissions are set to 644 or more restrictive",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.3.22": api.RESTBenchCheck{
@@ -879,10 +879,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that /etc/default/docker file permissions are set to 644 or more restrictive",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"D.4.1": api.RESTBenchCheck{
@@ -1064,9 +1064,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that privileged containers are not used",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"D.5.5": api.RESTBenchCheck{
@@ -1078,9 +1078,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure sensitive host system directories are not mounted on containers",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"D.5.6": api.RESTBenchCheck{
@@ -1092,9 +1092,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure sshd is not run within containers",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"D.5.7": api.RESTBenchCheck{
@@ -1106,9 +1106,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure privileged ports are not mapped within containers",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"D.5.8": api.RESTBenchCheck{
@@ -1130,9 +1130,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure the host's network namespace is not shared",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"D.5.10": api.RESTBenchCheck{
@@ -1164,9 +1164,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the container's root filesystem is mounted as read only",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"D.5.13": api.RESTBenchCheck{
@@ -1198,9 +1198,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure the host's process namespace is not shared",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"D.5.16": api.RESTBenchCheck{
@@ -1212,9 +1212,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure the host's IPC namespace is not shared",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"D.5.17": api.RESTBenchCheck{
@@ -1226,9 +1226,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that host devices are not directly exposed to containers",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"D.5.18": api.RESTBenchCheck{
@@ -1260,9 +1260,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure the host's UTS namespace is not shared",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"D.5.21": api.RESTBenchCheck{
@@ -1314,9 +1314,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the container is restricted from acquiring additional privileges",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"D.5.26": api.RESTBenchCheck{
@@ -1368,9 +1368,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the host's user namespaces are not shared",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"D.5.31": api.RESTBenchCheck{
@@ -1382,9 +1382,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the Docker socket is not mounted inside any containers",
 		Remediation: "",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"K.1.1.1": api.RESTBenchCheck{
@@ -1396,10 +1396,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod 644 /etc/kubernetes/manifests/kube-apiserver.yaml",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.2": api.RESTBenchCheck{
@@ -1411,10 +1411,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the API server pod specification file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown root:root /etc/kubernetes/manifests/kube-apiserver.yaml",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.3": api.RESTBenchCheck{
@@ -1426,10 +1426,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod 644 /etc/kubernetes/manifests/kube-controller-manager.yaml",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.4": api.RESTBenchCheck{
@@ -1441,10 +1441,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the controller manager pod specification file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown root:root /etc/kubernetes/manifests/kube-controller-manager.yaml",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.5": api.RESTBenchCheck{
@@ -1456,10 +1456,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod 644 /etc/kubernetes/manifests/kube-scheduler.yaml",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.6": api.RESTBenchCheck{
@@ -1471,10 +1471,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the scheduler pod specification file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown root:root /etc/kubernetes/manifests/kube-scheduler.yaml",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.7": api.RESTBenchCheck{
@@ -1486,10 +1486,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod 644 /etc/kubernetes/manifests/etcd.yaml",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.8": api.RESTBenchCheck{
@@ -1501,10 +1501,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the etcd pod specification file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown root:root /etc/kubernetes/manifests/etcd.yaml",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.9": api.RESTBenchCheck{
@@ -1516,10 +1516,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod 644 <path/to/cni/files>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.10": api.RESTBenchCheck{
@@ -1531,10 +1531,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the Container Network Interface file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown root:root <path/to/cni/files>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.11": api.RESTBenchCheck{
@@ -1546,10 +1546,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the etcd data directory permissions are set to 700 or more restrictive",
 		Remediation: "On the etcd server node, get the etcd data directory, passed as an argument --data-dir, from the below command: ps -ef | grep etcd Run the below command (based on the etcd data directory found above). For example, chmod 700 /var/lib/etcd",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.12": api.RESTBenchCheck{
@@ -1561,10 +1561,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the etcd data directory ownership is set to etcd:etcd",
 		Remediation: "On the etcd server node, get the etcd data directory, passed as an argument --data-dir, from the below command: ps -ef | grep etcd Run the below command (based on the etcd data directory found above). For example, chown etcd:etcd /var/lib/etcd",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.13": api.RESTBenchCheck{
@@ -1576,10 +1576,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admin.conf file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod 644 /etc/kubernetes/admin.conf",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.14": api.RESTBenchCheck{
@@ -1591,10 +1591,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admin.conf file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown root:root /etc/kubernetes/admin.conf",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.15": api.RESTBenchCheck{
@@ -1606,10 +1606,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod 644 /etc/kubernetes/scheduler.conf",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.16": api.RESTBenchCheck{
@@ -1621,10 +1621,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the scheduler.conf file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown root:root /etc/kubernetes/scheduler.conf",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.17": api.RESTBenchCheck{
@@ -1636,10 +1636,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod 644 /etc/kubernetes/controller-manager.conf",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.18": api.RESTBenchCheck{
@@ -1651,10 +1651,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the controller-manager.conf file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown root:root /etc/kubernetes/controller-manager.conf",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.19": api.RESTBenchCheck{
@@ -1666,10 +1666,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chown -R root:root /etc/kubernetes/pki/",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.20": api.RESTBenchCheck{
@@ -1681,10 +1681,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod -R 644 /etc/kubernetes/pki/*.crt",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.1.21": api.RESTBenchCheck{
@@ -1696,10 +1696,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the Kubernetes PKI key file permissions are set to 600",
 		Remediation: "Run the below command (based on the file location on your system) on the master node. For example, chmod -R 600 /etc/kubernetes/pki/*.key",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.1": api.RESTBenchCheck{
@@ -1711,10 +1711,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --anonymous-auth argument is set to false",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the below parameter. --anonymous-auth=false",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.2": api.RESTBenchCheck{
@@ -1726,10 +1726,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --basic-auth-file argument is not set",
 		Remediation: "Follow the documentation and configure alternate mechanisms for authentication. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and remove the --basic-auth-file=<filename> parameter.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.3": api.RESTBenchCheck{
@@ -1741,10 +1741,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --token-auth-file parameter is not set",
 		Remediation: "Follow the documentation and configure alternate mechanisms for authentication. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and remove the --token-auth-file=<filename> parameter.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.4": api.RESTBenchCheck{
@@ -1756,10 +1756,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --kubelet-https argument is set to true",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and remove the --kubelet-https parameter.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.5": api.RESTBenchCheck{
@@ -1771,10 +1771,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate",
 		Remediation: "Follow the Kubernetes documentation and set up the TLS connection between the apiserver and kubelets. Then, edit API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the kubelet client certificate and key parameters as below. --kubelet-client-certificate=<path/to/client-certificate-file> --kubelet-client-key=<path/to/client-key-file>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.6": api.RESTBenchCheck{
@@ -1786,10 +1786,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --kubelet-certificate-authority argument is set as appropriate",
 		Remediation: "Follow the Kubernetes documentation and setup the TLS connection between the apiserver and kubelets. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the -- kubelet-certificate-authority parameter to the path to the cert file for the certificate authority. --kubelet-certificate-authority=<ca-string>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.7": api.RESTBenchCheck{
@@ -1801,10 +1801,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --authorization-mode argument is not set to AlwaysAllow",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --authorization-mode parameter to values other than AlwaysAllow . One such example could be as below. --authorization-mode=RBAC",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.8": api.RESTBenchCheck{
@@ -1816,10 +1816,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --authorization-mode argument includes Node",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --authorization-mode parameter to a value that includes Node . --authorization-mode=Node,RBAC",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.9": api.RESTBenchCheck{
@@ -1831,10 +1831,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --authorization-mode argument includes RBAC",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --authorization-mode parameter to a value that includes RBAC, for example:--authorization-mode=Node,RBAC",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.10": api.RESTBenchCheck{
@@ -1846,9 +1846,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admission control plugin EventRateLimit is set",
 		Remediation: "Follow the Kubernetes documentation and set the desired limits in a configuration file. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml and set the below parameters.  --enable-admission-plugins=...,EventRateLimit,... --admission-control-config-file=<path/to/configuration/file>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"K.1.2.11": api.RESTBenchCheck{
@@ -1860,9 +1860,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admission control plugin AlwaysAdmit is not set",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and either remove the --enable-admission-plugins parameter, or set it to a value that does not include AlwaysAdmit.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"K.1.2.12": api.RESTBenchCheck{
@@ -1874,9 +1874,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admission control plugin AlwaysPullImages is set",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --enable-admission-plugins parameter to include AlwaysPullImages.  --enable-admission-plugins=...,AlwaysPullImages,...",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"K.1.2.13": api.RESTBenchCheck{
@@ -1888,9 +1888,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --enable-admission-plugins parameter to include SecurityContextDeny, unless PodSecurityPolicy is already in place.  --enable-admission-plugins=...,SecurityContextDeny,...",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"K.1.2.14": api.RESTBenchCheck{
@@ -1902,9 +1902,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admission control plugin ServiceAccount is set",
 		Remediation: "Follow the documentation and create ServiceAccount objects as per your environment. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and ensure that the --disable-admission-plugins parameter is set to a value that does not include ServiceAccount.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"K.1.2.15": api.RESTBenchCheck{
@@ -1916,9 +1916,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admission control plugin NamespaceLifecycle is set",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --disable-admission-plugins parameter to ensure it does not include NamespaceLifecycle.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"K.1.2.16": api.RESTBenchCheck{
@@ -1930,9 +1930,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admission control plugin PodSecurityPolicy is set",
 		Remediation: "Follow the documentation and create Pod Security Policy objects as per your environment. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --enable-admission-plugins parameter to a value that includes PodSecurityPolicy: --enable-admission-plugins=...,PodSecurityPolicy,... Then restart the API Server.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"K.1.2.17": api.RESTBenchCheck{
@@ -1944,9 +1944,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the admission control plugin NodeRestriction is set",
 		Remediation: "Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --enable-admission-plugins parameter to a value that includes NodeRestriction. --enable-admission-plugins=...,NodeRestriction,...",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
 		},
 	},
 	"K.1.2.18": api.RESTBenchCheck{
@@ -1958,10 +1958,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --insecure-bind-address argument is not set",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and remove the --insecure-bind-address parameter.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.19": api.RESTBenchCheck{
@@ -1973,10 +1973,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --insecure-port argument is set to 0",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the below parameter. --insecure-port=0",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.20": api.RESTBenchCheck{
@@ -1988,10 +1988,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --secure-port argument is not set to 0",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and either remove the --secure-port parameter or set it to a different (non-zero) desired port.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.21": api.RESTBenchCheck{
@@ -2013,9 +2013,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --audit-log-path argument is set",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --audit-log-path parameter to a suitable path and file where you would like audit logs to be written, for example: --audit-log-path=/var/log/apiserver/audit.log",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.23": api.RESTBenchCheck{
@@ -2027,9 +2027,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --audit-log-maxage parameter to 30 or as an appropriate number of days: --audit-log-maxage=30",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.24": api.RESTBenchCheck{
@@ -2041,9 +2041,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --audit-log-maxbackup parameter to 10 or to an appropriate value. --audit-log-maxbackup=10",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.25": api.RESTBenchCheck{
@@ -2055,9 +2055,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --audit-log-maxsize parameter to an appropriate size in MB. For example, to set it as 100 MB: --audit-log-maxsize=100",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.26": api.RESTBenchCheck{
@@ -2079,10 +2079,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --service-account-lookup argument is set to true",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the below parameter. --service-account-lookup=true",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.28": api.RESTBenchCheck{
@@ -2094,10 +2094,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --service-account-key-file argument is set as appropriate",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --service-account-key-file parameter to the public key file for service accounts: --service-account-key-file=<filename>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.29": api.RESTBenchCheck{
@@ -2109,10 +2109,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate",
 		Remediation: "Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the etcd certificate and key file parameters.  --etcd-certfile=<path/to/client-certificate-file> --etcd-keyfile=<path/to/client-key-file>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.30": api.RESTBenchCheck{
@@ -2124,10 +2124,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate",
 		Remediation: "Follow the Kubernetes documentation and set up the TLS connection on the apiserver. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the TLS certificate and private key file parameters. --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key-file=<path/to/tls-key-file>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.31": api.RESTBenchCheck{
@@ -2139,10 +2139,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --client-ca-file argument is set as appropriate",
 		Remediation: "Follow the Kubernetes documentation and set up the TLS connection on the apiserver. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the client certificate authority file. --client-ca-file=<path/to/client-ca-file>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.32": api.RESTBenchCheck{
@@ -2154,10 +2154,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --etcd-cafile argument is set as appropriate",
 		Remediation: "Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the etcd certificate authority file parameter. --etcd-cafile=<path/to/ca-file>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.33": api.RESTBenchCheck{
@@ -2169,10 +2169,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --encryption-provider-config argument is set as appropriate",
 		Remediation: "Follow the Kubernetes documentation and configure a EncryptionConfig file. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the --encryption-provider-config parameter to the path of that file: --encryption-provider-config=</path/to/EncryptionConfig/File>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.34": api.RESTBenchCheck{
@@ -2184,10 +2184,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that encryption providers are appropriately configured",
 		Remediation: "Follow the Kubernetes documentation and configure a EncryptionConfig file. In this file, choose aescbc, kms or secretbox as the encryption provider.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.2.35": api.RESTBenchCheck{
@@ -2199,10 +2199,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers",
 		Remediation: "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set the below parameter as follows, or to a subset of these values. --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM _SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM _SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM _SHA384",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.3.1": api.RESTBenchCheck{
@@ -2234,10 +2234,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --use-service-account-credentials argument is set to true",
 		Remediation: "Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml on the master node to set the below parameter. --use-service-account-credentials=true",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.3.4": api.RESTBenchCheck{
@@ -2249,10 +2249,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --service-account-private-key-file argument is set as appropriate",
 		Remediation: "Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml on the master node and set the --service-account-private- key-file parameter to the private key file for service accounts. --service-account-private-key-file=<filename>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.3.5": api.RESTBenchCheck{
@@ -2264,10 +2264,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --root-ca-file argument is set as appropriate",
 		Remediation: "Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml on the master node and set the --root-ca-file parameter to the certificate bundle file`. --root-ca-file=<path/to/file>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.3.6": api.RESTBenchCheck{
@@ -2279,10 +2279,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the RotateKubeletServerCertificate argument is set to true",
 		Remediation: "Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml on the master node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true. --feature-gates=RotateKubeletServerCertificate=true",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.1.3.7": api.RESTBenchCheck{
@@ -2324,10 +2324,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --cert-file and --key-file arguments are set as appropriate",
 		Remediation: "Follow the etcd service documentation and configure TLS encryption. Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and set the below parameters.  --cert-file=</path/to/ca-file> --key-file=</path/to/key-file>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.2.2": api.RESTBenchCheck{
@@ -2339,10 +2339,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --client-cert-auth argument is set to true",
 		Remediation: "Edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and set the below parameter. --client-cert-auth=\"true\"",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.2.3": api.RESTBenchCheck{
@@ -2354,10 +2354,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --auto-tls argument is not set to true",
 		Remediation: "Edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and either remove the --auto-tls parameter or set it to false. --auto-tls=false",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.2.4": api.RESTBenchCheck{
@@ -2369,10 +2369,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate",
 		Remediation: "Follow the etcd service documentation and configure peer TLS encryption as appropriate for your etcd cluster. Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and set the below parameters.  --peer-cert-file=</path/to/peer-cert-file> --peer-key-file=</path/to/peer-key-file>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.2.5": api.RESTBenchCheck{
@@ -2384,10 +2384,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --peer-client-cert-auth argument is set to true",
 		Remediation: "Edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and set the below parameter. --peer-client-cert-auth=true",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.2.6": api.RESTBenchCheck{
@@ -2399,10 +2399,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --peer-auto-tls argument is not set to true",
 		Remediation: "Edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and either remove the --peer-auto-tls parameter or set it to false. --peer-auto-tls=false",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.2.7": api.RESTBenchCheck{
@@ -2414,10 +2414,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that a unique Certificate Authority is used for etcd",
 		Remediation: "Follow the etcd documentation and create a dedicated certificate authority setup for the etcd service. Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and set the below parameter. --trusted-ca-file=</path/to/ca-file>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.3.1.1": api.RESTBenchCheck{
@@ -2439,9 +2439,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that a minimal audit policy is created",
 		Remediation: "Create an audit policy file for your cluster.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.3.2.2": api.RESTBenchCheck{
@@ -2453,9 +2453,9 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the audit policy covers key security concerns",
 		Remediation: "Consider modification of the audit policy in use on the cluster to include these items, at a minimum.",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.1.1": api.RESTBenchCheck{
@@ -2467,10 +2467,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the kubelet service file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the each worker node. For example, chmod 644 /etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.1.2": api.RESTBenchCheck{
@@ -2482,10 +2482,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the kubelet service file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the each worker node. For example, chown root:root /etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.1.3": api.RESTBenchCheck{
@@ -2497,10 +2497,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the proxy kubeconfig file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the each worker node. For example, chmod 644 <proxy kubeconfig file",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.1.4": api.RESTBenchCheck{
@@ -2512,10 +2512,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the proxy kubeconfig file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the each worker node. For example, chown root:root <proxy kubeconfig file>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.1.5": api.RESTBenchCheck{
@@ -2527,10 +2527,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the kubelet.conf file permissions are set to 644 or more restrictive",
 		Remediation: "Run the below command (based on the file location on your system) on the each worker node. For example, chmod 644 /etc/kubernetes/kubelet.conf",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.1.6": api.RESTBenchCheck{
@@ -2542,10 +2542,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the kubelet.conf file ownership is set to root:root",
 		Remediation: "Run the below command (based on the file location on your system) on the each worker node. For example, chown root:root /etc/kubernetes/kubelet.conf",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.1.7": api.RESTBenchCheck{
@@ -2557,10 +2557,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive",
 		Remediation: "Run the following command to modify the file permissions of the --client-ca-file chmod 644 <filename>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.1.8": api.RESTBenchCheck{
@@ -2572,10 +2572,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the client certificate authorities file ownership is set to root:root",
 		Remediation: "Run the following command to modify the ownership of the --client-ca-file. chown root:root <filename>",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.1.9": api.RESTBenchCheck{
@@ -2587,10 +2587,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the kubelet configuration file has permissions set to 644 or more restrictive",
 		Remediation: "Run the following command (using the config file location identied in the Audit step) chmod 644 /var/lib/kubelet/config.yaml",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.1.10": api.RESTBenchCheck{
@@ -2602,10 +2602,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the kubelet configuration file ownership is set to root:root",
 		Remediation: "Run the following command (using the config file location identied in the Audit step) chown root:root /etc/kubernetes/kubelet.conf",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.2.1": api.RESTBenchCheck{
@@ -2617,10 +2617,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the anonymous-auth argument is set to false",
 		Remediation: "If using a Kubelet config file, edit the file to set authentication: anonymous: enabled to false. If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable. --anonymous-auth=false Based on your system, restart the kubelet service. For example:  systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.2.2": api.RESTBenchCheck{
@@ -2632,10 +2632,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the --authorization-mode argument is not set to AlwaysAllow",
 		Remediation: "If using a Kubelet config file, edit the file to set authorization: mode to Webhook. If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable. --authorization-mode=Webhook Based on your system, restart the kubelet service. For example:  systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.2.3": api.RESTBenchCheck{
@@ -2647,10 +2647,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the --client-ca-file argument is set as appropriate",
 		Remediation: "If using a Kubelet config file, edit the file to set authentication: x509: clientCAFile to the location of the client CA file. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable. --client-ca-file=<path/to/client-ca-file> Based on your system, restart the kubelet service. For example:  systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.2.4": api.RESTBenchCheck{
@@ -2662,10 +2662,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the --read-only-port argument is set to 0",
 		Remediation: "If using a Kubelet config file, edit the file to set readOnlyPort to 0. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable. --read-only-port=0 Based on your system, restart the kubelet service. For example:  systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.2.5": api.RESTBenchCheck{
@@ -2687,10 +2687,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --protect-kernel-defaults argument is set to true",
 		Remediation: "If using a Kubelet config file, edit the file to set protectKernelDefaults: true. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable. --protect-kernel-defaults=true Based on your system, restart the kubelet service. For example:  systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.2.7": api.RESTBenchCheck{
@@ -2732,10 +2732,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   true,
 		Description: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate",
 		Remediation: "If using a Kubelet config file, edit the file to set tlsCertFile to the location of the certificate file to use to identify this Kubelet, and tlsPrivateKeyFile to the location of the corresponding private key file. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameters in KUBELET_CERTIFICATE_ARGS variable.  --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key- file=<path/to/tls-key-file> Based on your system, restart the kubelet service. For example:  systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.2.11": api.RESTBenchCheck{
@@ -2747,10 +2747,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the --rotate-certificates argument is not set to false",
 		Remediation: "If using a Kubelet config file, edit the file to add the line rotateCertificates: true or remove it altogether to use the default value. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS variable. Based on your system, restart the kubelet service. For example: systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.2.12": api.RESTBenchCheck{
@@ -2762,10 +2762,10 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the RotateKubeletServerCertificate argument is set to true",
 		Remediation: "On the master edit /var/lib/kubelet/kubeadm-flags.env and set the parameter KUBELET_CERTIFICATE_ARGS --feature-gates=RotateKubeletServerCertificate=true or as an alternative, and suggested as a last resort, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable. --feature-gates=RotateKubeletServerCertificate=true Based on your system, restart the kubelet service. For example:  systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 	"K.4.2.13": api.RESTBenchCheck{
@@ -2777,24 +2777,24 @@ var cisItems = map[string]api.RESTBenchCheck{
 		Automated:   false,
 		Description: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers",
 		Remediation: "If using a Kubelet config file, edit the file to set TLSCipherSuites: to TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256 or to a subset of these values. If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the --tls-cipher-suites parameter as follows, or to a subset of these values. --tls-cipher- suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM _SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM _SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM _SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256 Based on your system, restart the kubelet service. For example:  systemctl daemon-reload systemctl restart kubelet.service",
-		Tags: []map[string][]api.TagDetail{
-			{"HIPAA": []api.TagDetail{}},
-			{"PCI": []api.TagDetail{}},
-			{"GDPR": []api.TagDetail{}},
+		Tags: map[string]share.TagDetails{
+			"HIPAA": share.TagDetails{},
+			"PCI":   share.TagDetails{},
+			"GDPR":  share.TagDetails{},
 		},
 	},
 }
 
 type CISCheck struct {
-	ID          string                       `yaml:"id"`
-	Description string                       `yaml:"description"`
-	Type        string                       `yaml:"type"`
-	Category    string                       `yaml:"category"`
-	Scored      bool                         `yaml:"scored"`
-	Profile     string                       `yaml:"profile"`
-	Automated   bool                         `yaml:"automated"`
-	Tags        []map[string][]api.TagDetail `yaml:"tags,omitempty"`
-	Remediation string                       `yaml:"remediation"`
+	ID          string                      `yaml:"id"`
+	Description string                      `yaml:"description"`
+	Type        string                      `yaml:"type"`
+	Category    string                      `yaml:"category"`
+	Scored      bool                        `yaml:"scored"`
+	Profile     string                      `yaml:"profile"`
+	Automated   bool                        `yaml:"automated"`
+	Tags        map[string]share.TagDetails `yaml:"tags,omitempty"`
+	Remediation string                      `yaml:"remediation"`
 }
 
 type Group struct {
@@ -2806,8 +2806,8 @@ type CISBenchmarkConfig struct {
 }
 
 type CISCheckWithTags struct {
-	ID   string                       `yaml:"id"`
-	Tags []map[string][]api.TagDetail `yaml:"tags,omitempty"`
+	ID   string                      `yaml:"id"`
+	Tags map[string]share.TagDetails `yaml:"tags,omitempty"`
 }
 
 type PrimeCISBenchmarkConfig struct {
@@ -2898,7 +2898,7 @@ func PrepareBackup() {
 	}
 
 	for key, value := range dockerImageCISItems {
-		BackupDockerImageCISItems[key] = DeepCopyRESTBenchCheck(value)
+		backupDockerImageCISItems[key] = DeepCopyRESTBenchCheck(value)
 	}
 }
 
@@ -2912,23 +2912,26 @@ func DeepCopyRESTBenchCheck(orig api.RESTBenchCheck) api.RESTBenchCheck {
 		Automated:   orig.Automated,
 		Description: orig.Description,
 		Remediation: orig.Remediation,
+		Tags:        nil,
 	}
 
-	// Deep copy the Tags slice
+	// Deep copy the Tags map
 	if orig.Tags != nil {
-		copy.Tags = make([]map[string][]api.TagDetail, len(orig.Tags))
-		for i, tagMap := range orig.Tags {
-			copy.Tags[i] = make(map[string][]api.TagDetail)
-			for key, details := range tagMap {
-				copiedDetails := make([]api.TagDetail, len(details))
-				for j, detail := range details {
-					// Assuming TagDetail has more complex fields, deeply copy each one
-					copiedDetails[j] = api.TagDetail{ID: detail.ID, Title: detail.Title, Description: detail.Description}
+		copy.Tags = make(map[string]share.TagDetails)
+		for compliance, detailsMap := range orig.Tags {
+			copiedDetailsMap := make(share.TagDetails)
+			for key, detail := range detailsMap {
+				copiedDetailsMap[key] = share.TagDetail{
+					ID:              detail.ID,
+					Title:           detail.Title,
+					Description:     detail.Description,
+					CIS_Sub_Control: detail.CIS_Sub_Control,
 				}
-				copy.Tags[i][key] = copiedDetails
 			}
+			copy.Tags[compliance] = copiedDetailsMap
 		}
 	}
+
 	return copy
 }
 
@@ -3031,7 +3034,7 @@ func GetK8sCISMeta(remediationFolder string, cis_bench_items map[string]api.REST
 	// if Failed at walk, stay with original value
 	if err != nil {
 		cisItems = backupCISItems
-		dockerImageCISItems = BackupDockerImageCISItems
+		dockerImageCISItems = backupDockerImageCISItems
 	}
 }
 
@@ -3056,14 +3059,21 @@ func updateWithPrimeConfig(primeConfig string, metaMap map[string]api.RESTBenchM
 	}
 
 	for _, check := range primeCISBenchmarkConfig.CISChecksWithTags {
-		for _, tag := range check.Tags {
-			if checkItem, exists := metaMap[check.ID]; exists {
-				checkItem.Tags = append(checkItem.Tags, tag)
-				metaMap[check.ID] = checkItem
-			} else {
-				log.WithFields(log.Fields{"check.Id": check.ID}).Info("check.ID is not in metaMap: ")
-				break
+		if metaData, exists := metaMap[check.ID]; exists {
+			primeMetaData := metaData
+
+			if primeMetaData.Tags == nil {
+				primeMetaData.Tags = make(map[string]share.TagDetails)
 			}
+
+			for compliance, complianceDetails := range check.Tags {
+				primeMetaData.Tags[compliance] = complianceDetails
+			}
+
+			metaMap[check.ID] = primeMetaData
+		} else {
+			log.WithFields(log.Fields{"check.Id": check.ID}).Info("check.ID is not in metaMap: ")
+			break
 		}
 	}
 	*updateFlag = true

--- a/share/scan/compliance_test.go
+++ b/share/scan/compliance_test.go
@@ -1,7 +1,6 @@
 package scan
 
 import (
-	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -108,10 +107,8 @@ func TestTagConsistance(t *testing.T) {
 		mockTagCount := make(map[string]int)
 		cisItemTagCount := make(map[string]int)
 
-		for _, tags := range cisItems[id].Tags {
-			for tag, _ := range tags {
-				cisItemTagCount[tag]++
-			}
+		for tag, _ := range cisItems[id].Tags {
+			cisItemTagCount[tag]++
 		}
 
 		for _, tag := range value.Tags {
@@ -146,7 +143,7 @@ func TestGetComplianceMeta(t *testing.T) {
 	mockMetas, mockMetaMap := getMetaMapForTest(remediationFolder, mockCISItems, mockComplianceMetas, mockComplianceMetaMap, &isUpdateMockComplianceMetaMap)
 
 	if diff := cmp.Diff(mockMetas, metas); diff != "" {
-		t.Errorf("mockMetas metas (-want +got):\n%s", diff)
+		t.Errorf("mockMetas mismatch (-want +got):\n%s", diff)
 	}
 
 	if diff := cmp.Diff(mockMetaMap, metaMap); diff != "" {
@@ -206,7 +203,6 @@ func TestLoadCreateEmpty(t *testing.T) {
 	go func() {
 		LoadConfig(primeConfig, mockLoadMetaMap, &isUpdateMockLoadMetaMap)
 		close(done)
-		fmt.Println("stop the channel")
 	}()
 
 	// Give some time for fsnotify to start watching
@@ -251,7 +247,6 @@ func TestLoadCreateExisting(t *testing.T) {
 	go func() {
 		LoadConfig(primeConfig, mockLoadMetaMap, &isUpdateMockLoadMetaMap)
 		close(done)
-		fmt.Println("XXX done", mockLoadMetaMap)
 	}()
 
 	// Give some time for fsnotify to start watching
@@ -266,17 +261,14 @@ func TestLoadCreateExisting(t *testing.T) {
 
 	<-done
 	getMetaMapForLoadTest(&mockLoadMetas, mockLoadMetaMap, &isUpdateMockLoadMetaMap)
-	fmt.Println("XXX getMetaMapForLoadTest", mockLoadMetaMap)
 
 	// Iterate over the slice of Meta structs
 	for _, meta := range mockLoadMetas {
 		// Check if the current meta ID is one we're interested in
 		if _, ok := expectedTags[meta.TestNum]; ok {
-			for _, tag := range meta.Tags {
-				for compliance, _ := range tag {
-					if _, found := expectedTags[meta.TestNum][compliance]; !found {
-						t.Errorf("Expected compliance %s not found for TestNum %s", compliance, meta.TestNum)
-					}
+			for compliance, _ := range meta.Tags {
+				if _, found := expectedTags[meta.TestNum][compliance]; !found {
+					t.Errorf("Expected compliance %s not found for TestNum %s", compliance, meta.TestNum)
 				}
 			}
 		} else {
@@ -287,11 +279,9 @@ func TestLoadCreateExisting(t *testing.T) {
 	for _, meta := range mockLoadMetaMap {
 		// Check if the current meta ID is one we're interested in
 		if _, ok := expectedTags[meta.TestNum]; ok {
-			for _, tag := range meta.Tags {
-				for compliance, _ := range tag {
-					if _, found := expectedTags[meta.TestNum][compliance]; !found {
-						t.Errorf("Expected compliance %s not found for TestNum %s", compliance, meta.TestNum)
-					}
+			for compliance, _ := range meta.Tags {
+				if _, found := expectedTags[meta.TestNum][compliance]; !found {
+					t.Errorf("Expected compliance %s not found for TestNum %s", compliance, meta.TestNum)
 				}
 			}
 		} else {

--- a/share/scan/scan_report.go
+++ b/share/scan/scan_report.go
@@ -258,20 +258,13 @@ func ImageBench2REST(cmds []string, secrets []*share.ScanSecretLog, setids []*sh
 	}
 
 	// add tags to every checks
-	for i := range checks {
-		item := checks[i]
-
+	for _, item := range checks {
 		if tagMap == nil {
-			item.Tags = map[string]share.TagDetails{}
-		} else if tags, ok := tagMap[item.TestNum]; ok {
-			item.Tags = map[string]share.TagDetails{}
-
-			for _, tag := range tags {
-				item.Tags[tag] = share.TagDetails{}
-			}
-
+			item.Tags = make([]string, 0)
+		} else if tags, ok := tagMap[item.TestNum]; !ok {
+			item.Tags = make([]string, 0)
 		} else {
-			item.Tags = map[string]share.TagDetails{}
+			item.Tags = tags
 		}
 	}
 

--- a/share/scan/scan_report.go
+++ b/share/scan/scan_report.go
@@ -262,17 +262,16 @@ func ImageBench2REST(cmds []string, secrets []*share.ScanSecretLog, setids []*sh
 		item := checks[i]
 
 		if tagMap == nil {
-			item.Tags = make([]map[string][]api.TagDetail, 0)
+			item.Tags = map[string]share.TagDetails{}
 		} else if tags, ok := tagMap[item.TestNum]; ok {
-			item.Tags = make([]map[string][]api.TagDetail, 0, len(tags))
+			item.Tags = map[string]share.TagDetails{}
 
 			for _, tag := range tags {
-				tagMap := map[string][]api.TagDetail{tag: []api.TagDetail{}}
-				item.Tags = append(item.Tags, tagMap)
+				item.Tags[tag] = share.TagDetails{}
 			}
 
 		} else {
-			item.Tags = make([]map[string][]api.TagDetail, 0)
+			item.Tags = map[string]share.TagDetails{}
 		}
 	}
 

--- a/share/scan/testdata/mock-cis/master/1_control_plane_components.yaml
+++ b/share/scan/testdata/mock-cis/master/1_control_plane_components.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
@@ -44,9 +44,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -70,9 +70,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
@@ -99,9 +99,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -125,9 +125,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
@@ -154,9 +154,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -180,9 +180,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
@@ -209,9 +209,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -235,9 +235,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -278,9 +278,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list

--- a/share/scan/testdata/mock-cis/master/1_control_plane_components.yaml
+++ b/share/scan/testdata/mock-cis/master/1_control_plane_components.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
@@ -44,9 +44,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -70,9 +70,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
@@ -99,9 +99,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -125,9 +125,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
@@ -154,9 +154,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -180,9 +180,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
@@ -209,9 +209,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -235,9 +235,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list
@@ -278,9 +278,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           # Initialize counters and non-compliant files list

--- a/share/scan/testdata/mock-cis/master/2_etcd.yaml
+++ b/share/scan/testdata/mock-cis/master/2_etcd.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
@@ -50,9 +50,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--client-cert-auth' >/dev/null 2>&1; then
@@ -73,9 +73,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--auto-tls=true' >/dev/null 2>&1; then
@@ -98,9 +98,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
@@ -135,9 +135,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-client-cert-auth=true' >/dev/null 2>&1; then
@@ -158,9 +158,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-auto-tls=true' >/dev/null 2>&1; then
@@ -182,9 +182,9 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--trusted-ca-file' >/dev/null 2>&1; then

--- a/share/scan/testdata/mock-cis/master/2_etcd.yaml
+++ b/share/scan/testdata/mock-cis/master/2_etcd.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--cert-file' >/dev/null 2>&1; then
@@ -50,9 +50,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--client-cert-auth' >/dev/null 2>&1; then
@@ -73,9 +73,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--auto-tls=true' >/dev/null 2>&1; then
@@ -98,9 +98,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-cert-file' >/dev/null 2>&1; then
@@ -135,9 +135,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-client-cert-auth=true' >/dev/null 2>&1; then
@@ -158,9 +158,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--peer-auto-tls=true' >/dev/null 2>&1; then
@@ -182,9 +182,9 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_ETCD_CMD" '--trusted-ca-file' >/dev/null 2>&1; then

--- a/share/scan/testdata/mock-cis/master/3_control_plane_configuration.yaml
+++ b/share/scan/testdata/mock-cis/master/3_control_plane_configuration.yaml
@@ -14,7 +14,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -29,7 +29,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -43,7 +43,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"
@@ -61,8 +61,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-policy-file' >/dev/null 2>&1; then
@@ -82,8 +82,8 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          - HIPAA: []
-          - GDPR: []
+          HIPAA: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/share/scan/testdata/mock-cis/master/3_control_plane_configuration.yaml
+++ b/share/scan/testdata/mock-cis/master/3_control_plane_configuration.yaml
@@ -61,8 +61,8 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--audit-policy-file' >/dev/null 2>&1; then
@@ -82,8 +82,8 @@ groups:
         profile: Level 2
         automated: false
         tags:
-          HIPAA: {}
-          GDPR: {}
+          HIPAA: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/share/scan/testdata/mock-cis/worker/4_worker_nodes.yaml
+++ b/share/scan/testdata/mock-cis/worker/4_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           kubeadm=$(append_prefix "$CONFIG_PREFIX" "/etc/systemd/system/kubelet.service.d/kubeadm.conf")
@@ -51,9 +51,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -77,9 +77,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -109,9 +109,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"           
           if [ -f "$file" ]; then
@@ -137,9 +137,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file=""
@@ -170,9 +170,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -196,9 +196,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -226,9 +226,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -256,9 +256,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -286,9 +286,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -318,9 +318,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -344,9 +344,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
@@ -370,9 +370,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -398,9 +398,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
@@ -525,9 +525,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -561,9 +561,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--rotate-certificates=false' >/dev/null 2>&1; then
@@ -586,9 +586,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
@@ -614,9 +614,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          HIPAA: {}
-          PCI: {}
-          GDPR: {}
+          HIPAA: []
+          PCI: []
+          GDPR: []
         audit: |
           check="$id  - $description"
           success=1

--- a/share/scan/testdata/mock-cis/worker/4_worker_nodes.yaml
+++ b/share/scan/testdata/mock-cis/worker/4_worker_nodes.yaml
@@ -15,9 +15,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           kubeadm=$(append_prefix "$CONFIG_PREFIX" "/etc/systemd/system/kubelet.service.d/kubeadm.conf")
@@ -51,9 +51,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -77,9 +77,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -109,9 +109,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"           
           if [ -f "$file" ]; then
@@ -137,9 +137,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file=""
@@ -170,9 +170,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if [ -f "$file" ]; then
@@ -196,9 +196,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -226,9 +226,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -256,9 +256,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -286,9 +286,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
@@ -318,9 +318,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
@@ -344,9 +344,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
@@ -370,9 +370,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
@@ -398,9 +398,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
@@ -429,7 +429,7 @@ groups:
         scored: true
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--streaming-connection-idle-timeout=0' >/dev/null 2>&1; then
@@ -454,7 +454,7 @@ groups:
         scored: true
         profile: Level 1
         automated: true
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--make-iptables-util-chains=true' >/dev/null 2>&1; then
@@ -475,7 +475,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--hostname-override' >/dev/null 2>&1; then
@@ -495,7 +495,7 @@ groups:
         scored: false
         profile: Level 2
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--event-qps' >/dev/null 2>&1; then
@@ -525,9 +525,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
@@ -561,9 +561,9 @@ groups:
         profile: Level 1
         automated: true
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--rotate-certificates=false' >/dev/null 2>&1; then
@@ -586,9 +586,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
@@ -614,9 +614,9 @@ groups:
         profile: Level 1
         automated: false
         tags:
-          - HIPAA: []
-          - PCI: []
-          - GDPR: []
+          HIPAA: {}
+          PCI: {}
+          GDPR: {}
         audit: |
           check="$id  - $description"
           success=1
@@ -664,7 +664,7 @@ groups:
         scored: false
         profile: Level 1
         automated: false
-        tags: []
+        tags: {}
         audit: |
           check="$id  - $description"
           manual "$check"

--- a/share/scan/testdata/mock-prime-config.yaml
+++ b/share/scan/testdata/mock-prime-config.yaml
@@ -1,9 +1,9 @@
 checks:
 - id: I.4.1
   tags: 
-    Mock3: {}
+    Mock3: []
 - id: I.4.6
   tags:
-    Mock1: {}
-    Mock2: {}
-    Mock4: {}
+    Mock1: []
+    Mock2: []
+    Mock4: []

--- a/share/scan/testdata/mock-prime-config.yaml
+++ b/share/scan/testdata/mock-prime-config.yaml
@@ -1,9 +1,9 @@
 checks:
 - id: I.4.1
   tags: 
-    - Mock3: []
+    Mock3: {}
 - id: I.4.6
   tags:
-  - Mock1: []
-  - Mock2: []
-  - Mock4: []
+    Mock1: {}
+    Mock2: {}
+    Mock4: {}


### PR DESCRIPTION
## Purpose

- Fix compliance profile related api
- Fix backward compatible issues
- Support r.GET("/v1/compliance/available_filter", handlerGetAvaiableComplianceFilter), help FE get the available filters, e.g.
```shell
{
  "available_filter": [
    "HIPAA",
    "GDPR",
    "PCI",
....
  ]
}
```
- Add TagV2 for only support r.GET("/v1/compliance/asset", handlerAssetCompliance) 

## Changes 

- TagV2 for internal api r.GET("/v1/compliance/asset", handlerAssetCompliance) 

```shel
                "tags": 
                    "HIPAA": [
                        {
                            "CIS_Sub_Control": "",
                            "description": "cccc.",
                            "id": "fff",
                            "title": "ddd"
                        },
                    ],
                "test_number": "D.1.1.10",
                "type": "host"
            },...}
```

- other maintain, for backward compatible

```shell
        {
            "automated": false,
            "category": "kubernetes",
            "description": "xxxx",
            "level": "PASS",
            "message": [],
            "profile": "Level 1",
            "remediation": xxxx",
            "scored": false,
            "tags": [
                "HIPAA",
                "PCI",
                "GDPR"
            ],
            "test_number": "xxxx",
            "type": "master"
        },
```
## Tests performed

1. Rolling update from the pre 5.4 version, make sure it's able to update seamlessly.
2. Other pages mantain the same functionality, beside the compliance page