### PR TITLE
NVSHAS-9290: User added process profile rule not taking effect with ZD enabled

### DIFF
--- a/agent/probe/probe.go
+++ b/agent/probe/probe.go
@@ -694,10 +694,10 @@ func (p *Probe) ReportDockerCp(id, containerName string, toContainer bool) {
 }
 
 ///// by policy order
-func (p *Probe) addProcessControl(id, setting, svcGroup string, pid int, process []*share.CLUSProcessProfileEntry) {
+func (p *Probe) addProcessControl(id, setting, svcGroup string, pid int, ppe_list []*share.CLUSProcessProfileEntry) {
 	if p.fAccessCtl != nil {
-		for _, proc := range process {
-			mLog.WithFields(log.Fields{"name": proc.Name, "path": proc.Path, "action": proc.Action}).Debug("PROC:")
+		for _, ppe := range ppe_list {
+			mLog.WithFields(log.Fields{"name": ppe.Name, "path": ppe.Path, "action": ppe.Action}).Debug("PROC:")
 		}
 
 		if !osutil.IsPidValid(pid) {
@@ -705,7 +705,7 @@ func (p *Probe) addProcessControl(id, setting, svcGroup string, pid int, process
 			return
 		}
 
-		if !p.fAccessCtl.AddContainerControlByPolicyOrder(id, setting, svcGroup, pid, process) {
+		if !p.fAccessCtl.AddContainerControlByPolicyOrder(id, setting, svcGroup, pid, ppe_list) {
 			log.WithFields(log.Fields{"id": id, "pid": pid}).Debug("PROC: failed")
 		}
 	} else {

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -3196,11 +3196,15 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 
 			bPass = true
 			ppe.Action = share.PolicyActionAllow
-			if !ppe.AllowFileUpdate && !bNotImageButNewlyAdded {
-				if bModified {
-					bPass = false
-					ppe.Action = negativeResByMode(mode)
-					ppe.Uuid = share.CLUSReservedUuidAnchorMode
+			if ppe.CfgType != share.Learned {
+				// user allows the process manually
+			} else {
+				if !ppe.AllowFileUpdate && !bNotImageButNewlyAdded {
+					if bModified {
+						bPass = false
+						ppe.Action = negativeResByMode(mode)
+						ppe.Uuid = share.CLUSReservedUuidAnchorMode
+					}
 				}
 			}
 		case share.PolicyActionDeny:


### PR DESCRIPTION
Patching the insider process conditions to allow the actions when a not-learned (user-defined) process rule is applied to the modified/newly-added app.