### PR TITLE
feat: NVSHAS-7518 helm review comments

### DIFF
--- a/upgrader/main.go
+++ b/upgrader/main.go
@@ -159,6 +159,12 @@ func main() {
 					Usage:   "Whether it's a fresh install.  When in fresh install mode, upgrader will create certs and bypass the rolling update flow.",
 					EnvVars: []string{"FRESH_INSTALL"},
 				},
+				&cli.BoolFlag{
+					Name:    "disable-rotation",
+					Value:   false,
+					Usage:   "When this is specified, this program will skip the whole logic to rotate certificate.",
+					EnvVars: []string{"DISABLE_ROTATION"},
+				},
 			},
 			Action: PostSyncHook,
 		},

--- a/upgrader/main.go
+++ b/upgrader/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -10,7 +11,9 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/urfave/cli/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -67,12 +70,22 @@ func NewK8sClient(kubeconfig string) (dynamic.Interface, error) {
 	return dynamic.NewForConfig(config)
 }
 
-func CreateLocker(namespace string, lockName string) (*k8slock.Locker, error) {
+func CreateLocker(client dynamic.Interface, namespace string, lockName string) (*k8slock.Locker, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		log.Info("failed to get hostname: %w", err)
 	}
 	hostname += "_" + uuid.New().String()
+
+	if _, err := client.Resource(
+		schema.GroupVersionResource{
+			Resource: "leases",
+			Version:  "v1",
+			Group:    "coordination.k8s.io",
+		},
+	).Namespace(namespace).Get(context.TODO(), lockName, metav1.GetOptions{}); err != nil {
+		return nil, fmt.Errorf("failed to find lease object: %w", err)
+	}
 
 	return k8slock.NewLocker(
 		lockName,

--- a/upgrader/postsync.go
+++ b/upgrader/postsync.go
@@ -748,23 +748,23 @@ func PostSyncHook(ctx *cli.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx.Context, timeout)
 	defer cancel()
 
-	log.Info("Initializing lock")
-
-	// Make sure only one cert-upgrader will be running at the same time.
-	lock, err := CreateLocker(namespace, UPGRADER_LEASE_NAME)
-	if err != nil {
-		log.Fatal("failed to acquire cluster-wide lock: %w", err)
-	}
-
-	lock.Lock()
-	defer lock.Unlock()
-
 	log.Info("Creating k8s client")
 
 	client, err := NewK8sClient(kubeconfig)
 	if err != nil {
 		return fmt.Errorf("failed to create k8s client: %w", err)
 	}
+
+	log.Info("Initializing lock")
+
+	// Make sure only one cert-upgrader will be running at the same time.
+	lock, err := CreateLocker(client, namespace, UPGRADER_LEASE_NAME)
+	if err != nil {
+		log.Fatal("failed to acquire cluster-wide lock: %w", err)
+	}
+
+	lock.Lock()
+	defer lock.Unlock()
 
 	// Start watcher, so when `neuvector-internal-certs` secret is deleted, cert-upgrader will stop
 	watcher, err := client.Resource(schema.GroupVersionResource{

--- a/upgrader/postsync.go
+++ b/upgrader/postsync.go
@@ -743,6 +743,7 @@ func PostSyncHook(ctx *cli.Context) error {
 	renewThreshold := ctx.Duration("expiry-cert-threshold")
 	timeout := ctx.Duration("timeout")
 	waitDeploymentTimeout := ctx.Duration("rollout-timeout")
+	disableRotation := ctx.Bool("disable-rotation")
 
 	timeoutCtx, cancel := context.WithTimeout(ctx.Context, timeout)
 	defer cancel()
@@ -846,6 +847,11 @@ func PostSyncHook(ctx *cli.Context) error {
 	if noInitialSecret && retSecret != nil && freshInstall {
 		log.Info("This is fresh install.  Everything is done.")
 		// Everything is good now.  Exit.
+		return nil
+	}
+
+	if disableRotation {
+		log.Info("Rotation is disabled. Finishing.")
 		return nil
 	}
 

--- a/upgrader/presync.go
+++ b/upgrader/presync.go
@@ -150,7 +150,7 @@ func GetCronJobDetail(ctx context.Context, client dynamic.Interface, namespace s
 func CreatePostSyncJob(ctx context.Context, client dynamic.Interface, namespace string, certUpgraderUID string, withLock bool) (*batchv1.Job, error) {
 	// Global cluster-level lock with 5 mins TTL
 	if withLock {
-		lock, err := CreateLocker(namespace, CONTROLLER_LEASE_NAME)
+		lock, err := CreateLocker(client, namespace, CONTROLLER_LEASE_NAME)
 		if err != nil {
 			return nil, fmt.Errorf("failed to acquire cluster-wide lock: %w", err)
 		}


### PR DESCRIPTION
1. Allow disabling rotation via an environment variable.
2. Read namespace from /var/run/secrets/kubernetes.io/serviceaccount/namespace.  The original environment variable will take precedence if it exists. 