### PR TITLE
NVSHAS-8305 remove built-in certificate

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -195,6 +195,7 @@ type Context struct {
 	RestConfigFunc           func(cmd, interval uint32, param1 interface{}, param2 interface{}) error
 	CreateQuerySessionFunc   func(qsr *api.QuerySessionRequest) error
 	DeleteQuerySessionFunc   func(queryToken string) error
+	NotifyCertChange         func(cn string) error
 }
 
 type k8sProbeCmd struct {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -766,6 +766,7 @@ func main() {
 		RestConfigFunc:           rest.RestConfig,
 		CreateQuerySessionFunc:   rest.CreateQuerySession,
 		DeleteQuerySessionFunc:   rest.DeleteQuerySession,
+		NotifyCertChange:         nil, // To be filled later
 	}
 	cacher = cache.Init(&cctx, Ctrler.Leader, lead, restoredFedRole)
 	cache.ScannerChangeNotify(Ctrler.Leader)
@@ -839,6 +840,9 @@ func main() {
 
 	// init rest server context before listening KV object store, as federation server can be started from there.
 	rest.InitContext(&rctx)
+
+	// Assign callback so cert manager can receive cert changes.
+	cctx.NotifyCertChange = rest.CertManager.NotifyChanges
 
 	// Registry cluster event handlers
 	cluster.RegisterLeadChangeWatcher(leadChangeHandler, lead)

--- a/controller/kv/certmanager.go
+++ b/controller/kv/certmanager.go
@@ -51,27 +51,29 @@ func isValidCallback(callback *CertManagerCallback) bool {
 }
 
 type CertManager struct {
-	callbacks map[string]*CertManagerCallback
-	mutex     sync.RWMutex
-	config    CertManagerConfig
+	callbacks  map[string]*CertManagerCallback
+	mutex      sync.Mutex // Protect callbacks and other shared configs.
+	config     CertManagerConfig
+	notifyChan chan string
 }
 
 func NewCertManager(config CertManagerConfig) *CertManager {
 	return &CertManager{
-		callbacks: make(map[string]*CertManagerCallback),
-		config:    config,
+		callbacks:  make(map[string]*CertManagerCallback),
+		config:     config,
+		notifyChan: make(chan string),
 	}
 }
 
+// Main go routine of cert manager.
 func (c *CertManager) Run(ctx context.Context) error {
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-
 	ticker := time.NewTicker(c.config.ExpiryCheckPeriod)
 	for {
 		select {
 		case <-ticker.C:
 			c.CheckAndRenewCerts()
+		case cn := <-c.notifyChan:
+			c.UpdateCerts(cn)
 		case <-ctx.Done():
 			goto end
 		}
@@ -81,6 +83,7 @@ end:
 	return nil
 }
 
+// Utility function.  Retry consul API until it succeeds or retry number is reached.
 func RetryOnCASError(retry int, fn func() error) error {
 	steps := 0
 	sleeptime := DefaultSleepTime
@@ -222,8 +225,14 @@ func (c *CertManager) checkAndRotateCert(cn string, callback *CertManagerCallbac
 	})
 }
 
+// Check and renew certificates.
+// This is supposed to be called by one go routine.
 func (c *CertManager) CheckAndRenewCerts() error {
 	log.Debug("CheckAndRenewCerts() starts.")
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
 	for cn, callback := range c.callbacks {
 		c.checkAndRotateCert(cn, callback)
 	}
@@ -248,4 +257,39 @@ func (c *CertManager) Unregister(cn string) error {
 	defer c.mutex.Unlock()
 	delete(c.callbacks, cn)
 	return nil
+}
+
+// Notify cert manager that a change is detected.
+func (c *CertManager) NotifyChanges(cn string) error {
+	log.WithFields(log.Fields{
+		"cn": cn,
+	}).Debug("Changes detected in certificate")
+	c.notifyChan <- cn
+	return nil
+}
+
+// Update certificate based on data in consul
+func (c *CertManager) UpdateCerts(cn string) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	callback, ok := c.callbacks[cn]
+	if !ok {
+		return fmt.Errorf("no suitable callback for: %s", cn)
+	}
+
+	return RetryOnCASError(DefaultRetryNumber, func() error {
+		data, index, err := clusHelper.GetObjectCertRev(cn)
+		if err != nil && err != cluster.ErrKeyNotFound {
+			// This function assumes the previous certificate should be there.  If not, return an error.
+			return fmt.Errorf("failed to get certificate: %w", err)
+		}
+
+		if callback.lastModifyIndex != index {
+			callback.lastModifyIndex = index
+			// Changed by others or initial start
+			callback.NotifyNewCert(nil, data)
+		}
+		return nil
+	})
 }

--- a/controller/rest/rest.go
+++ b/controller/rest/rest.go
@@ -1442,7 +1442,7 @@ func initCertificates() error {
 				}
 
 				if newcert.OldCert != nil {
-					if expiryDate, err := getExpiryDate([]byte(oldcert.Cert)); err != nil {
+					if expiryDate, err := getExpiryDate([]byte(newcert.Cert)); err != nil {
 						log.WithError(err).Error("failed to get cert's expiry time.")
 					} else {
 						oldExpiryDate = &expiryDate
@@ -1899,7 +1899,6 @@ func StartRESTServer(isNewCluster bool, isLead bool) {
 			defer tlsMutex.RUnlock()
 			return tlsCertificate, nil
 		}
-		config.Certificates = []tls.Certificate{*tlsCertificate}
 	}
 
 	server := &http.Server{
@@ -1987,7 +1986,6 @@ func startFedRestServer(fedPingInterval uint32) {
 					defer tlsMutex.RUnlock()
 					return tlsCertificate, nil
 				}
-				server.TLSConfig.Certificates = []tls.Certificate{*tlsCertificate}
 			}
 		}
 		for i := 0; i < 5; i++ {

--- a/controller/rest/rest.go
+++ b/controller/rest/rest.go
@@ -51,6 +51,11 @@ import (
 const retryClusterMax int = 3
 const clusterLockWait = time.Duration(time.Second * 20)
 
+const DEFAULT_JWTCERT_VALIDITY_DAYS = 90
+const DEFAULT_TLSCERT_VALIDITY_DAYS = 365
+const DEFAULT_CERTMANAGER_EXPIRY_CHECK_PERIOD = time.Minute * 30
+const DEFAULT_CERTMANAGER_RENEW_THRESHOLD = time.Hour * 24 * 30
+
 type ApiVersion int
 
 const (
@@ -113,6 +118,8 @@ var restErrAgentDisconnected error = errors.New("Enforcer is disconnected")
 var checkCrdSchemaFunc func(lead, init, crossCheck bool, cspType share.TCspType) []string
 
 var CertManager *kv.CertManager
+var tlsMutex sync.RWMutex
+var tlsCertificate *tls.Certificate
 
 var restErrMessage = []string{
 	api.RESTErrNotFound:              "URL not found",
@@ -1268,7 +1275,6 @@ type Context struct {
 	CspPauseInterval   uint   // in minutes
 	CustomCheckControl string // disable / strict / loose
 	CheckCrdSchemaFunc func(lead, init, crossCheck bool, cspType share.TCspType) []string
-	CertManager        *kv.CertManager
 }
 
 var cctx *Context
@@ -1282,46 +1288,56 @@ func getExpiryDate(certPEM []byte) (time.Time, error) {
 	return cert.NotAfter, nil
 }
 
-func initJWTSignKey() error {
-	ExpiryCheckPeriod := time.Minute * 30
-	RenewThreshold := time.Hour * 24 * 30
-	JWTCertValidityPeriodDay := 90 // 90 days.
+func initCertificates() error {
+	expiryCheckPeriod := DEFAULT_CERTMANAGER_EXPIRY_CHECK_PERIOD
+	renewThreshold := DEFAULT_CERTMANAGER_RENEW_THRESHOLD
+
+	jwtCertValidityPeriodDay := DEFAULT_JWTCERT_VALIDITY_DAYS
+	tlsCertValidityPeriodDay := DEFAULT_TLSCERT_VALIDITY_DAYS
 
 	if envvar := os.Getenv("CERT_EXPIRY_CHECK_PERIOD"); envvar != "" {
 		if v, err := time.ParseDuration(envvar); err == nil {
-			ExpiryCheckPeriod = v
+			expiryCheckPeriod = v
 		} else {
 			log.WithError(err).Warn("failed to load ExpiryCheckPeriod")
 		}
 	}
 	if envvar := os.Getenv("CERT_RENEW_THRESHOLD"); envvar != "" {
 		if v, err := time.ParseDuration(envvar); err == nil {
-			RenewThreshold = v
+			renewThreshold = v
 		} else {
 			log.WithError(err).Warn("failed to load RenewThreshold")
 		}
 	}
 	if envvar := os.Getenv("JWTCERT_VALIDITY_PERIOD_DAY"); envvar != "" {
 		if v, err := strconv.Atoi(envvar); err == nil {
-			JWTCertValidityPeriodDay = v
+			jwtCertValidityPeriodDay = v
 		} else {
 			log.WithError(err).Warn("failed to load JWTCertValidityPeriodDay")
 		}
 	}
 
+	if envvar := os.Getenv("TLSCERT_VALIDITY_PERIOD_DAY"); envvar != "" {
+		if v, err := strconv.Atoi(envvar); err == nil {
+			tlsCertValidityPeriodDay = v
+		} else {
+			log.WithError(err).Warn("failed to load TLSCertValidityPeriodDay")
+		}
+	}
+
 	log.WithFields(log.Fields{
-		"period":              ExpiryCheckPeriod,
-		"threshold":           RenewThreshold,
-		"validity_length_day": JWTCertValidityPeriodDay,
+		"period":              expiryCheckPeriod,
+		"threshold":           renewThreshold,
+		"validity_length_day": jwtCertValidityPeriodDay,
 	}).Info("cert manager is configured.")
 
 	CertManager = kv.NewCertManager(kv.CertManagerConfig{
-		RenewThreshold:    RenewThreshold,
-		ExpiryCheckPeriod: ExpiryCheckPeriod,
+		RenewThreshold:    renewThreshold,
+		ExpiryCheckPeriod: expiryCheckPeriod,
 	})
 	CertManager.Register(share.CLUSJWTKey, &kv.CertManagerCallback{
 		NewCert: func(*share.CLUSX509Cert) (*share.CLUSX509Cert, error) {
-			cert, key, err := kv.GenTlsKeyCert(share.CLUSJWTKey, "", "", kv.ValidityPeriod{Day: JWTCertValidityPeriodDay}, x509.ExtKeyUsageAny)
+			cert, key, err := kv.GenTlsKeyCert(share.CLUSJWTKey, "", "", kv.ValidityPeriod{Day: jwtCertValidityPeriodDay}, x509.ExtKeyUsageAny)
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate tls key/cert: %w", err)
 			}
@@ -1382,6 +1398,67 @@ func initJWTSignKey() error {
 			}).Info("new certificate is loaded")
 		},
 	})
+
+	tlsCertNotfound := false
+	if _, err := os.Stat(defaultSSLCertFile); errors.Is(err, os.ErrNotExist) {
+		tlsCertNotfound = true
+	}
+
+	if _, err := os.Stat(defaultSSLKeyFile); errors.Is(err, os.ErrNotExist) {
+		tlsCertNotfound = true
+	}
+
+	if tlsCertNotfound {
+		CertManager.Register(share.CLUSTLSCert, &kv.CertManagerCallback{
+			NewCert: func(*share.CLUSX509Cert) (*share.CLUSX509Cert, error) {
+				cert, key, err := kv.GenTlsKeyCert(share.CLUSTLSCert, "", "", kv.ValidityPeriod{Day: tlsCertValidityPeriodDay}, x509.ExtKeyUsageServerAuth)
+				if err != nil {
+					return nil, fmt.Errorf("failed to generate tls key/cert: %w", err)
+				}
+				return &share.CLUSX509Cert{
+					CN:   share.CLUSTLSCert,
+					Key:  string(key),
+					Cert: string(cert),
+				}, nil
+			},
+			NotifyNewCert: func(oldcert *share.CLUSX509Cert, newcert *share.CLUSX509Cert) {
+				tlsMutex.Lock()
+				defer tlsMutex.Unlock()
+
+				var oldExpiryDate *time.Time
+				var newExpiryDate *time.Time
+				var err error
+
+				tlsCert, err := tls.X509KeyPair([]byte(newcert.Cert), []byte(newcert.Key))
+				if err != nil {
+					log.WithError(err).Error("failed to parse key.")
+					return
+				}
+
+				if expiryDate, err := getExpiryDate([]byte(newcert.Cert)); err != nil {
+					log.WithError(err).Error("failed to get cert's expiry time.")
+				} else {
+					newExpiryDate = &expiryDate
+				}
+
+				if newcert.OldCert != nil {
+					if expiryDate, err := getExpiryDate([]byte(oldcert.Cert)); err != nil {
+						log.WithError(err).Error("failed to get cert's expiry time.")
+					} else {
+						oldExpiryDate = &expiryDate
+					}
+				}
+
+				tlsCertificate = &tlsCert
+
+				log.WithFields(log.Fields{
+					"cn":            share.CLUSTLSCert,
+					"newExpiryDate": newExpiryDate,
+					"oldExpiryDate": oldExpiryDate,
+				}).Info("new certificate is loaded")
+			},
+		})
+	}
 	// Create and setup certificate.
 	CertManager.CheckAndRenewCerts()
 	go CertManager.Run(context.TODO())
@@ -1422,8 +1499,8 @@ func InitContext(ctx *Context) {
 		_teleFreq = 60
 	}
 
-	if err := initJWTSignKey(); err != nil {
-		log.WithError(err).Error("failed to initialize JWT sign key.")
+	if err := initCertificates(); err != nil {
+		log.WithError(err).Error("failed to initialize keys/certificates.")
 	}
 	initHttpClients()
 }
@@ -1808,6 +1885,23 @@ func StartRESTServer(isNewCluster bool, isLead bool) {
 		PreferServerCipherSuites: true,
 		CipherSuites:             utils.GetSupportedTLSCipherSuites(),
 	}
+
+	// tlsCertificate is only generated when default location has no files
+	// so we can check if tlsCertificate is nil to see if we should adopt dynamically generated certificate.
+	certFileName := defaultSSLCertFile
+	keyFileName := defaultSSLKeyFile
+	if tlsCertificate != nil {
+		// When provide certificate from memory, certFileName and keyFileName have to be empty strings.
+		certFileName = ""
+		keyFileName = ""
+		config.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			tlsMutex.RLock()
+			defer tlsMutex.RUnlock()
+			return tlsCertificate, nil
+		}
+		config.Certificates = []tls.Certificate{*tlsCertificate}
+	}
+
 	server := &http.Server{
 		Addr:      addr,
 		Handler:   restLogger{r},
@@ -1817,7 +1911,7 @@ func StartRESTServer(isNewCluster bool, isLead bool) {
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0), // disable http/2
 	}
 	for {
-		if err := server.ListenAndServeTLS(defaultSSLCertFile, defaultSSLKeyFile); err != nil {
+		if err := server.ListenAndServeTLS(certFileName, keyFileName); err != nil {
 			if err == http.ErrServerClosed {
 				if cfgmapRetryTimer != nil {
 					cfgmapRetryTimer.Stop()
@@ -1870,13 +1964,31 @@ func startFedRestServer(fedPingInterval uint32) {
 
 	log.WithFields(log.Fields{"port": _fedPort}).Info("Start fed REST server")
 	go func() {
+		// The certificate used by fed rest server will be in the order below:
+		// 1. fed-ssl-cert.key
+		// 2. ssl-cert.key
+		// 3. tlsCertificate, which is generated in memory and stored in consul.
 		keyFileName := defFedSSLKeyFile
 		certFileName := defFedSSLCertFile
 		_, err1 := os.Stat(keyFileName)
 		_, err2 := os.Stat(certFileName)
 		if os.IsNotExist(err1) || os.IsNotExist(err2) {
-			keyFileName = defaultSSLKeyFile
 			certFileName = defaultSSLCertFile
+			keyFileName = defaultSSLKeyFile
+
+			// tlsCertificate is only generated when default location has no files
+			// so we can check if tlsCertificate is nil to see if we should adopt dynamically generated certificate.
+			if tlsCertificate != nil {
+				// When provide certificate from memory, certFileName and keyFileName have to be empty strings.
+				certFileName = ""
+				keyFileName = ""
+				config.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+					tlsMutex.RLock()
+					defer tlsMutex.RUnlock()
+					return tlsCertificate, nil
+				}
+				server.TLSConfig.Certificates = []tls.Certificate{*tlsCertificate}
+			}
 		}
 		for i := 0; i < 5; i++ {
 			if err := server.ListenAndServeTLS(certFileName, keyFileName); err != nil {

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -2034,6 +2034,7 @@ const (
 const (
 	CLUSRootCAKey = "rootCA"
 	CLUSJWTKey    = "neuvector-jwt-signing"
+	CLUSTLSCert   = "neuvector"
 )
 
 func CLUSObjectCertKey(cn string) string {


### PR DESCRIPTION
## Purpose

Auto-generate TLS certificate when `/etc/neuvector/certs/ssl-cert.*` is absent, so we can remove built-in TLS certificates from container images.

## Changes

1. Auto generate TLS certificate used by REST server and store in consul kv when `/etc/neuvector/certs/ssl-cert.pem` or `/etc/neuvector/certs/ssl-cert.key` doesn't exist.
2. The auto-generated certificate will also be used by federal REST server when `fed-ssl-cert` and `ssl-cert` are both absent.
3. Provide a notification mechanism via consul kv watch to minimize the time period when the certificate is different across different nodes.
4. Fix a minor issue in lock. 

The example of the TLS certificate is as below:
```
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 2029 (0x7ed)
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: C = US, ST = CA, L = EN, O = Neuvector, OU = Neuvector, CN = neuvector
        Validity
            Not Before: Jul 24 12:42:53 2024 GMT
            Not After : Jul 24 13:42:53 2025 GMT
        Subject: C = US, ST = CA, L = EN, O = Neuvector, OU = Neuvector, CN = neuvector
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
                Public-Key: (2048 bit)
                Modulus:
                    00:cf:d4:02:85:96:00:8d:4d:32:e9:2a:7c:40:50:
                    c1:f7:0c:9c:bc:7f:2e:f9:2a:0f:b4:56:11:c6:bd:
                    00:12:ca:0e:42:1f:9c:bd:60:94:9c:07:f5:02:7b:
                    d1:bf:be:77:7b:37:44:a6:b3:f7:df:4c:7e:c0:42:
                    e5:58:c3:3b:4f:06:ca:23:bc:8f:9d:72:1d:9b:e4:
                    9a:b2:6b:79:dd:b2:11:39:1e:52:6a:65:3e:9b:57:
                    09:a1:b5:32:1d:01:12:ff:11:4b:a4:87:27:6c:76:
                    c9:24:9e:05:21:82:9e:ab:15:ed:85:fe:ef:03:e6:
                    77:83:1b:33:b7:12:8c:c6:5f:81:74:fc:0c:21:cd:
                    cc:d5:54:34:87:27:f9:9d:f3:eb:05:fc:94:d7:f3:
                    82:cc:35:1c:84:3a:ae:b0:45:80:4a:59:00:5a:25:
                    26:1e:f2:aa:5e:0d:95:73:ab:ac:fc:c6:29:1f:05:
                    6b:f1:ce:75:aa:ba:06:98:b5:b7:4f:4d:a6:19:57:
                    59:62:47:7c:8e:96:1a:1e:c7:1f:e2:f0:06:07:ea:
                    c6:43:76:c1:98:6d:68:f7:16:73:58:5c:db:f0:64:
                    87:65:7c:de:7a:2d:67:e7:b7:f1:8d:2e:53:5f:34:
                    55:e4:fe:62:eb:cd:52:bc:56:7b:73:3e:be:d0:af:
                    2b:b9
                Exponent: 65537 (0x10001)
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
            X509v3 Extended Key Usage: 
                TLS Web Server Authentication
            X509v3 Subject Key Identifier: 
                01:02:03:04:06
            X509v3 Subject Alternative Name: 
                DNS:neuvector
    Signature Algorithm: sha256WithRSAEncryption
    Signature Value:
        8f:11:8f:79:3b:5f:5b:dc:83:f3:03:82:e4:1c:5e:4f:01:ae:
        dc:c7:85:9a:5b:13:fb:b1:4a:a1:d3:60:d4:7a:02:e8:9f:b9:
        e9:cc:4e:55:17:87:7b:0d:32:84:ec:25:23:fb:46:6c:75:38:
        1f:50:22:6a:53:4d:67:a1:92:7d:ad:3b:cd:21:c5:62:de:9d:
        9b:82:bb:ff:5b:a2:e5:a8:21:b5:fb:4a:7d:41:ae:88:80:e2:
        7a:29:26:b0:c1:4a:91:d6:96:a2:db:4d:54:a2:5d:ac:10:3d:
        3c:b5:13:28:19:3a:6d:c0:bd:30:5b:eb:8d:79:bf:3a:05:0c:
        3e:ae:1d:2a:99:b6:d7:aa:78:96:3a:07:b4:c5:a2:34:23:36:
        00:32:2d:ed:a9:f2:29:42:ec:a5:74:24:fc:1c:80:d3:af:6d:
        a8:e3:25:e5:2b:9f:85:f5:58:a9:3c:03:c7:2f:40:ee:6f:c7:
        cf:de:a3:5a:f5:8f:c9:01:45:34:46:62:b6:ec:fb:7e:94:fe:
        fb:b7:75:50:eb:da:14:5f:67:32:6c:74:c7:49:d2:16:54:b6:
        4f:95:a2:17:cf:dc:c0:c5:cc:02:65:fe:9a:52:fc:66:2f:a7:
        24:a9:06:2f:ce:73:66:fd:67:e9:2f:2c:51:36:da:db:eb:dd:
        52:4d:97:fe
```

## Tests performed

- Sanity test with the default helm chart setting to verify that I can login and TLS cert is consistent on all nodes.
- Sanity test by making `/etc/neuvector/certs` empty and with below configs and confirm certificate will be consistent on all controller nodes using `openssl s_client`
```
        - name: CERT_EXPIRY_CHECK_PERIOD                                
          value: 600s                                                   
        - name: CERT_RENEW_THRESHOLD                                    
          value: 87600h                                                 
        - name: TLSCERT_VALIDITY_PERIOD_DAY                             
          value: 48h          
```

