### PR TITLE
NVSHAS-9177: Reexam host interface afte 1 minute of enforcer startup

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -2545,6 +2545,10 @@ func intfHostMonitorLoop(hid string, stopCh chan struct{}) {
 
 	log.Debug("Start monitoring Host Interface changes...")
 
+	// Set up a timer to call taskReexamHostIntf only once after 1 minute
+	timer := time.NewTimer(1 * time.Minute)
+	defer timer.Stop()
+
 	for {
 		select {
 		case <-stopCh:
@@ -2571,6 +2575,9 @@ func intfHostMonitorLoop(hid string, stopCh chan struct{}) {
 				// for all other conditions(includes address delete) re-exam host interface
 				taskReexamHostIntf()
 			}
+		case <-timer.C:
+			taskReexamHostIntf()
+			timer.Stop()
 		}
 	}
 }


### PR DESCRIPTION
Set up a timer to call taskReexamHostIntf after 1 minute of enforcer startup to avoid missing network interfaces if there is no host link or address change