### PR TITLE
[NVSHAS-6979] Ability to include comment of response rule in alert content and beautify content

### DIFF
--- a/controller/cache/log.go
+++ b/controller/cache/log.go
@@ -419,7 +419,7 @@ func webhookActivity(act *actionDesc, arg interface{}) {
 		for _, w := range act.webhooks {
 			if whc := getWebhookCache(rlog.ResponseRuleID, w); whc != nil {
 				proxy := getWebhookProxy(whc)
-				whc.c.Notify(rlog, rlog.Level, api.CategoryEvent, rlog.ClusterName, title, proxy)
+				whc.c.Notify(rlog, rlog.Level, api.CategoryEvent, rlog.ClusterName, title, act.comment, proxy)
 			}
 		}
 	}
@@ -433,7 +433,7 @@ func webhookEvent(act *actionDesc, arg interface{}) {
 		for _, w := range act.webhooks {
 			if whc := getWebhookCache(rlog.ResponseRuleID, w); whc != nil {
 				proxy := getWebhookProxy(whc)
-				whc.c.Notify(rlog, rlog.Level, api.CategoryEvent, rlog.ClusterName, title, proxy)
+				whc.c.Notify(rlog, rlog.Level, api.CategoryEvent, rlog.ClusterName, title, act.comment, proxy)
 			}
 		}
 	}
@@ -447,7 +447,7 @@ func webhookViolation(act *actionDesc, arg interface{}) {
 		for _, w := range act.webhooks {
 			if whc := getWebhookCache(rlog.ResponseRuleID, w); whc != nil {
 				proxy := getWebhookProxy(whc)
-				whc.c.Notify(rlog, rlog.Level, api.CategoryViolation, rlog.ClusterName, title, proxy)
+				whc.c.Notify(rlog, rlog.Level, api.CategoryViolation, rlog.ClusterName, title, act.comment, proxy)
 			}
 		}
 	}
@@ -468,7 +468,7 @@ func webhookThreat(act *actionDesc, arg interface{}) {
 		for _, w := range act.webhooks {
 			if whc := getWebhookCache(rlog.ResponseRuleID, w); whc != nil {
 				proxy := getWebhookProxy(whc)
-				whc.c.Notify(rlog, rlog.Level, api.CategoryThreat, rlog.ClusterName, title, proxy)
+				whc.c.Notify(rlog, rlog.Level, api.CategoryThreat, rlog.ClusterName, title, act.comment, proxy)
 			}
 		}
 		rlog.CapLen, rlog.Packet = len, pkt
@@ -483,7 +483,7 @@ func webhookIncident(act *actionDesc, arg interface{}) {
 		for _, w := range act.webhooks {
 			if whc := getWebhookCache(rlog.ResponseRuleID, w); whc != nil {
 				proxy := getWebhookProxy(whc)
-				whc.c.Notify(rlog, rlog.Level, api.CategoryIncident, rlog.ClusterName, title, proxy)
+				whc.c.Notify(rlog, rlog.Level, api.CategoryIncident, rlog.ClusterName, title, act.comment, proxy)
 			}
 		}
 	}
@@ -512,7 +512,7 @@ func webhookAudit(act *actionDesc, arg interface{}) {
 		for _, w := range act.webhooks {
 			if whc := getWebhookCache(rlog.ResponseRuleID, w); whc != nil {
 				proxy := getWebhookProxy(whc)
-				whc.c.Notify(rlog, rlog.Level, api.CategoryAudit, rlog.ClusterName, title, proxy)
+				whc.c.Notify(rlog, rlog.Level, api.CategoryAudit, rlog.ClusterName, title, act.comment, proxy)
 			}
 		}
 	}

--- a/controller/cache/response.go
+++ b/controller/cache/response.go
@@ -36,6 +36,7 @@ type eventDesc struct {
 
 type actionDesc struct {
 	id       uint32
+	comment  string
 	actions  []string
 	webhooks []string
 }
@@ -336,7 +337,7 @@ func lookup(desc *eventDesc) []actionDesc {
 				}
 			}
 			if len(rule.Conditions) == 0 || matchConditions(desc, rule.Conditions) {
-				ret = append(ret, actionDesc{id: rule.ID, actions: rule.Actions, webhooks: rule.Webhooks})
+				ret = append(ret, actionDesc{id: rule.ID, comment: rule.Comment, actions: rule.Actions, webhooks: rule.Webhooks})
 			}
 		}
 	}

--- a/controller/kv/create.go
+++ b/controller/kv/create.go
@@ -12,7 +12,7 @@ import (
 	"github.com/neuvector/neuvector/controller/access"
 	"github.com/neuvector/neuvector/controller/api"
 	"github.com/neuvector/neuvector/controller/common"
-	"github.com/neuvector/neuvector/controller/nvk8sapi/nvvalidatewebhookcfg"
+	admission "github.com/neuvector/neuvector/controller/nvk8sapi/nvvalidatewebhookcfg"
 	"github.com/neuvector/neuvector/controller/resource"
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/cluster"
@@ -873,7 +873,7 @@ func CreateDefaultFedGroups() {
 	}
 }
 
-//compress for existing rulelist pre-3.2.1 and 3.2.1
+// compress for existing rulelist pre-3.2.1 and 3.2.1
 func CompressPolicyRuleList() {
 	//since 3.2.1 rulelist key is changed to
 	//CLUSPolicyZipRuleListKey from


### PR DESCRIPTION
### Summary

1. Ability to include comment of response rule in alert content and beautify content
2. output the data result like the following (slack, Json, txt as example)
3. Beautify by move the rule to the front of the messages if user setup any. (if they don't specify, we don't provide the response rule comment.)
<img width="1531" alt="Screen Shot 2024-07-01 at 10 56 34 AM" src="https://github.com/neuvector/neuvector/assets/145627854/229354c0-c9cc-4d72-b09e-bec56f55dcc6">
<img width="1363" alt="Screen Shot 2024-07-01 at 10 56 27 AM" src="https://github.com/neuvector/neuvector/assets/145627854/0c14866e-82db-4aa2-bfc1-12e1d1d44cee">


