### PR TITLE
NVSHAS-8242: update critical vul support flag

### DIFF
--- a/controller/grpc.go
+++ b/controller/grpc.go
@@ -282,7 +282,7 @@ func (ss *ScanService) SubmitScanResult(ctx context.Context, result *share.ScanR
 
 func (s *ScanService) GetCaps(ctx context.Context, v *share.RPCVoid) (*share.ControllerCaps, error) {
 	return &share.ControllerCaps{
-		CriticalVul: false,
+		CriticalVul: true,
 	}, nil
 }
 


### PR DESCRIPTION
This flag needs to be set to true for the scanner to not downgrade critical CVEs when the controller supports them.

Related scanner code for reference: https://github.com/neuvector/scanner/blob/86b0b95c33d80f74cf4a089aef2b499939fedcad/server.go#L366