### PR TITLE
NVSHAS-8925: Log/Alert when Federated cluster disconnects

### DIFF
--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -2340,10 +2340,11 @@ type CLUSFedSettings struct { // stored on each cluster (master & joint cluster)
 }
 
 type CLUSFedClusterStatus struct {
-	Status            int       `json:"status"` // status of a joint cluster
-	CspType           TCspType  `json:"csp_type"`
-	Nodes             int       `json:"nodes"`               // total nodes count in this cluster
-	LastConnectedTime time.Time `json:"last_connected_time"` // only for master's connection status on joint cluster
+	Status              int       `json:"status"`                // status of a joint cluster
+	SwitchToUnreachable int       `json:"switch_to_unreachable"` // counts of connected -> disconnected
+	CspType             TCspType  `json:"csp_type"`
+	Nodes               int       `json:"nodes"`               // total nodes count in this cluster
+	LastConnectedTime   time.Time `json:"last_connected_time"` // only for master's connection status on joint cluster
 }
 
 type CLUSFedJoinedClusterList struct { // only available on master cluster


### PR DESCRIPTION
When a user log in NV console, an alert message is generated 
1. if a managed cluster is disconnected for > 1 hour (when user is on primary cluster UI)
2. if the primary cluster is disconnected for > 1 hour (when user is on managed cluster UI)
There is another UI jira case so that user can accept this alert so that this alert won't show up in 1 hour.
After 1 hour, if the disconnection still persist, the alert is re-generated in user's next login.

The 1 hour value can be overridden by env var specified in controller deployment yaml:
```
            - name: TELEMETRY_FREQ
              value: "3"   // minutes

```

