### PR TITLE
NVSHAS-7853 TLS handshake EOF

### DIFF
--- a/controller/rest/rest.go
+++ b/controller/rest/rest.go
@@ -1937,6 +1937,7 @@ func StartRESTServer(isNewCluster bool, isLead bool) {
 		// ReadTimeout:  time.Duration(5) * time.Second,
 		// WriteTimeout: time.Duration(35) * time.Second,
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0), // disable http/2
+		ErrorLog:     newHttpServerErrorWriter(),
 	}
 	for {
 		if err := server.ListenAndServeTLS(certFileName, keyFileName); err != nil {
@@ -1986,6 +1987,7 @@ func startFedRestServer(fedPingInterval uint32) {
 		TLSConfig: config,
 		// ReadTimeout:  time.Duration(5) * time.Second,
 		// WriteTimeout: time.Duration(35) * time.Second,
+		ErrorLog: newHttpServerErrorWriter(),
 	}
 
 	atomic.StoreUint64(&fedRestServerState, _fedRestServerRunning_)

--- a/controller/rest/servererrorlogger.go
+++ b/controller/rest/servererrorlogger.go
@@ -1,0 +1,22 @@
+package rest
+
+import (
+	"log"
+	"os"
+	"strings"
+)
+
+type HttpServerErrorWriter struct{}
+
+func (*HttpServerErrorWriter) Write(b []byte) (int, error) {
+	msg := string(b)
+	if strings.Contains(msg, "http: TLS handshake error") && strings.HasSuffix(msg, ": EOF\n") {
+		return 0, nil
+	}
+
+	return os.Stderr.Write(b)
+}
+
+func newHttpServerErrorWriter() *log.Logger {
+	return log.New(&HttpServerErrorWriter{}, "", log.LstdFlags)
+}


### PR DESCRIPTION
When controller's service is configured as LoadBalancer, LoadBalancer can perform health check on the endpoint and generate a lot of error messages in controller:

```
http: TLS handshake error from xxxxxx: EOF
```
This commit skips this kind of error by providing a different logger for controller's REST server.