### PR TITLE
NVSHAS-8539 proxy password lost

### DIFF
--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -1759,6 +1759,8 @@ type RESTSystemConfigConfig struct {
 	RegistryHttpsProxyEnable  *bool                            `json:"registry_https_proxy_status,omitempty"`
 	RegistryHttpProxy         *RESTProxy                       `json:"registry_http_proxy,omitempty"`
 	RegistryHttpsProxy        *RESTProxy                       `json:"registry_https_proxy,omitempty"`
+	RegistryHttpProxyCfg      *RESTProxyConfig                 `json:"registry_http_proxy_cfg,omitempty"`
+	RegistryHttpsProxyCfg     *RESTProxyConfig                 `json:"registry_https_proxy_cfg,omitempty"`
 	IBMSAEpEnabled            *bool                            `json:"ibmsa_ep_enabled,omitempty"`
 	IBMSAEpDashboardURL       *string                          `json:"ibmsa_ep_dashboard_url,omitempty"`
 	XffEnabled                *bool                            `json:"xff_enabled,omitempty"`
@@ -1830,10 +1832,12 @@ type RESTSystemConfigAuthCfgV2 struct {
 }
 
 type RESTSystemConfigProxyCfgV2 struct {
-	RegistryHttpProxyEnable  *bool      `json:"registry_http_proxy_status,omitempty"`
-	RegistryHttpsProxyEnable *bool      `json:"registry_https_proxy_status,omitempty"`
-	RegistryHttpProxy        *RESTProxy `json:"registry_http_proxy,omitempty"`
-	RegistryHttpsProxy       *RESTProxy `json:"registry_https_proxy,omitempty"`
+	RegistryHttpProxyEnable  *bool            `json:"registry_http_proxy_status,omitempty"`
+	RegistryHttpsProxyEnable *bool            `json:"registry_https_proxy_status,omitempty"`
+	RegistryHttpProxy        *RESTProxy       `json:"registry_http_proxy,omitempty"`
+	RegistryHttpsProxy       *RESTProxy       `json:"registry_https_proxy,omitempty"`
+	RegistryHttpProxyCfg     *RESTProxyConfig `json:"registry_http_proxy_cfg,omitempty"`
+	RegistryHttpsProxyCfg    *RESTProxyConfig `json:"registry_https_proxy_cfg,omitempty"`
 }
 
 type RESTSystemConfigMiscCfgV2 struct {
@@ -1876,6 +1880,12 @@ type RESTSystemRequest struct {
 
 type RESTSystemRequestData struct {
 	Request *RESTSystemRequest `json:"request"`
+}
+
+type RESTProxyConfig struct {
+	URL      *string `json:"url"`
+	Username *string `json:"username"`
+	Password *string `json:"password,cloak"`
 }
 
 // If more log servers needed, they can be defined as servers.
@@ -1981,10 +1991,12 @@ type RESTSystemConfigAutoscale struct {
 }
 
 type RESTSystemConfigProxyV2 struct {
-	RegistryHttpProxyEnable  bool      `json:"registry_http_proxy_status"`
-	RegistryHttpsProxyEnable bool      `json:"registry_https_proxy_status"`
-	RegistryHttpProxy        RESTProxy `json:"registry_http_proxy"`
-	RegistryHttpsProxy       RESTProxy `json:"registry_https_proxy"`
+	RegistryHttpProxyEnable  bool            `json:"registry_http_proxy_status"`
+	RegistryHttpsProxyEnable bool            `json:"registry_https_proxy_status"`
+	RegistryHttpProxy        RESTProxy       `json:"registry_http_proxy"`
+	RegistryHttpsProxy       RESTProxy       `json:"registry_https_proxy"`
+	RegistryHttpProxyCfg     RESTProxyConfig `json:"registry_http_proxy_cfg"`
+	RegistryHttpsProxyCfg    RESTProxyConfig `json:"registry_https_proxy_cfg"`
 }
 
 type RESTSystemConfigIBMSAV2 struct {

--- a/controller/api/apis.yaml
+++ b/controller/api/apis.yaml
@@ -8418,6 +8418,24 @@ definitions:
         type: string
         format: password
         example: password
+    description: Define proxy settings.
+  RESTProxyConfig:
+    type: object
+    required:
+      - url
+      - username
+    properties:
+      url:
+        type: string
+        example: ""
+      username:
+        type: string
+        example: username
+      password:
+        type: string
+        format: password
+        example: password
+    description: Define proxy settings, similar to RESTProxy, but allow users to perform partial update on RESTProxy. When both exist, this config will take precedence over RESTProxy.
   RESTSystemConfigAutoscale:
     type: object
     required:
@@ -8526,6 +8544,10 @@ definitions:
         $ref: '#/definitions/RESTProxy'
       registry_https_proxy:
         $ref: '#/definitions/RESTProxy'
+      registry_http_proxy_cfg:
+        $ref: '#/definitions/RESTProxyConfig'
+      registry_https_proxy_cfg:
+        $ref: '#/definitions/RESTProxyConfig'
   RESTSystemConfigIBMSAVCfg2:
     type: object
     properties:
@@ -10985,6 +11007,10 @@ definitions:
         $ref: '#/definitions/RESTProxy'
       registry_https_proxy:
         $ref: '#/definitions/RESTProxy'
+      registry_http_proxy_cfg:
+        $ref: '#/definitions/RESTProxyConfig'
+      registry_https_proxy_cfg:
+        $ref: '#/definitions/RESTProxyConfig'
   RESTSystemConfigSyslogV2:
     type: object
     required:


### PR DESCRIPTION
## NVSHAS-8539 proxy password lost

### Problem
Controller doesn't check if password is null or not before overwriting the existing value.

### Solution

This commit provides an API update for UI to
resolve this issue.

### Tests performed

Slack integration with tinyproxy. 