### PR TITLE
feat: NVSHAS-7518 internal cert rotation

### DIFF
--- a/share/migration/migration_informer.go
+++ b/share/migration/migration_informer.go
@@ -310,9 +310,21 @@ func InitializeInternalSecretController(ctx context.Context, reloadFuncs []func(
 		return fmt.Errorf("failed to get k8s config: %w", err)
 	}
 
-	factory := informers.NewSharedInformerFactoryWithOptions(clientset, time.Hour*24, informers.WithNamespace(os.Getenv("POD_NAMESPACE")))
+	var namespace string
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		namespace = string(data)
+	} else {
+		log.WithError(err).Warn("failed to open namespace file.")
+	}
 
-	controller, err := NewInternalSecretController(factory, os.Getenv("POD_NAMESPACE"), "neuvector-internal-certs", reloadFuncs)
+	// Allow overriding via POD_NAMESPACE variable for testing
+	if nsenv := os.Getenv("POD_NAMESPACE"); nsenv != "" {
+		namespace = nsenv
+	}
+
+	factory := informers.NewSharedInformerFactoryWithOptions(clientset, time.Hour*24, informers.WithNamespace(namespace))
+
+	controller, err := NewInternalSecretController(factory, namespace, "neuvector-internal-certs", reloadFuncs)
 	if err != nil {
 		return fmt.Errorf("failed to create internal secret controller: %w", err)
 	}

--- a/upgrader/presync.go
+++ b/upgrader/presync.go
@@ -150,7 +150,7 @@ func GetCronJobDetail(ctx context.Context, client dynamic.Interface, namespace s
 func CreatePostSyncJob(ctx context.Context, client dynamic.Interface, namespace string, certUpgraderUID string, withLock bool) (*batchv1.Job, error) {
 	// Global cluster-level lock with 5 mins TTL
 	if withLock {
-		lock, err := CreateLocker(namespace, CONTROLLER_LEASE_NAME)
+		lock, err := CreateLocker(client, namespace, CONTROLLER_LEASE_NAME)
 		if err != nil {
 			return nil, fmt.Errorf("failed to acquire cluster-wide lock: %w", err)
 		}


### PR DESCRIPTION
This PR addresses three issues:
1. Allow disabling rotation via an environment variable.
2. Read namespace from /var/run/secrets/kubernetes.io/serviceaccount/namespace.
3. NVSHAS-9150 do not panic when lease is absent