### PR TITLE
fix: NVSHAS-8439 ignore io.EOF from k8s watch api

### DIFF
--- a/controller/resource/kubernetes_resource.go
+++ b/controller/resource/kubernetes_resource.go
@@ -1460,10 +1460,11 @@ func (d *kubernetes) startWatchResource(rt, ns string, wcb orchAPI.WatchCallback
 					atomic.StoreInt32(&watchFailedFlag, 1)
 				}
 
-				if scb != nil {
-					scb(ConnStateDisconnected, e)
-				}
+				// Ignore io.EOF per https://github.com/kubernetes/client-go/issues/623
 				if !strings.HasSuffix(e.Error(), io.EOF.Error()) {
+					if scb != nil {
+						scb(ConnStateDisconnected, e)
+					}
 					log.WithFields(log.Fields{"resource": rt, "error": e}).Error("Watch failure")
 					time.Sleep(kubeWatchRetry)
 				}


### PR DESCRIPTION
### Purpose

Per https://github.com/kubernetes/client-go/issues/623, watch API will close the connection when no event is detected in a given time frame.

When this happens, io.EOF will be returned and cause noises in controller log.

This PR makes io.EOF not reported to state callback.

### Tests performed

- Install NV and monitor controller's logs => no `OrchConnLastError:EOF`.
- Use tcpkill to terminate API service connection => connection can be recovered with correct error logs:
```
2024-07-25T02:51:45.312|INFO|CTL|main.(*orchConn).cbWatcherState: updating conn status - lastError=read tcp 192.168.36.233:57276->10.100.0.1:443: read: connection reset by peer status=disconnected
2024-07-25T02:51:45.321|INFO|CTL|main.(*orchConn).cbWatcherState: updating conn status - lastError=read frame body: read tcp 192.168.36.233:57276->10.100.0.1:443: read: connection reset by peer status=disconnected
2024-07-25T02:51:50.403|INFO|CTL|main.(*orchConn).cbWatcherState: updating conn status - lastError= status=connected
```