### PR TITLE
NVSHAS-9223: temporarily revert critical cve logic

### DIFF
--- a/controller/nvk8sapi/nvvalidatewebhookcfg/admission/admission.go
+++ b/controller/nvk8sapi/nvvalidatewebhookcfg/admission/admission.go
@@ -340,48 +340,52 @@ func getAdmK8sDenyRuleOptions() map[string]*api.RESTAdmissionRuleOption {
 				Ops:      allSetOps,
 				MatchSrc: api.MatchSrcImage,
 			},
-			share.CriteriaKeyCVECriticalCount: &api.RESTAdmissionRuleOption{
-				Name:       share.CriteriaKeyCVECriticalCount,
-				Ops:        []string{share.CriteriaOpBiggerEqualThan},
-				MatchSrc:   api.MatchSrcImage,
-				SubOptions: subOptions,
-			},
+			// NVSHAS-8242: temporary reversion
+			// share.CriteriaKeyCVECriticalCount: &api.RESTAdmissionRuleOption{
+			// 	Name:       share.CriteriaKeyCVECriticalCount,
+			// 	Ops:        []string{share.CriteriaOpBiggerEqualThan},
+			// 	MatchSrc:   api.MatchSrcImage,
+			// 	SubOptions: subOptions,
+			// },
 			share.CriteriaKeyCVEHighCount: &api.RESTAdmissionRuleOption{
 				Name:       share.CriteriaKeyCVEHighCount,
 				Ops:        []string{share.CriteriaOpBiggerEqualThan},
 				MatchSrc:   api.MatchSrcImage,
 				SubOptions: subOptions,
 			},
-			share.CriteriaKeyCVEHighCountNoCritical: &api.RESTAdmissionRuleOption{
-				Name:       share.CriteriaKeyCVEHighCountNoCritical,
-				Ops:        []string{share.CriteriaOpBiggerEqualThan},
-				MatchSrc:   api.MatchSrcImage,
-				SubOptions: subOptions,
-			},
+			// NVSHAS-8242: temporary reversion
+			// share.CriteriaKeyCVEHighCountNoCritical: &api.RESTAdmissionRuleOption{
+			// 	Name:       share.CriteriaKeyCVEHighCountNoCritical,
+			// 	Ops:        []string{share.CriteriaOpBiggerEqualThan},
+			// 	MatchSrc:   api.MatchSrcImage,
+			// 	SubOptions: subOptions,
+			// },
 			share.CriteriaKeyCVEMediumCount: &api.RESTAdmissionRuleOption{
 				Name:       share.CriteriaKeyCVEMediumCount,
 				Ops:        []string{share.CriteriaOpBiggerEqualThan},
 				MatchSrc:   api.MatchSrcImage,
 				SubOptions: subOptions,
 			},
-			share.CriteriaKeyCVECriticalWithFixCount: &api.RESTAdmissionRuleOption{
-				Name:       share.CriteriaKeyCVECriticalWithFixCount,
-				Ops:        []string{share.CriteriaOpBiggerEqualThan},
-				MatchSrc:   api.MatchSrcImage,
-				SubOptions: subOptions,
-			},
+			// NVSHAS-8242: temporary reversion
+			// share.CriteriaKeyCVECriticalWithFixCount: &api.RESTAdmissionRuleOption{
+			// 	Name:       share.CriteriaKeyCVECriticalWithFixCount,
+			// 	Ops:        []string{share.CriteriaOpBiggerEqualThan},
+			// 	MatchSrc:   api.MatchSrcImage,
+			// 	SubOptions: subOptions,
+			// },
 			share.CriteriaKeyCVEHighWithFixCount: &api.RESTAdmissionRuleOption{
 				Name:       share.CriteriaKeyCVEHighWithFixCount,
 				Ops:        []string{share.CriteriaOpBiggerEqualThan},
 				MatchSrc:   api.MatchSrcImage,
 				SubOptions: subOptions,
 			},
-			share.CriteriaKeyCVEHighWithFixCountNoCritical: &api.RESTAdmissionRuleOption{
-				Name:       share.CriteriaKeyCVEHighWithFixCountNoCritical,
-				Ops:        []string{share.CriteriaOpBiggerEqualThan},
-				MatchSrc:   api.MatchSrcImage,
-				SubOptions: subOptions,
-			},
+			// NVSHAS-8242: temporary reversion
+			// share.CriteriaKeyCVEHighWithFixCountNoCritical: &api.RESTAdmissionRuleOption{
+			// 	Name:       share.CriteriaKeyCVEHighWithFixCountNoCritical,
+			// 	Ops:        []string{share.CriteriaOpBiggerEqualThan},
+			// 	MatchSrc:   api.MatchSrcImage,
+			// 	SubOptions: subOptions,
+			// },
 			share.CriteriaKeyCVEScoreCount: &api.RESTAdmissionRuleOption{
 				Name:       share.CriteriaKeyCVEScoreCount,
 				Ops:        []string{share.CriteriaOpBiggerEqualThan},
@@ -585,41 +589,45 @@ func getAdmK8sExceptRuleOptions() map[string]*api.RESTAdmissionRuleOption { // f
 				Ops:      allSetOps,
 				MatchSrc: api.MatchSrcImage,
 			},
-			share.CriteriaKeyCVECriticalCount: &api.RESTAdmissionRuleOption{
-				Name:     share.CriteriaKeyCVECriticalCount,
-				Ops:      []string{share.CriteriaOpLessEqualThan, share.CriteriaOpBiggerEqualThan},
-				MatchSrc: api.MatchSrcImage,
-			},
+			// NVSHAS-8242: temporary reversion
+			// share.CriteriaKeyCVECriticalCount: &api.RESTAdmissionRuleOption{
+			// 	Name:     share.CriteriaKeyCVECriticalCount,
+			// 	Ops:      []string{share.CriteriaOpLessEqualThan, share.CriteriaOpBiggerEqualThan},
+			// 	MatchSrc: api.MatchSrcImage,
+			// },
 			share.CriteriaKeyCVEHighCount: &api.RESTAdmissionRuleOption{
 				Name:     share.CriteriaKeyCVEHighCount,
 				Ops:      []string{share.CriteriaOpLessEqualThan, share.CriteriaOpBiggerEqualThan},
 				MatchSrc: api.MatchSrcImage,
 			},
-			share.CriteriaKeyCVEHighCountNoCritical: &api.RESTAdmissionRuleOption{
-				Name:     share.CriteriaKeyCVEHighCountNoCritical,
-				Ops:      []string{share.CriteriaOpLessEqualThan, share.CriteriaOpBiggerEqualThan},
-				MatchSrc: api.MatchSrcImage,
-			},
+			// NVSHAS-8242: temporary reversion
+			// share.CriteriaKeyCVEHighCountNoCritical: &api.RESTAdmissionRuleOption{
+			// 	Name:     share.CriteriaKeyCVEHighCountNoCritical,
+			// 	Ops:      []string{share.CriteriaOpLessEqualThan, share.CriteriaOpBiggerEqualThan},
+			// 	MatchSrc: api.MatchSrcImage,
+			// },
 			share.CriteriaKeyCVEMediumCount: &api.RESTAdmissionRuleOption{
 				Name:     share.CriteriaKeyCVEMediumCount,
 				Ops:      []string{share.CriteriaOpLessEqualThan, share.CriteriaOpBiggerEqualThan},
 				MatchSrc: api.MatchSrcImage,
 			},
-			share.CriteriaKeyCVECriticalWithFixCount: &api.RESTAdmissionRuleOption{
-				Name:     share.CriteriaKeyCVECriticalWithFixCount,
-				Ops:      []string{share.CriteriaOpLessEqualThan, share.CriteriaOpBiggerEqualThan},
-				MatchSrc: api.MatchSrcImage,
-			},
+			// NVSHAS-8242: temporary reversion
+			// share.CriteriaKeyCVECriticalWithFixCount: &api.RESTAdmissionRuleOption{
+			// 	Name:     share.CriteriaKeyCVECriticalWithFixCount,
+			// 	Ops:      []string{share.CriteriaOpLessEqualThan, share.CriteriaOpBiggerEqualThan},
+			// 	MatchSrc: api.MatchSrcImage,
+			// },
 			share.CriteriaKeyCVEHighWithFixCount: &api.RESTAdmissionRuleOption{
 				Name:     share.CriteriaKeyCVEHighWithFixCount,
 				Ops:      []string{share.CriteriaOpLessEqualThan, share.CriteriaOpBiggerEqualThan},
 				MatchSrc: api.MatchSrcImage,
 			},
-			share.CriteriaKeyCVEHighWithFixCountNoCritical: &api.RESTAdmissionRuleOption{
-				Name:     share.CriteriaKeyCVEHighWithFixCountNoCritical,
-				Ops:      []string{share.CriteriaOpLessEqualThan, share.CriteriaOpBiggerEqualThan},
-				MatchSrc: api.MatchSrcImage,
-			},
+			// NVSHAS-8242: temporary reversion
+			// share.CriteriaKeyCVEHighWithFixCountNoCritical: &api.RESTAdmissionRuleOption{
+			// 	Name:     share.CriteriaKeyCVEHighWithFixCountNoCritical,
+			// 	Ops:      []string{share.CriteriaOpLessEqualThan, share.CriteriaOpBiggerEqualThan},
+			// 	MatchSrc: api.MatchSrcImage,
+			// },
 			/*share.CriteriaKeyCVEScore: &api.RESTAdmissionRuleOption{
 				Name:     share.CriteriaKeyCVEScore,
 				Ops:      []string{share.CriteriaOpLessEqualThan, share.CriteriaOpBiggerEqualThan},

--- a/share/scan/scan_report.go
+++ b/share/scan/scan_report.go
@@ -392,9 +392,12 @@ func fillVulFields(vr *share.ScanVulnerability, v *api.RESTVulnerability) {
 	}
 
 	if v.Severity == "" {
-		if v.Score >= 9 || v.ScoreV3 >= 9 {
-			v.Severity = share.VulnSeverityCritical
-		} else if v.Score >= 7 || v.ScoreV3 >= 7 {
+		// NVSHAS-8242: temporary reversion
+		// if v.Score >= 9 || v.ScoreV3 >= 9 {
+		// 	v.Severity = share.VulnSeverityCritical
+		// } else
+
+		if v.Score >= 7 || v.ScoreV3 >= 7 {
 			v.Severity = share.VulnSeverityHigh
 		} else if v.Score >= 4 || v.ScoreV3 >= 4 {
 			v.Severity = share.VulnSeverityMedium
@@ -527,9 +530,10 @@ func ExtractVulnerability(vuls []*share.ScanVulnerability) []*VulTrait {
 			pkgName:  v.PackageName, pkgVer: v.PackageVersion, fixVer: v.FixedVersion,
 		}
 
-		if v.Score >= 9 || v.ScoreV3 >= 9 {
-			traits[i].severity = vulnSeverityCritical
-		}
+		// NVSHAS-8242: temporary reversion
+		// if v.Score >= 9 || v.ScoreV3 >= 9 {
+		// 	traits[i].severity = vulnSeverityCritical
+		// }
 	}
 	return traits
 }

--- a/share/types.go
+++ b/share/types.go
@@ -163,16 +163,16 @@ const (
 )
 
 const (
-	EventCondTypeName               string = "name"
-	EventCondTypeCVEName            string = "cve-name"
-	EventCondTypeCVECritical        string = "cve-critical"
-	EventCondTypeCVEHigh            string = "cve-high"
-	EventCondTypeCVEMedium          string = "cve-medium"
-	EventCondTypeCVECriticalWithFix string = "cve-critical-with-fix"
-	EventCondTypeCVEHighWithFix     string = "cve-high-with-fix"
-	EventCondTypeLevel              string = "level"
-	EventCondTypeProc               string = "process"
-	EventCondTypeBenchNumber        string = "number"
+	EventCondTypeName    string = "name"
+	EventCondTypeCVEName string = "cve-name"
+	// EventCondTypeCVECritical        string = "cve-critical" // NVSHAS-8242: temporary reversion
+	EventCondTypeCVEHigh   string = "cve-high"
+	EventCondTypeCVEMedium string = "cve-medium"
+	// EventCondTypeCVECriticalWithFix string = "cve-critical-with-fix" // NVSHAS-8242: temporary reversion
+	EventCondTypeCVEHighWithFix string = "cve-high-with-fix"
+	EventCondTypeLevel          string = "level"
+	EventCondTypeProc           string = "process"
+	EventCondTypeBenchNumber    string = "number"
 )
 
 const (


### PR DESCRIPTION
This temporarily nullifies any effectual or front-facing logic/types for the critical CVE change.