### PR TITLE
NVSHAS-8970: add NetMode check "bridge" for docker version 26+

### DIFF
--- a/share/orchestration/rancher.go
+++ b/share/orchestration/rancher.go
@@ -75,7 +75,8 @@ func (d *rancher) SetIPAddrScope(ports map[string][]share.CLUSIPAddr,
 	meta *container.ContainerMeta, nets map[string]*container.Network,
 ) {
 	// In 'default' mode, the interface is plugged by docker, not Rancher.
-	if !d.isDeployedBy(meta) || meta.NetMode == "default" {
+	// In docker version 26, after start a normal container the network_mode becomes 'bridge' instead of 'default'
+	if !d.isDeployedBy(meta) || meta.NetMode == "default" || meta.NetMode == "bridge" {
 		baseDriver.SetIPAddrScope(ports, meta, nets)
 		return
 	}


### PR DESCRIPTION
When start a normal container in docker version 26+, network_mode will become "bridge" instead of "default". Add the check for SetIPAddrScope.