### PR TITLE
NVSHAS-9117: the Kubenetes.NeuVector.RBAC event is missing if the rba…

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -2186,6 +2186,9 @@ func CacheEvent(ev share.TLogEvent, msg string) error {
 			Msg:            msg,
 		}
 		cctx.EvQueue.Append(&log)
+		if ev == share.CLUSEvK8sNvRBAC {
+			cctx.EvQueue.Flush()
+		}
 	}
 
 	return nil


### PR DESCRIPTION
…c is not met with our requirement