### PR TITLE
[NVSHAS-9270] Support k3s for cis benchmark pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ copy_ctrl:
 	cp -r neuvector/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/ ${STAGE_DIR}/usr/local/bin/scripts/cis_yamls/
 	cp -r neuvector/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/ ${STAGE_DIR}/usr/local/bin/scripts/cis_yamls/
 	cp -r neuvector/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/ ${STAGE_DIR}/usr/local/bin/scripts/cis_yamls/
+	cp -r neuvector/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/ ${STAGE_DIR}/usr/local/bin/scripts/cis_yamls/
 	cp -r neuvector/agent/nvbench/kubernetes-cis-benchmark/gke-1.4.0/ ${STAGE_DIR}/usr/local/bin/scripts/cis_yamls/
 	cp -r neuvector/agent/nvbench/kubernetes-cis-benchmark/aks-1.4.0/ ${STAGE_DIR}/usr/local/bin/scripts/cis_yamls/
 	cp -r neuvector/agent/nvbench/kubernetes-cis-benchmark/eks-1.4.0/ ${STAGE_DIR}/usr/local/bin/scripts/cis_yamls/

--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,14 @@ copy_enf:
 	cp neuvector/agent/nvbench/kubecis_gke_1_0_0.rem ${STAGE_DIR}/usr/local/bin/scripts/rem/
 	cp neuvector/agent/nvbench/kubecis_ocp_4_5.rem ${STAGE_DIR}/usr/local/bin/scripts/rem/
 	cp neuvector/agent/nvbench/kubecis_ocp_4_3.rem ${STAGE_DIR}/usr/local/bin/scripts/rem/
+	cp neuvector/agent/nvbench/journal.tmpl ${STAGE_DIR}/usr/local/bin/scripts/
 	cp neuvector/tools/nstools/nstools ${STAGE_DIR}/usr/local/bin/
 	cp -r neuvector/agent/nvbench/utils/ ${STAGE_DIR}/usr/local/bin/scripts/
 	cp -r neuvector/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/ ${STAGE_DIR}/usr/local/bin/scripts/cis_yamls/
 	cp -r neuvector/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/ ${STAGE_DIR}/usr/local/bin/scripts/cis_yamls/
 	cp -r neuvector/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/ ${STAGE_DIR}/usr/local/bin/scripts/cis_yamls/
 	cp -r neuvector/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/ ${STAGE_DIR}/usr/local/bin/scripts/cis_yamls/
+	cp -r neuvector/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/ ${STAGE_DIR}/usr/local/bin/scripts/cis_yamls/
 	cp -r neuvector/agent/nvbench/kubernetes-cis-benchmark/gke-1.4.0/ ${STAGE_DIR}/usr/local/bin/scripts/cis_yamls/
 	cp -r neuvector/agent/nvbench/kubernetes-cis-benchmark/aks-1.4.0/ ${STAGE_DIR}/usr/local/bin/scripts/cis_yamls/
 	cp -r neuvector/agent/nvbench/kubernetes-cis-benchmark/eks-1.4.0/ ${STAGE_DIR}/usr/local/bin/scripts/cis_yamls/

--- a/agent/nvbench/journal.tmpl
+++ b/agent/nvbench/journal.tmpl
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+CIS_APISERVER_CMD="<<<.Replace_apiserver_cmd>>>"
+CIS_MANAGER_CMD="<<<.Replace_manager_cmd>>>"
+CIS_SCHEDULER_CMD="<<<.Replace_scheduler_cmd>>>"
+CIS_ETCD_CMD="<<<.Replace_etcd_cmd>>>"
+CIS_PROXY_CMD="<<<.Replace_proxy_cmd>>>"
+CIS_KUBELET_CMD="<<<.Replace_kubelet_cmd>>>"
+
+fetch_kube_cmd() {
+    echo "$JOURNAL_LOG" |  grep "Running $1" | tail -n1   | sed "s/[\"']//g"
+}
+
+JOURNAL_LOG=$(journalctl -D /var/log/journal -u k3s)
+
+# Read logs for each component
+kube_apiserver_cmd=$(fetch_kube_cmd "$CIS_APISERVER_CMD")
+kube_controller_manager_cmd=$(fetch_kube_cmd "$CIS_MANAGER_CMD")
+kube_scheduler_cmd=$(fetch_kube_cmd "$CIS_SCHEDULER_CMD")
+etcd_cmd=$(fetch_kube_cmd "$CIS_ETCD_CMD")
+kube_proxy_cmd=$(fetch_kube_cmd "$CIS_PROXY_CMD")
+kubelet_cmd=$(fetch_kube_cmd "$CIS_KUBELET_CMD")
+
+# Combine the output, use @@@ as dialmeter
+echo "$kube_apiserver_cmd@@@$kube_controller_manager_cmd@@@$kube_scheduler_cmd@@@$etcd_cmd@@@$kube_proxy_cmd@@@$kubelet_cmd"

--- a/agent/nvbench/journal.tmpl
+++ b/agent/nvbench/journal.tmpl
@@ -17,7 +17,7 @@ JOURNAL_LOG=$(journalctl -D /var/log/journal -u k3s)
 kube_apiserver_cmd=$(fetch_kube_cmd "$CIS_APISERVER_CMD")
 kube_controller_manager_cmd=$(fetch_kube_cmd "$CIS_MANAGER_CMD")
 kube_scheduler_cmd=$(fetch_kube_cmd "$CIS_SCHEDULER_CMD")
-etcd_cmd=$(fetch_kube_cmd "$CIS_ETCD_CMD")
+etcd_cmd=$(echo "$CIS_ETCD_CMD" | grep -m1 'Managed etcd cluster' )
 kube_proxy_cmd=$(fetch_kube_cmd "$CIS_PROXY_CMD")
 kubelet_cmd=$(fetch_kube_cmd "$CIS_KUBELET_CMD")
 

--- a/agent/nvbench/journal.tmpl
+++ b/agent/nvbench/journal.tmpl
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-CIS_APISERVER_CMD="<<<.Replace_apiserver_cmd>>>"
-CIS_MANAGER_CMD="<<<.Replace_manager_cmd>>>"
-CIS_SCHEDULER_CMD="<<<.Replace_scheduler_cmd>>>"
-CIS_ETCD_CMD="<<<.Replace_etcd_cmd>>>"
-CIS_PROXY_CMD="<<<.Replace_proxy_cmd>>>"
-CIS_KUBELET_CMD="<<<.Replace_kubelet_cmd>>>"
+CIS_APISERVER_CMD="kube-apiserver"
+CIS_MANAGER_CMD="kube-controller-manager"
+CIS_SCHEDULER_CMD="kube-scheduler"
+CIS_ETCD_CMD="etcd"
+CIS_PROXY_CMD="kube-proxy"
+CIS_KUBELET_CMD="kubelet"
 
 fetch_kube_cmd() {
     echo "$JOURNAL_LOG" |  grep "Running $1" | tail -n1   | sed "s/[\"']//g"

--- a/agent/nvbench/kube_runner.tmpl
+++ b/agent/nvbench/kube_runner.tmpl
@@ -21,6 +21,14 @@ export PATH="$PATH:$BASE_IMAGE_BIN_PATH/usr/bin:$BASE_IMAGE_BIN_PATH/bin"
 export LD_LIBRARY_PATH="$BASE_IMAGE_BIN_PATH/bin:$LD_LIBRARY_PATH"
 CONFIG_PREFIX="<<<.Replace_configPrefix_path>>>"
 
+# For k3s read journal case
+KUBE_APISERVER_CMD=""
+KUBE_CONTROLLER_MANAGER_CMD=""
+KUBE_SCHEDULER_CMD=""
+ETCD_CMD=""
+KUBE_PROXY_CMD=""
+KUBELET_CMD=""
+
 yell "# ------------------------------------------------------------------------------
 # Kubernetes CIS benchmark
 #
@@ -35,7 +43,7 @@ yell "# ------------------------------------------------------------------------
 run_check() {
   local RUN_FOLDER=$1
 
-  find $RUN_FOLDER -type f -name "*.yaml" | sort | while read -r YAML_FILE; do
+  for YAML_FILE in $(find "$RUN_FOLDER" -type f -name "*.yaml" | sort); do
     # Get the number of groups
     NUM_GROUPS=$(yq e '.groups | length' "$YAML_FILE")
 
@@ -62,13 +70,13 @@ run_check() {
             profile=$(yq e ".groups[$group_index].checks[$check_index].profile" "$YAML_FILE")
             scored=$(yq e ".groups[$group_index].checks[$check_index].scored" "$YAML_FILE")
 
-            if [ "$profile" == "Level 2" ]; then
+            if [ "$profile" = "Level 2" ]; then
                 level2=$id
             else
                 level2=""
             fi
 
-            if [ "$scored" == false ]; then
+            if [ "$scored" = false ]; then
                 not_scored=$id
             else
                 not_scored=""
@@ -84,9 +92,59 @@ run_check() {
 
 # Input folder
 folder=$1
+JOURNAL_LOG=$2
 
-# Check if folder ends with 'master' or 'worker'
-if echo "$folder" | grep -q 'master$'; then
+# In k3s, there is no specific YAML file for API server configuration as in Kubernetes.
+# Instead, k3s components are configured through various mechanisms.
+# The primary configuration file is /etc/rancher/k3s/config.yaml.
+# If /etc/rancher/k3s/config.yaml does not exist, NV will use the configuration files in the /etc/rancher/k3s/config.yaml.d directory.
+if echo "$folder" | grep -q 'k3s'; then
+    CONFIG_FILE="$CONFIG_PREFIX/etc/rancher/k3s/config.yaml"
+    CONFIG_DIR="$CONFIG_PREFIX/etc/rancher/k3s/config.yaml.d"
+    CONFIG_FILES=""
+
+    # Check if the main configuration file exists and add it to the list
+    if [ -f "$CONFIG_FILE" ]; then
+        CONFIG_FILES="$CONFIG_FILE"
+    fi
+
+    # Check if the configuration directory exists and add its files to the list
+    if [ -d "$CONFIG_DIR" ]; then
+        for file in "$CONFIG_DIR"/*.yaml; do
+            if [ -e "$file" ]; then
+                CONFIG_FILES="$CONFIG_FILES $file"
+            fi
+        done
+    fi
+    # Parse the journal string as different command with argument, the order will be the following
+    # kube-apiserver, kube-controller-manager, kube-scheduler, etcd, kube-proxy, kubelet
+    # Process each line in the string and assign to a capitalized variable with _CMD suffix
+
+    i=1
+    OLD_IFS=$IFS
+
+    # Change IFS to "@@@"
+    IFS="@@@"
+    for status in $JOURNAL_LOG; do
+        # Check if the status is not empty
+        if [ -n "$status" ]; then
+            # Assign each part to a respective variable
+            case $i in
+                1) KUBE_APISERVER_CMD="$status" ;;
+                2) KUBE_CONTROLLER_MANAGER_CMD="$status" ;;
+                3) KUBE_SCHEDULER_CMD="$status" ;;
+                4) ETCD_CMD="$status" ;;
+                5) KUBE_PROXY_CMD="$status" ;;
+                6) KUBELET_CMD="$status" ;;
+            esac
+            i=$((i + 1))
+        fi
+    done
+
+    # Restore the original IFS value
+    IFS=$OLD_IFS
+
+elif echo "$folder" | grep -q 'master$'; then
     # Check if it is a Kubernetes master node
     if ps -ef | grep "$CIS_APISERVER_CMD" 2>/dev/null | grep -v "grep" >/dev/null 2>&1; then
         info "Kubernetes Master Node Security Configuration"

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/1_control_plane_components.yaml
@@ -1135,10 +1135,10 @@ groups:
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--request-timeout' >/dev/null 2>&1; then
               requestTimeout=$(get_argument_value "$CIS_APISERVER_CMD" '--request-timeout')
-              warn "$check"
-              warn "      * request-timeout: $requestTimeout"
-          else
               pass "$check"
+              pass "      * request-timeout: $requestTimeout"
+          else
+              warn "$check"
           fi        
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           and set the below parameter as appropriate and if needed. For example, --request-timeout=300s
@@ -1156,10 +1156,10 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--service-account-lookup=false' >/dev/null 2>&1; then
-              warn "$check"
-          else
+          if check_argument "$CIS_APISERVER_CMD" '--service-account-lookup=true' >/dev/null 2>&1; then
               pass "$check"
+          else
+              warn "$check"
           fi        
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the below parameter. --service-account-lookup=true

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/1_control_plane_components.yaml
@@ -1255,10 +1255,10 @@ groups:
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--request-timeout' >/dev/null 2>&1; then
               requestTimeout=$(get_argument_value "$CIS_APISERVER_CMD" '--request-timeout')
-              warn "$check"
-              warn "      * request-timeout: $requestTimeout"
-          else
               pass "$check"
+              pass "      * request-timeout: $requestTimeout"
+          else
+              warn "$check"
           fi        
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           and set the below parameter as appropriate and if needed. For example, --request-timeout=300s
@@ -1276,10 +1276,10 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--service-account-lookup=false' >/dev/null 2>&1; then
-              warn "$check"
-          else
+          if check_argument "$CIS_APISERVER_CMD" '--service-account-lookup=true' >/dev/null 2>&1; then
               pass "$check"
+          else
+              warn "$check"
           fi        
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the below parameter. --service-account-lookup=true

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/1_control_plane_components.yaml
@@ -1108,10 +1108,10 @@ groups:
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--request-timeout' >/dev/null 2>&1; then
               requestTimeout=$(get_argument_value "$CIS_APISERVER_CMD" '--request-timeout')
-              warn "$check"
-              warn "      * request-timeout: $requestTimeout"
-          else
               pass "$check"
+              pass "      * request-timeout: $requestTimeout"
+          else
+              warn "$check"
           fi        
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           and set the below parameter as appropriate and if needed. For example, --request-timeout=300s
@@ -1129,10 +1129,10 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--service-account-lookup=false' >/dev/null 2>&1; then
-              warn "$check"
-          else
+          if check_argument "$CIS_APISERVER_CMD" '--service-account-lookup=true' >/dev/null 2>&1; then
               pass "$check"
+          else
+              warn "$check"
           fi        
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the below parameter. --service-account-lookup=true

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/master/1_control_plane_components.yaml
@@ -1,4 +1,4 @@
-version: cis-1.23
+version: cis-k3s-1.8
 id: 1
 title: 1 - Control Plane Components
 type: master
@@ -20,21 +20,21 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-apiserver.yaml")
-
-          if [ -f $file ]; then
-            if [ "$(stat -c %a $file)" -eq 600 ]; then
-              pass "$check"
-            else
-              warn "$check"
-              warn "      * Wrong permissions for $file"
-            fi
+          if [ -n "$CONFIG_FILES" ]; then
+              for config in $CONFIG_FILES; do
+                if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+                  pass "$check"
+                else
+                  warn "$check"
+                  warn "      * Wrong permissions for $file, get $(stat -c %a $file)"
+                fi
+              done
           else
-            info "$check"
-            info "      * File not found"
+              warn "$check"
+              warn "      * File not found: $CONFIG_FILES" 
           fi
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chmod 600 /etc/kubernetes/manifests/kube-apiserver.yaml
+          on the master node. For example, chmod 600 if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
       - id: K.1.1.2
         description: Ensure that the API server pod specification file ownership is
           set to root:root (Automated)
@@ -49,18 +49,21 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
-            if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-              pass "$check"
-            else
-              warn "$check"
-              warn "      * Wrong ownership for $file"
-            fi
+          if [ -n "$CONFIG_FILES" ]; then
+              for config in $CONFIG_FILES; do
+                if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+                  pass "$check"
+                else
+                  warn "$check"
+                  warn "      * Wrong permissions for $file, expect root:root, get $(stat -c %U:%G $file)"
+                fi
+              done
           else
-            info "$check"
+              warn "$check"
+              warn "      * File not found: $CONFIG_FILES" 
           fi
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chown root:root /etc/kubernetes/manifests/kube-apiserver.yaml
+          on the master node. For example, chown root:root /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
       - id: K.1.1.3
         description: Ensure that the controller manager pod specification file permissions
           are set to 600 or more restrictive (Automated)
@@ -75,21 +78,21 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
-
-          if [ -f "$file" ]; then
-            if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
-              pass "$check"
-            else
-              warn "$check"
-              warn "      * Wrong permissions for $file"
-            fi
+          if [ -n "$CONFIG_FILES" ]; then
+              for config in $CONFIG_FILES; do
+                if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+                  pass "$check"
+                else
+                  warn "$check"
+                  warn "      * Wrong permissions for $file, get $(stat -c %a $file)"
+                fi
+              done
           else
-            info "$check"
-            info "      * File not found"
+              warn "$check"
+              warn "      * File not found: $CONFIG_FILES" 
           fi
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chmod 600 /etc/kubernetes/manifests/kube-controller-manager.yaml
+          on the master node. For example, chmod 600 /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
       - id: K.1.1.4
         description: Ensure that the controller manager pod specification file ownership
           is set to root:root (Automated)
@@ -103,19 +106,22 @@ groups:
           PCI: []
           GDPR: []
         audit: |
-          check="$id  - $description"
-          if [ -f "$file" ]; then
-            if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-              pass "$check"
-            else
-              warn "$check"
-              warn "      * Wrong ownership for $file"
-            fi
+          check="$id  - $description"        
+          if [ -n "$CONFIG_FILES" ]; then
+              for config in $CONFIG_FILES; do
+                if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+                  pass "$check"
+                else
+                  warn "$check"
+                  warn "      * Wrong permissions for $file, expect root:root, get $(stat -c %U:%G $file)"
+                fi
+              done
           else
-            info "$check"
+              warn "$check"
+              warn "      * File not found: $CONFIG_FILES" 
           fi
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chown root:root /etc/kubernetes/manifests/kube-controller-manager.yaml
+          on the master node. For example, chown root:root /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
       - id: K.1.1.5
         description: Ensure that the scheduler pod specification file permissions
           are set to 600 or more restrictive (Automated)
@@ -130,21 +136,21 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
-
-          if [ -f "$file" ]; then
-            if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
-              pass "$check"
-            else
-              warn "$check"
-              warn "      * Wrong permissions for $file"
-            fi
+          if [ -n "$CONFIG_FILES" ]; then
+              for config in $CONFIG_FILES; do
+                if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+                  pass "$check"
+                else
+                  warn "$check"
+                  warn "      * Wrong permissions for $file, get $(stat -c %a $file)"
+                fi
+              done
           else
-            info "$check"
-            info "      * File not found"
+              warn "$check"
+              warn "      * File not found: $CONFIG_FILES" 
           fi
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chmod 600 /etc/kubernetes/manifests/kube-scheduler.yaml
+          on the master node. For example, chmod 600 /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
       - id: K.1.1.6
         description: Ensure that the scheduler pod specification file ownership is
           set to root:root (Automated)
@@ -159,18 +165,21 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
-            if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-              pass "$check"
-            else
-              warn "$check"
-              warn "      * Wrong ownership for $file"
-            fi
+          if [ -n "$CONFIG_FILES" ]; then
+              for config in $CONFIG_FILES; do
+                if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+                  pass "$check"
+                else
+                  warn "$check"
+                  warn "      * Wrong permissions for $file, expect root:root, get $(stat -c %U:%G $file)"
+                fi
+              done
           else
-            info "$check"
+              warn "$check"
+              warn "      * File not found: $CONFIG_FILES" 
           fi
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chown root:root /etc/kubernetes/manifests/kube-scheduler.yaml
+          on the master node. For example, chown root:root /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
       - id: K.1.1.7
         description: Ensure that the etcd pod specification file permissions are set
           to 600 or more restrictive (Automated)
@@ -185,21 +194,21 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
-
-          if [ -f "$file" ]; then
-            if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
-              pass "$check"
-            else
-              warn "$check"
-              warn "      * Wrong permissions for $file"
-            fi
+          if [ -n "$CONFIG_FILES" ]; then
+              for config in $CONFIG_FILES; do
+                if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+                  pass "$check"
+                else
+                  warn "$check"
+                  warn "      * Wrong permissions for $file, get $(stat -c %a $file)"
+                fi
+              done
           else
-            info "$check"
-            info "      * File not found"
+              warn "$check"
+              warn "      * File not found: $CONFIG_FILES" 
           fi
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chmod 600 /etc/kubernetes/manifests/etcd.yaml
+          on the master node. For example, chmod 600 /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
       - id: K.1.1.8
         description: Ensure that the etcd pod specification file ownership is set
           to root:root (Automated)
@@ -214,18 +223,21 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
-            if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-              pass "$check"
-            else
-              warn "$check"
-              warn "      * Wrong ownership for $file"
-            fi
+          if [ -n "$CONFIG_FILES" ]; then
+              for config in $CONFIG_FILES; do
+                if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+                  pass "$check"
+                else
+                  warn "$check"
+                  warn "      * Wrong permissions for $file, expect root:root, get $(stat -c %U:%G $file)"
+                fi
+              done
           else
-            info "$check"
+              warn "$check"
+              warn "      * File not found: $CONFIG_FILES" 
           fi
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chown root:root /etc/kubernetes/manifests/etcd.yaml
+          on the master node. For example, chown root:root /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
       - id: K.1.1.9
         description: Ensure that the Container Network Interface file permissions
           are set to 600 or more restrictive (Manual)
@@ -240,35 +252,21 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          # Initialize counters and non-compliant files list
-          count_files=0
-          non_compliant_files=""
-          cni_folder=$(append_prefix "$CONFIG_PREFIX" "/etc/cni/net.d")
-          for file in $(find "$cni_folder" -name "*kube*" -type f); do
-            count_files=$((count_files + 1))
-            permissions=$(stat -c %a "$file")
-
-            # Check if the permissions are more permissive than 600
-            if [ "$permissions" -gt 600 ]; then
-              non_compliant_files="$non_compliant_files$file ($permissions), "
-            fi
-          done
-
-          # Remove trailing comma and space
-          non_compliant_files=${non_compliant_files%, }
-
-          # Check and output results
-          if [ "$count_files" -eq 0 ]; then
-            warn "$check"
-            warn "      * No matching files found in $cni_folder"
-          elif [ -z "$non_compliant_files" ]; then
-            pass "$check"
+          if [ -n "$CONFIG_FILES" ]; then
+              for config in $CONFIG_FILES; do
+                if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+                  pass "$check"
+                else
+                  warn "$check"
+                  warn "      * Wrong permissions for $file, get $(stat -c %a $file)"
+                fi
+              done
           else
-            warn "$check"
-            warn "$check - Non-compliant file(s): $non_compliant_files"
+              warn "$check"
+              warn "      * File not found: $CONFIG_FILES" 
           fi
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chmod 600 the related files in etc/cni/net.d
+          on the master node. For example, chmod 600 /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
       - id: K.1.1.10
         description: Ensure that the Container Network Interface file ownership is
           set to root:root (Manual)
@@ -283,35 +281,21 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          # Initialize counters and non-compliant files list
-          count_files=0
-          non_compliant_files=""
-          cni_folder=$(append_prefix "$CONFIG_PREFIX" "/etc/cni/net.d")
-          for file in $(find "$cni_folder" -name "*kube*" -type f); do
-            count_files=$((count_files + 1))
-            permissions=$(stat -c %u%g $file)
-
-            # Check if the ownership is set to root:root 
-            if [ "$permissions" != "00" ]; then
-              non_compliant_files="$non_compliant_files$file ($permissions), "
-            fi
-          done
-
-          # Remove trailing comma and space
-          non_compliant_files=${non_compliant_files%, }
-
-          # Check and output results
-          if [ "$count_files" -eq 0 ]; then
-            warn "$check"
-            warn "      * No matching files found in $cni_folder"
-          elif [ -z "$non_compliant_files" ]; then
-            pass "$check"
+          if [ -n "$CONFIG_FILES" ]; then
+              for config in $CONFIG_FILES; do
+                if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+                  pass "$check"
+                else
+                  warn "$check"
+                  warn "      * Wrong permissions for $file, expect root:root, get $(stat -c %U:%G $file)"
+                fi
+              done
           else
-            warn "$check"
-            warn "$check - Non-compliant file(s): $non_compliant_files"
+              warn "$check"
+              warn "      * File not found: $CONFIG_FILES" 
           fi
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chown root:root the related files in etc/cni/net.d
+          on the master node. For example, chown root:root /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
       - id: K.1.1.11
         description: Ensure that the etcd data directory permissions are set to 700
           or more restrictive (Automated)
@@ -326,31 +310,26 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          file=""
-          if check_argument "$CIS_ETCD_CMD" '--data-dir' >/dev/null 2>&1; then
-              file=$(get_argument_value "$CIS_ETCD_CMD" '--data-dir'|cut -d " " -f 1)
-          fi
-          file=$(append_prefix "$CONFIG_PREFIX" "$file")
-
-          if [ -f "$file" ]; then
-            if [ "$(stat -c %a $file)" -eq 700 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+          dir=$(append_prefix "$CONFIG_PREFIX" "/var/lib/rancher/k3s/server/db/etcd")
+          if [ -d "$dir" ]; then
+            if [ "$(stat -c %a $dir)" -eq 700 -o "$(stat -c %a $dir)" -eq 600 -o "$(stat -c %a $dir)" -eq 400 ]; then
               pass "$check"
             else
               warn "$check"
-              warn "      * Wrong permissions for $file"
+              warn "      * Wrong permissions for $dir, get $(stat -c %a $dir)"
             fi
           else
-            info "$check"
-            info "      * etcd data directory not found."
+            warn "$check"
+            warn "      * etcd data directory $dir not found."
           fi
         remediation: 'On the etcd server node, get the etcd data directory, passed
           as an argument --data-dir, from the below command: ps -ef | grep etcd Run
           the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd'
+          chmod 700 /var/lib/rancher/k3s/server/db/etcd'
       - id: K.1.1.12
         description: Ensure that the etcd data directory ownership is set to etcd:etcd
           (Automated)
-        type: master
+        type: master 
         category: kubernetes
         scored: true
         profile: Level 1
@@ -361,21 +340,22 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
-            if [ "$(stat -c %U:%G $file)" = "etcd:etcd" ]; then
+          dir=$(append_prefix "$CONFIG_PREFIX" "/var/lib/rancher/k3s/server/db/etcd")
+          if [ -d "$dir" ]; then
+            if [ "$(stat -c %U:%G $dir)" = "etcd:etcd" ]; then
               pass "$check"
             else
               warn "$check"
-              warn "      * Wrong permissions for $file"
+              warn "      * Wrong permissions for $dir, expect etcd:etcd, get $(stat -c %U:%G $dir)"
             fi
           else
-            info "$check"
-            info "      * etcd data directory not found."
+            warn "$check"
+            warn "      * etcd data directory: $dir not found."
           fi
         remediation: 'On the etcd server node, get the etcd data directory, passed
           as an argument --data-dir, from the below command: ps -ef | grep etcd Run
           the below command (based on the etcd data directory found above). For example,
-          chown etcd:etcd /var/lib/etcd'
+          chown etcd:etcd /var/lib/rancher/k3s/server/db/etcd'
       - id: K.1.1.13
         description: Ensure that the admin.conf file permissions are set to 600 (Automated)
         type: master
@@ -389,7 +369,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          file="/etc/kubernetes/admin.conf"
+          file="/var/lib/rancher/k3s/server/cred/admin.kubeconfig"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
           if [ -f "$file" ]; then
@@ -397,14 +377,14 @@ groups:
               pass "$check"
             else
               warn "$check"
-              warn "      * Wrong permissions for $file"
+              warn "      * Wrong permissions for $file, get $(stat -c %a $file)"
             fi
           else
-            info "$check"
-            info "      * File not found"
+            warn "$check"
+            warn "      * File: $file not found"
           fi
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chmod 600 /etc/kubernetes/admin.conf
+          on the master node. For example, chmod 600 /var/lib/rancher/k3s/server/cred/admin.kubeconfig
       - id: K.1.1.14
         description: Ensure that the admin.conf file ownership is set to root:root
           (Automated)
@@ -424,13 +404,14 @@ groups:
               pass "$check"
             else
               warn "$check"
-              warn "      * Wrong ownership for $file"
+              warn "      * Wrong ownership for $file, expect root:root, get $(stat -c %U:%G $file)"
             fi
           else
-            info "$check"
+            warn "$check"
+            warn "      * File: $file not found"
           fi
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chown root:root /etc/kubernetes/admin.conf
+          on the master node. For example, chown root:root /var/lib/rancher/k3s/server/cred/admin.kubeconfig
       - id: K.1.1.15
         description: Ensure that the scheduler.conf file permissions are set to 600
           or more restrictive (Automated)
@@ -445,7 +426,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          file="/etc/kubernetes/scheduler.conf"
+          file="/var/lib/rancher/k3s/server/cred/scheduler.kubeconfig"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
           if [ -f "$file" ]; then
@@ -453,14 +434,14 @@ groups:
               pass "$check"
             else
               warn "$check"
-              warn "      * Wrong permissions for $file"
+              warn "      * Wrong permissions for $file, get $(stat -c %a $file)"
             fi
           else
-            info "$check"
-            info "      * File not found"
+            warn "$check"
+            warn "      * File: $file not found"
           fi
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chmod 600 /etc/kubernetes/scheduler.conf
+          on the master node. For example, chmod 600 /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig
       - id: K.1.1.16
         description: Ensure that the scheduler.conf file ownership is set to root:root
           (Automated)
@@ -480,13 +461,14 @@ groups:
               pass "$check"
             else
               warn "$check"
-              warn "      * Wrong ownership for $file"
+              warn "      * Wrong ownership for $file, expect root:root, get $(stat -c %U:%G $file)"
             fi
           else
-            info "$check"
+            warn "$check"
+            warn "      * File: $file not found"
           fi
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chown root:root /etc/kubernetes/scheduler.conf
+          on the master node. For example, chown root:root /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig
       - id: K.1.1.17
         description: Ensure that the controller-manager.conf file permissions are
           set to 600 or more restrictive (Automated)
@@ -501,7 +483,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          file="/etc/kubernetes/controller-manager.conf"
+          file="/var/lib/rancher/k3s/server/cred/controller.kubeconfig"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
           if [ -f "$file" ]; then
@@ -509,14 +491,14 @@ groups:
               pass "$check"
             else
               warn "$check"
-              warn "      * Wrong permissions for $file"
+              warn "      * Wrong permissions for $file, get $(stat -c %a $file)"
             fi
           else
-            info "$check"
-            info "      * File not found"
-          fi        
+            warn "$check"
+            warn "      * File: $file not found"
+          fi     
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chmod 600 /etc/kubernetes/controller-manager.conf
+          on the master node. For example, chmod 600 /var/lib/rancher/k3s/server/cred/controller.kubeconfig
       - id: K.1.1.18
         description: Ensure that the controller-manager.conf file ownership is set
           to root:root (Automated)
@@ -536,13 +518,14 @@ groups:
               pass "$check"
             else
               warn "$check"
-              warn "      * Wrong ownership for $file"
+              warn "      * Wrong ownership for $file, expect root:root, get $(stat -c %U:%G $file)"
             fi
           else
-            info "$check"
-          fi        
+            warn "$check"
+            warn "      * File: $file not found"
+          fi   
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chown root:root /etc/kubernetes/controller-manager.conf
+          on the master node. For example, chown root:root /var/lib/rancher/k3s/server/cred/controller.kubeconfig
       - id: K.1.1.19
         description: Ensure that the Kubernetes PKI directory and file ownership is
           set to root:root (Automated)
@@ -557,7 +540,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          file="/etc/kubernetes/pki/"
+          file="/var/lib/rancher/k3s/server/tls"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
           files=$(find $file)
           pass=true
@@ -574,7 +557,7 @@ groups:
             warn "$check"
           fi
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chown -R root:root /etc/kubernetes/pki/
+          on the master node. For example, chown -R root:root /var/lib/rancher/k3s/server/tls
       - id: K.1.1.20
         description: Ensure that the Kubernetes PKI certificate file permissions are
           set to 600 or more restrictive (Manual)
@@ -604,7 +587,7 @@ groups:
             warn "$check"
           fi        
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chmod -R 600 /etc/kubernetes/pki/*.crt
+          on the master node. For example, chmod -R 600 /var/lib/rancher/k3s/server/tls/*.crt
       - id: K.1.1.21
         description: Ensure that the Kubernetes PKI key file permissions are set to
           600 (Manual)
@@ -634,7 +617,7 @@ groups:
             warn "$check"
           fi
         remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chmod -R 600 /etc/kubernetes/pki/*.key
+          on the master node. For example, chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
   - id: 1.2
     title: 1.2 - API Server
     checks:
@@ -651,12 +634,13 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
               pass "$check"
           else
               warn "$check"
-          fi        
-        remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+              warn "      * found: $(check_argument_from_journal "$KUBE_APISERVER_CMD" '--anonymous-auth=false')" 
+          fi              
+        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
           on the master node and set the below parameter. --anonymous-auth=false
       - id: K.1.2.2
         description: Ensure that the --token-auth-file parameter is not set (Automated)
@@ -671,16 +655,17 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--token-auth-file' >/dev/null 2>&1; then
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--token-auth-file' >/dev/null 2>&1; then
               warn "$check"
+              warn "      * found: $(check_argument_from_journal "$KUBE_APISERVER_CMD" '--token-auth-file')" 
           else
               pass "$check"
-          fi
+          fi             
         remediation: Follow the documentation and configure alternate mechanisms for
-          authentication. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+          authentication. Then, edit the API server pod specification file /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
           on the master node and remove the --token-auth-file=<filename> parameter.
       - id: K.1.2.3
-        description: Ensure that the --DenyServiceExternalIPs is not set (Automated)
+        description: Ensure that the DenyServiceExternalIPs is set (Manual)
         type: master
         category: kubernetes
         scored: true
@@ -692,13 +677,15 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--DenyServiceExternalIPs' >/dev/null 2>&1; then
-              warn "$check"
-          else
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--disable-admission-plugins=DenyServiceExternalIP' >/dev/null 2>&1; then
               pass "$check"
+          elif check_argument_from_journal "$KUBE_APISERVER_CMD" '--enable-admission-plugins=DenyServiceExternalIP' >/dev/null 2>&1; then
+              pass "$check"
+          else
+              warn "$check"
           fi
         remediation: |
-          Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and remove the `-- DenyServiceExternalIPs'parameter or The Kubernetes API server flag disable-admission-plugins takes a comma-delimited list of admission control plugins to be disabled, even if they are in the list of plugins enabled by default. kube-apiserver --disable-admission-plugins=DenyServiceExternalIPs,AlwaysDeny...
+          Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory) on the master node and remove the `--DenyServiceExternalIPs'parameter or The Kubernetes API server flag disable-admission-plugins takes a comma-delimited list of admission control plugins to be disabled, even if they are in the list of plugins enabled by default. kube-apiserver --disable-admission-plugins=DenyServiceExternalIPs,AlwaysDeny...
       - id: K.1.2.4
         description: Ensure that the --kubelet-client-certificate and --kubelet-client-key
           arguments are set as appropriate (Automated)
@@ -713,10 +700,10 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--kubelet-client-certificate' >/dev/null 2>&1; then
-              if check_argument "$CIS_APISERVER_CMD" '--kubelet-client-key' >/dev/null 2>&1; then
-                  certificate=$(get_argument_value "$CIS_APISERVER_CMD" '--kubelet-client-certificate')
-                  key=$(get_argument_value "$CIS_APISERVER_CMD" '--kubelet-client-key')
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--kubelet-client-certificate' >/dev/null 2>&1; then
+              if check_argument_from_journal "$KUBE_APISERVER_CMD" '--kubelet-client-key' >/dev/null 2>&1; then
+                  certificate=$(get_argument_value_from_journal_from_journal "$KUBE_APISERVER_CMD" '--kubelet-client-certificate')
+                  key=$(get_argument_value_from_journal_from_journal "$KUBE_APISERVER_CMD" '--kubelet-client-key')
                   pass "$check"
                   pass "      * kubelet-client-certificate: $certificate"
                   pass "      * kubelet-client-key: $key"
@@ -728,7 +715,7 @@ groups:
           fi  
         remediation: Follow the Kubernetes documentation and set up the TLS connection
           between the apiserver and kubelets. Then, edit API server pod specification
-          file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and
+          file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory) on the master node and
           set the kubelet client certificate and key parameters as below. --kubelet-client-certificate=<path/to/client-certificate-file>
           --kubelet-client-key=<path/to/client-key-file>
       - id: K.1.2.5
@@ -745,14 +732,14 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--kubelet-certificate-authority' >/dev/null 2>&1; then
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--kubelet-certificate-authority' >/dev/null 2>&1; then
               pass "$check"
           else
               warn "$check"
           fi        
         remediation: Follow the Kubernetes documentation and setup the TLS connection
           between the apiserver and kubelets. Then, edit the API server pod specification
-          file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and
+          file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory) on the master node and
           set the -- kubelet-certificate-authority parameter to the path to the cert
           file for the certificate authority. --kubelet-certificate-authority=<ca-string>
       - id: K.1.2.6
@@ -769,12 +756,12 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'AlwaysAllow' >/dev/null 2>&1; then
+          if get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--authorization-mode'| grep 'AlwaysAllow' >/dev/null 2>&1; then
               warn "$check"
           else
               pass "$check"
           fi        
-        remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the --authorization-mode parameter to values
           other than AlwaysAllow . One such example could be as below. --authorization-mode=RBAC
       - id: K.1.2.7
@@ -790,12 +777,12 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'Node' >/dev/null 2>&1; then
+          if get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--authorization-mode'| grep 'Node' >/dev/null 2>&1; then
               pass "$check"
           else
               warn "$check"
           fi        
-        remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the --authorization-mode parameter to a value
           that includes Node . --authorization-mode=Node,RBAC
       - id: K.1.2.8
@@ -811,12 +798,12 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if get_argument_value "$CIS_APISERVER_CMD" '--authorization-mode'| grep 'RBAC' >/dev/null 2>&1; then
+          if get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--authorization-mode'| grep 'RBAC' >/dev/null 2>&1; then
               pass "$check"
           else
               warn "$check"
           fi
-        remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the --authorization-mode parameter to a value
           that includes RBAC, for example:--authorization-mode=Node,RBAC
       - id: K.1.2.9
@@ -832,14 +819,14 @@ groups:
           PCI: []
         audit: |
           check="$id  - $description"
-          if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'EventRateLimit' >/dev/null 2>&1; then
+          if get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--enable-admission-plugins'| grep 'EventRateLimit' >/dev/null 2>&1; then
               pass "$check"
           else
               warn "$check"
           fi        
         remediation: Follow the Kubernetes documentation and set the desired limits
           in a configuration file. Then, edit the API server pod specification file
-          /etc/kubernetes/manifests/kube-apiserver.yaml and set the below parameters.  --enable-admission-plugins=...,EventRateLimit,...
+          /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory) and set the below parameters.  --enable-admission-plugins=...,EventRateLimit,...
           --admission-control-config-file=<path/to/configuration/file>
       - id: K.1.2.10
         description: Ensure that the admission control plugin AlwaysAdmit is not set
@@ -854,12 +841,12 @@ groups:
           PCI: []
         audit: |
           check="$id  - $description"
-          if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysAdmit' >/dev/null 2>&1; then
+          if get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysAdmit' >/dev/null 2>&1; then
               warn "$check"
           else
               pass "$check"
           fi        
-        remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and either remove the --enable-admission-plugins parameter,
           or set it to a value that does not include AlwaysAdmit.
       - id: K.1.2.11
@@ -875,12 +862,12 @@ groups:
           PCI: []
         audit: |
           check="$id  - $description"
-          if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysPullImages' >/dev/null 2>&1; then
+          if get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--enable-admission-plugins'| grep 'AlwaysPullImages' >/dev/null 2>&1; then
               pass "$check"
           else
               warn "$check"
           fi        
-        remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the --enable-admission-plugins parameter to include
           AlwaysPullImages.  --enable-admission-plugins=...,AlwaysPullImages,...
       - id: K.1.2.12
@@ -896,16 +883,16 @@ groups:
           PCI: []
         audit: |
           check="$id  - $description"
-          if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'PodSecurityPolicy' >/dev/null 2>&1; then
+          if get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--enable-admission-plugins'| grep 'PodSecurityPolicy' >/dev/null 2>&1; then
               pass "$check"
           else
-            if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'SecurityContextDeny' >/dev/null 2>&1; then
+            if get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--enable-admission-plugins'| grep 'SecurityContextDeny' >/dev/null 2>&1; then
               pass "$check"
             else
               warn "$check"
             fi
           fi        
-        remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the --enable-admission-plugins parameter to include
           SecurityContextDeny, unless PodSecurityPolicy is already in place.  --enable-admission-plugins=...,SecurityContextDeny,...
       - id: K.1.2.13
@@ -921,13 +908,13 @@ groups:
           PCI: []
         audit: |
           check="$id  - $description"
-          if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'ServiceAccount' >/dev/null 2>&1; then
+          if get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--disable-admission-plugins'| grep 'ServiceAccount' >/dev/null 2>&1; then
               warn "$check"
           else
               pass "$check"
           fi        
         remediation: Follow the documentation and create ServiceAccount objects as
-          per your environment. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+          per your environment. Then, edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and ensure that the --disable-admission-plugins parameter
           is set to a value that does not include ServiceAccount.
       - id: K.1.2.14
@@ -943,12 +930,12 @@ groups:
           PCI: []
         audit: |
           check="$id  - $description"
-          if get_argument_value "$CIS_APISERVER_CMD" '--disable-admission-plugins'| grep 'NamespaceLifecycle' >/dev/null 2>&1; then
+          if get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--disable-admission-plugins'| grep 'NamespaceLifecycle' >/dev/null 2>&1; then
               warn "$check"
           else
               pass "$check"
           fi
-        remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the --disable-admission-plugins parameter to
           ensure it does not include NamespaceLifecycle.
       - id: K.1.2.15
@@ -964,43 +951,16 @@ groups:
           PCI: []
         audit: |
           check="$id  - $description"
-          if get_argument_value "$CIS_APISERVER_CMD" '--enable-admission-plugins'| grep 'NodeRestriction' >/dev/null 2>&1; then
+          if get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--enable-admission-plugins'| grep 'NodeRestriction' >/dev/null 2>&1; then
               pass "$check"
           else
               warn "$check"
           fi
         remediation: Follow the Kubernetes documentation and configure NodeRestriction
-          plug-in on kubelets. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+          plug-in on kubelets. Then, edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the --enable-admission-plugins parameter to a
           value that includes NodeRestriction. --enable-admission-plugins=...,NodeRestriction,...
       - id: K.1.2.16
-        description: Ensure that the --secure-port argument is not set to 0 (Automated)
-        type: master
-        category: kubernetes
-        scored: true
-        profile: Level 1
-        automated: true
-        tags:
-          HIPAA: []
-          PCI: []
-          GDPR: []
-        audit: |
-          check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--secure-port' >/dev/null 2>&1; then
-              port=$(get_argument_value "$CIS_APISERVER_CMD" '--secure-port'|cut -d " " -f 1)
-              if [ "$port" = "0" ]; then
-                  warn "$check"
-                  warn "      * secure-port: $port"
-              else
-                  pass "$check"
-              fi
-          else
-              pass "$check"
-          fi        
-        remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
-          on the master node and either remove the --secure-port parameter or set
-          it to a different (non-zero) desired port.
-      - id: K.1.2.17
         description: Ensure that the --profiling argument is set to false (Automated)
         type: master
         category: kubernetes
@@ -1010,14 +970,14 @@ groups:
         tags: {}
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--profiling=false' >/dev/null 2>&1; then
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--profiling=false' >/dev/null 2>&1; then
               pass "$check"
           else
               warn "$check"
           fi        
-        remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the below parameter. --profiling=false
-      - id: K.1.2.18
+      - id: K.1.2.17
         description: Ensure that the --audit-log-path argument is set (Automated)
         type: master
         category: kubernetes
@@ -1029,16 +989,16 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--audit-log-path' >/dev/null 2>&1; then
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--audit-log-path' >/dev/null 2>&1; then
               pass "$check"
           else
               warn "$check"
           fi        
-        remediation: 'Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+        remediation: 'Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the --audit-log-path parameter to a suitable
           path and file where you would like audit logs to be written, for example:
           --audit-log-path=/var/log/apiserver/audit.log'
-      - id: K.1.2.19
+      - id: K.1.2.18
         description: Ensure that the --audit-log-maxage argument is set to 30 or as
           appropriate (Automated)
         type: master
@@ -1051,8 +1011,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxage' >/dev/null 2>&1; then
-              maxage=$(get_argument_value "$CIS_APISERVER_CMD" '--audit-log-maxage'|cut -d " " -f 1)
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--audit-log-maxage' >/dev/null 2>&1; then
+              maxage=$(get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--audit-log-maxage'|cut -d " " -f 1)
               if [ "$maxage" -ge "30" ]; then
                   pass "$check"
                   pass "      * audit-log-maxage: $maxage"
@@ -1063,10 +1023,10 @@ groups:
           else
               warn "$check"
           fi 
-        remediation: 'Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+        remediation: 'Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the --audit-log-maxage parameter to 30 or as
           an appropriate number of days: --audit-log-maxage=30'
-      - id: K.1.2.20
+      - id: K.1.2.19
         description: Ensure that the --audit-log-maxbackup argument is set to 10 or
           as appropriate (Automated)
         type: master
@@ -1079,8 +1039,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxbackup' >/dev/null 2>&1; then
-              maxbackup=$(get_argument_value "$CIS_APISERVER_CMD" '--audit-log-maxbackup'|cut -d " " -f 1)
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--audit-log-maxbackup' >/dev/null 2>&1; then
+              maxbackup=$(get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--audit-log-maxbackup'|cut -d " " -f 1)
               if [ "$maxbackup" -ge "10" ]; then
                   pass "$check"
                   pass "      * audit-log-maxbackup: $maxbackup"
@@ -1091,10 +1051,10 @@ groups:
           else
               warn "$check"
           fi
-        remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the --audit-log-maxbackup parameter to 10 or
           to an appropriate value. --audit-log-maxbackup=10
-      - id: K.1.2.21
+      - id: K.1.2.20
         description: Ensure that the --audit-log-maxsize argument is set to 100 or
           as appropriate (Automated)
         type: master
@@ -1107,8 +1067,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--audit-log-maxsize' >/dev/null 2>&1; then
-              maxsize=$(get_argument_value "$CIS_APISERVER_CMD" '--audit-log-maxsize'|cut -d " " -f 1)
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--audit-log-maxsize' >/dev/null 2>&1; then
+              maxsize=$(get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--audit-log-maxsize'|cut -d " " -f 1)
               if [ "$maxsize" -ge "100" ]; then
                   pass "$check"
                   pass "      * audit-log-maxsize: $maxsize"
@@ -1119,10 +1079,10 @@ groups:
           else
               warn "$check"
           fi
-        remediation: 'Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+        remediation: 'Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the --audit-log-maxsize parameter to an appropriate
           size in MB. For example, to set it as 100 MB: --audit-log-maxsize=100'
-      - id: K.1.2.22
+      - id: K.1.2.21
         description: Ensure that the --request-timeout argument is set as appropriate
           (Manual)
         type: master
@@ -1133,16 +1093,16 @@ groups:
         tags: {}
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--request-timeout' >/dev/null 2>&1; then
-              requestTimeout=$(get_argument_value "$CIS_APISERVER_CMD" '--request-timeout')
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--request-timeout' >/dev/null 2>&1; then
+              requestTimeout=$(get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--request-timeout')
               pass "$check"
               pass "      * request-timeout: $requestTimeout"
           else
               warn "$check"
           fi        
-        remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           and set the below parameter as appropriate and if needed. For example, --request-timeout=300s
-      - id: K.1.2.23
+      - id: K.1.2.22
         description: Ensure that the --service-account-lookup argument is set to true
           (Automated)
         type: master
@@ -1156,14 +1116,14 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--service-account-lookup=true' >/dev/null 2>&1; then
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--service-account-lookup=true' >/dev/null 2>&1; then
               pass "$check"
           else
               warn "$check"
           fi        
-        remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the below parameter. --service-account-lookup=true
-      - id: K.1.2.24
+      - id: K.1.2.23
         description: Ensure that the --service-account-key-file argument is set as
           appropriate (Automated)
         type: master
@@ -1177,18 +1137,18 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
-              file=$(get_argument_value "$CIS_APISERVER_CMD" '--service-account-key-file')
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--service-account-key-file' >/dev/null 2>&1; then
+              file=$(get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--service-account-key-file')
               file=$(append_prefix "$CONFIG_PREFIX" "$file")
               pass "$check"
               pass "      * service-account-key-file: $file"
           else
               warn "$check"
           fi        
-        remediation: 'Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+        remediation: 'Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the --service-account-key-file parameter to the
           public key file for service accounts: --service-account-key-file=<filename>'
-      - id: K.1.2.25
+      - id: K.1.2.24
         description: Ensure that the --etcd-certfile and --etcd-keyfile arguments
           are set as appropriate (Automated)
         type: master
@@ -1202,10 +1162,10 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
-              if check_argument "$CIS_APISERVER_CMD" '--etcd-keyfile' >/dev/null 2>&1; then
-                  certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-certfile')
-                  keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-keyfile')
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--etcd-certfile' >/dev/null 2>&1; then
+              if check_argument_from_journal "$KUBE_APISERVER_CMD" '--etcd-keyfile' >/dev/null 2>&1; then
+                  certfile=$(get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--etcd-certfile')
+                  keyfile=$(get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--etcd-keyfile')
                   certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
                   keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
                   pass "$check"
@@ -1219,10 +1179,10 @@ groups:
           fi
         remediation: Follow the Kubernetes documentation and set up the TLS connection
           between the apiserver and etcd. Then, edit the API server pod specification
-          file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and
+          file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory) on the master node and
           set the etcd certificate and key file parameters.  --etcd-certfile=<path/to/client-certificate-file>
           --etcd-keyfile=<path/to/client-key-file>
-      - id: K.1.2.26
+      - id: K.1.2.25
         description: Ensure that the --tls-cert-file and --tls-private-key-file arguments
           are set as appropriate (Automated)
         type: master
@@ -1236,10 +1196,10 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
-              if check_argument "$CIS_APISERVER_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
-                  certfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-cert-file')
-                  keyfile=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-private-key-file')
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--tls-cert-file' >/dev/null 2>&1; then
+              if check_argument_from_journal "$KUBE_APISERVER_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
+                  certfile=$(get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--tls-cert-file')
+                  keyfile=$(get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--tls-private-key-file')
                   certfile=$(append_prefix "$CONFIG_PREFIX" "$certfile")
                   keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
                   pass "$check"
@@ -1252,10 +1212,10 @@ groups:
               warn "$check"
           fi        
         remediation: Follow the Kubernetes documentation and set up the TLS connection
-          on the apiserver. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+          on the apiserver. Then, edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the TLS certificate and private key file parameters.
           --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key-file=<path/to/tls-key-file>
-      - id: K.1.2.27
+      - id: K.1.2.26
         description: Ensure that the --client-ca-file argument is set as appropriate
           (Automated)
         type: master
@@ -1269,8 +1229,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
-              cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--client-ca-file')
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--client-ca-file' >/dev/null 2>&1; then
+              cafile=$(get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--client-ca-file')
               cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
               pass "$check"
               pass "      * client-ca-file: $cafile"
@@ -1278,9 +1238,9 @@ groups:
               warn "$check"
           fi
         remediation: Follow the Kubernetes documentation and set up the TLS connection
-          on the apiserver. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+          on the apiserver. Then, edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the client certificate authority file. --client-ca-file=<path/to/client-ca-file>
-      - id: K.1.2.28
+      - id: K.1.2.27
         description: Ensure that the --etcd-cafile argument is set as appropriate
           (Automated)
         type: master
@@ -1294,8 +1254,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
-              cafile=$(get_argument_value "$CIS_APISERVER_CMD" '--etcd-cafile')
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--etcd-cafile' >/dev/null 2>&1; then
+              cafile=$(get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--etcd-cafile')
               cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
               pass "$check"
               pass "      * etcd-cafile: $cafile"
@@ -1304,9 +1264,9 @@ groups:
           fi        
         remediation: Follow the Kubernetes documentation and set up the TLS connection
           between the apiserver and etcd. Then, edit the API server pod specification
-          file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and
+          file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory) on the master node and
           set the etcd certificate authority file parameter. --etcd-cafile=<path/to/ca-file>
-      - id: K.1.2.29
+      - id: K.1.2.28
         description: Ensure that the --encryption-provider-config argument is set
           as appropriate (Manual)
         type: master
@@ -1320,16 +1280,16 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if get_argument_value "$CIS_APISERVER_CMD" '--encryption-provider-config'| grep 'EncryptionConfig' >/dev/null 2>&1; then
+          if get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--encryption-provider-config'| grep 'EncryptionConfig' >/dev/null 2>&1; then
               pass "$check"
           else
               warn "$check"
           fi     
         remediation: 'Follow the Kubernetes documentation and configure a EncryptionConfig
-          file. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+          file. Then, edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the --encryption-provider-config parameter to
           the path of that file: --encryption-provider-config=</path/to/EncryptionConfig/File>'
-      - id: K.1.2.30
+      - id: K.1.2.29
         description: Ensure that encryption providers are appropriately configured
           (Manual)
         type: master
@@ -1343,8 +1303,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--encryption-provider-config' >/dev/null 2>&1; then
-              encryptionConfig=$(get_argument_value "$CIS_APISERVER_CMD" '--encryption-provider-config')
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--encryption-provider-config' >/dev/null 2>&1; then
+              encryptionConfig=$(get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--encryption-provider-config')
               if [ -f "$encryptionConfig" ]; then
                 if [ $(grep -c "\- aescbc:\|\- kms:\|\- secretbox:" $encryptionConfig) -ne 0 ]; then
                   pass "$check"
@@ -1359,7 +1319,7 @@ groups:
           fi        
         remediation: Follow the Kubernetes documentation and configure a EncryptionConfig
           file. In this file, choose aescbc, kms or secretbox as the encryption provider.
-      - id: K.1.2.31
+      - id: K.1.2.30
         description: Ensure that the API Server only makes use of Strong Cryptographic
           Ciphers (Manual)
         type: master
@@ -1373,8 +1333,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_APISERVER_CMD" '--tls-cipher-suites' >/dev/null 2>&1; then
-              ciphers=$(get_argument_value "$CIS_APISERVER_CMD" '--tls-cipher-suites'|cut -d " " -f 1)
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--tls-cipher-suites' >/dev/null 2>&1; then
+              ciphers=$(get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--tls-cipher-suites'|cut -d " " -f 1)
               found=$(echo $ciphers| sed -rn '/(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305|TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305|TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384)/p')
               if [ ! -z "$found" ]; then
                 pass "$check"
@@ -1385,7 +1345,7 @@ groups:
               warn "$check"
           fi        
         remediation: |
-          Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and set the below parameter.
+          Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory) on the Control Plane node and set the below parameter.
           --tls-cipher-suites=TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384,
           TLS_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
           TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
@@ -1415,14 +1375,14 @@ groups:
           check="$id  - $description"
           # Filter out processes like "/bin/tee -a /var/log/kube-controller-manager.log"
           # which exist on kops-managed clusters.
-          if check_argument "$CIS_MANAGER_CMD" '--terminated-pod-gc-threshold' >/dev/null 2>&1; then
-              threshold=$(get_argument_value "$CIS_MANAGER_CMD" '--terminated-pod-gc-threshold')
+          if check_argument_from_journal "$KUBE_CONTROLLER_MANAGER_CMD" '--terminated-pod-gc-threshold' >/dev/null 2>&1; then
+              threshold=$(get_argument_value_from_journal "$KUBE_CONTROLLER_MANAGER_CMD" '--terminated-pod-gc-threshold')
               pass "$check"
               pass "      * terminated-pod-gc-threshold: $threshold"
           else
               warn "$check"
           fi        
-        remediation: 'Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
+        remediation: 'Edit the Controller Manager pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the --terminated-pod-gc-threshold to an appropriate
           threshold, for example: --terminated-pod-gc-threshold=10'
       - id: K.1.3.2
@@ -1435,12 +1395,12 @@ groups:
         tags: {}
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_MANAGER_CMD" '--profiling=false' >/dev/null 2>&1; then
+          if check_argument_from_journal "$KUBE_CONTROLLER_MANAGER_CMD" '--profiling=false' >/dev/null 2>&1; then
               pass "$check"
           else
               warn "$check"
           fi        
-        remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
+        remediation: Edit the Controller Manager pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the below parameter. --profiling=false
       - id: K.1.3.3
         description: Ensure that the --use-service-account-credentials argument is
@@ -1456,12 +1416,12 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_MANAGER_CMD" '--use-service-account-credentials=true' >/dev/null 2>&1; then
+          if check_argument_from_journal "$KUBE_CONTROLLER_MANAGER_CMD" '--use-service-account-credentials=true' >/dev/null 2>&1; then
               pass "$check"
           else
               warn "$check"
           fi        
-        remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
+        remediation: Edit the Controller Manager pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node to set the below parameter. --use-service-account-credentials=true
       - id: K.1.3.4
         description: Ensure that the --service-account-private-key-file argument is
@@ -1477,16 +1437,16 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
-              keyfile=$(get_argument_value "$CIS_MANAGER_CMD" '--service-account-private-key-file')
+          if check_argument_from_journal "$KUBE_CONTROLLER_MANAGER_CMD" '--service-account-private-key-file' >/dev/null 2>&1; then
+              keyfile=$(get_argument_value_from_journal "$KUBE_CONTROLLER_MANAGER_CMD" '--service-account-private-key-file')
               keyfile=$(append_prefix "$CONFIG_PREFIX" "$keyfile")
               pass "$check"
               pass "      * service-account-private-key-file: $keyfile"
           else
               warn "$check"
           fi        
-        remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
-          on the master node and set the --service-account-private-key-file parameter
+        remediation: Edit the Controller Manager pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
+          on the master node and set the --service-account-privat-key-file parameter
           to the private key file for service accounts. --service-account-private-key-file=<filename>
       - id: K.1.3.5
         description: Ensure that the --root-ca-file argument is set as appropriate
@@ -1502,15 +1462,15 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
-              cafile=$(get_argument_value "$CIS_MANAGER_CMD" '--root-ca-file')
+          if check_argument_from_journal "$KUBE_CONTROLLER_MANAGER_CMD" '--root-ca-file' >/dev/null 2>&1; then
+              cafile=$(get_argument_value_from_journal "$KUBE_CONTROLLER_MANAGER_CMD" '--root-ca-file')
               cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
               pass "$check"
               pass "      * root-ca-file: $cafile"
           else
               warn "$check"
           fi        
-        remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
+        remediation: Edit the Controller Manager pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the --root-ca-file parameter to the certificate
           bundle file`. --root-ca-file=<path/to/file>
       - id: K.1.3.6
@@ -1527,8 +1487,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_MANAGER_CMD" '--feature-gates' >/dev/null 2>&1; then
-              serverCert=$(get_argument_value "$CIS_MANAGER_CMD" '--feature-gates')
+          if check_argument_from_journal "$KUBE_CONTROLLER_MANAGER_CMD" '--feature-gates' >/dev/null 2>&1; then
+              serverCert=$(get_argument_value_from_journal "$KUBE_CONTROLLER_MANAGER_CMD" '--feature-gates')
               found=$(echo $serverCert| grep 'RotateKubeletServerCertificate=true')
               if [ ! -z $found ]; then
                 pass "$check"
@@ -1538,7 +1498,7 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
+        remediation: Edit the Controller Manager pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
           --feature-gates=RotateKubeletServerCertificate=true
       - id: K.1.3.7
@@ -1551,12 +1511,12 @@ groups:
         tags: {}
         audit: |
           check="$id  - $description"
-          if get_argument_value "$CIS_MANAGER_CMD" '--bind-address'| grep '127.0.0.1' >/dev/null 2>&1; then
+          if get_argument_value_from_journal "$KUBE_CONTROLLER_MANAGER_CMD" '--bind-address'| grep '127.0.0.1' >/dev/null 2>&1; then
               pass "$check"
           else
               warn "$check"
           fi        
-        remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
+        remediation: Edit the Controller Manager pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and ensure the correct value for the --bind-address parameter.
   - id: 1.4
     title: 1.4 - Scheduler
@@ -1571,12 +1531,12 @@ groups:
         tags: {}
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_SCHEDULER_CMD" '--profiling=false' >/dev/null 2>&1; then
+          if check_argument_from_journal "$KUBE_SCHEDULER_CMD" '--profiling=false' >/dev/null 2>&1; then
               pass "$check"
           else
               warn "$check"
           fi        
-        remediation: Edit the Scheduler pod specification file /etc/kubernetes/manifests/kube-scheduler.yaml
+        remediation: Edit the Scheduler pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           file on the master node and set the below parameter. --profiling=false
       - id: K.1.4.2
         description: Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)
@@ -1588,10 +1548,10 @@ groups:
         tags: {}
         audit: |
           check="$id  - $description"
-          if get_argument_value "$CIS_SCHEDULER_CMD" '--bind-address'| grep '127.0.0.1' >/dev/null 2>&1; then
+          if get_argument_value_from_journal "$KUBE_SCHEDULER_CMD" '--bind-address'| grep '127.0.0.1' >/dev/null 2>&1; then
               pass "$check"
           else
               warn "$check"
           fi        
-        remediation: Edit the Scheduler pod specification file /etc/kubernetes/manifests/kube-scheduler.yaml
+        remediation: Edit the Scheduler pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
           on the master node and ensure the correct value for the --bind-address parameter

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/master/1_control_plane_components.yaml
@@ -20,21 +20,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -n "$CONFIG_FILES" ]; then
-              for config in $CONFIG_FILES; do
-                if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
-                  pass "$check"
-                else
-                  warn "$check"
-                  warn "      * Wrong permissions for $file, get $(stat -c %a $file)"
-                fi
-              done
-          else
-              warn "$check"
-              warn "      * File not found: $CONFIG_FILES" 
-          fi
-        remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chmod 600 if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
+          pass "$check"
+        remediation: By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
       - id: K.1.1.2
         description: Ensure that the API server pod specification file ownership is
           set to root:root (Automated)
@@ -49,21 +36,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -n "$CONFIG_FILES" ]; then
-              for config in $CONFIG_FILES; do
-                if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-                  pass "$check"
-                else
-                  warn "$check"
-                  warn "      * Wrong permissions for $file, expect root:root, get $(stat -c %U:%G $file)"
-                fi
-              done
-          else
-              warn "$check"
-              warn "      * File not found: $CONFIG_FILES" 
-          fi
-        remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chown root:root /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
+          pass "$check"
+        remediation: By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
       - id: K.1.1.3
         description: Ensure that the controller manager pod specification file permissions
           are set to 600 or more restrictive (Automated)
@@ -78,21 +52,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -n "$CONFIG_FILES" ]; then
-              for config in $CONFIG_FILES; do
-                if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
-                  pass "$check"
-                else
-                  warn "$check"
-                  warn "      * Wrong permissions for $file, get $(stat -c %a $file)"
-                fi
-              done
-          else
-              warn "$check"
-              warn "      * File not found: $CONFIG_FILES" 
-          fi
-        remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chmod 600 /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
+          pass "$check"
+        remediation: By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
       - id: K.1.1.4
         description: Ensure that the controller manager pod specification file ownership
           is set to root:root (Automated)
@@ -106,22 +67,9 @@ groups:
           PCI: []
           GDPR: []
         audit: |
-          check="$id  - $description"        
-          if [ -n "$CONFIG_FILES" ]; then
-              for config in $CONFIG_FILES; do
-                if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-                  pass "$check"
-                else
-                  warn "$check"
-                  warn "      * Wrong permissions for $file, expect root:root, get $(stat -c %U:%G $file)"
-                fi
-              done
-          else
-              warn "$check"
-              warn "      * File not found: $CONFIG_FILES" 
-          fi
-        remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chown root:root /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
+          check="$id  - $description"  
+          pass "$check"      
+        remediation: By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
       - id: K.1.1.5
         description: Ensure that the scheduler pod specification file permissions
           are set to 600 or more restrictive (Automated)
@@ -136,21 +84,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -n "$CONFIG_FILES" ]; then
-              for config in $CONFIG_FILES; do
-                if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
-                  pass "$check"
-                else
-                  warn "$check"
-                  warn "      * Wrong permissions for $file, get $(stat -c %a $file)"
-                fi
-              done
-          else
-              warn "$check"
-              warn "      * File not found: $CONFIG_FILES" 
-          fi
-        remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chmod 600 /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
+          pass "$check"
+        remediation: By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
       - id: K.1.1.6
         description: Ensure that the scheduler pod specification file ownership is
           set to root:root (Automated)
@@ -165,21 +100,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -n "$CONFIG_FILES" ]; then
-              for config in $CONFIG_FILES; do
-                if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-                  pass "$check"
-                else
-                  warn "$check"
-                  warn "      * Wrong permissions for $file, expect root:root, get $(stat -c %U:%G $file)"
-                fi
-              done
-          else
-              warn "$check"
-              warn "      * File not found: $CONFIG_FILES" 
-          fi
-        remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chown root:root /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
+          pass "$check"
+        remediation: By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
       - id: K.1.1.7
         description: Ensure that the etcd pod specification file permissions are set
           to 600 or more restrictive (Automated)
@@ -194,21 +116,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -n "$CONFIG_FILES" ]; then
-              for config in $CONFIG_FILES; do
-                if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
-                  pass "$check"
-                else
-                  warn "$check"
-                  warn "      * Wrong permissions for $file, get $(stat -c %a $file)"
-                fi
-              done
-          else
-              warn "$check"
-              warn "      * File not found: $CONFIG_FILES" 
-          fi
-        remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chmod 600 /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
+          pass "$check"
+        remediation: By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
       - id: K.1.1.8
         description: Ensure that the etcd pod specification file ownership is set
           to root:root (Automated)
@@ -223,21 +132,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -n "$CONFIG_FILES" ]; then
-              for config in $CONFIG_FILES; do
-                if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-                  pass "$check"
-                else
-                  warn "$check"
-                  warn "      * Wrong permissions for $file, expect root:root, get $(stat -c %U:%G $file)"
-                fi
-              done
-          else
-              warn "$check"
-              warn "      * File not found: $CONFIG_FILES" 
-          fi
-        remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chown root:root /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
+          pass "$check"
+        remediation: By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
       - id: K.1.1.9
         description: Ensure that the Container Network Interface file permissions
           are set to 600 or more restrictive (Manual)
@@ -252,21 +148,39 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -n "$CONFIG_FILES" ]; then
-              for config in $CONFIG_FILES; do
-                if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
-                  pass "$check"
-                else
-                  warn "$check"
-                  warn "      * Wrong permissions for $file, get $(stat -c %a $file)"
+          dir=$(append_prefix "$CONFIG_PREFIX" "/var/lib/cni/networks")
+          all_pass=true
+          fail_files=""
+
+          if [ -d "$dir" ]; then
+            files=$(find "$dir" -type f ! -name lock 2>/dev/null)
+            
+            if [ -z "$files" ]; then
+              warn "$check"
+              warn "      * No files found in $dir."
+              all_pass=false
+            else
+              echo "$files" | while read -r file; do
+                perm=$(stat -c %a "$file")
+                if [ "$perm" -ne 600 ] && [ "$perm" -ne 400 ]; then
+                  all_pass=false
+                  fail_files="$fail_files\n      * Wrong permissions for $file (got $perm)"
                 fi
               done
+            fi
           else
-              warn "$check"
-              warn "      * File not found: $CONFIG_FILES" 
+            warn "$check"
+            warn "      * CNI data directory $dir not found."
+            all_pass=false
           fi
-        remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chmod 600 /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
+
+          if [ "$all_pass" = true ]; then
+            pass "$check"
+          else
+            warn "$check"
+            warn "      * One or more files failed the permission check, $fail_files"
+          fi
+        remediation: By default, K3s sets the CNI file permissions to 600. Note that for many CNIs, a lock file is created with permissions 750. This is expected and can be ignored. If you modify your CNI configuration, ensure that the permissions are set to 600. For example, chmod 600 /var/lib/cni/networks/<filename>
       - id: K.1.1.10
         description: Ensure that the Container Network Interface file ownership is
           set to root:root (Manual)
@@ -281,21 +195,39 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -n "$CONFIG_FILES" ]; then
-              for config in $CONFIG_FILES; do
-                if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-                  pass "$check"
-                else
-                  warn "$check"
-                  warn "      * Wrong permissions for $file, expect root:root, get $(stat -c %U:%G $file)"
+          dir=$(append_prefix "$CONFIG_PREFIX" "/var/lib/cni/networks")
+          all_pass=true
+          fail_files=""
+
+          if [ -d "$dir" ]; then
+            files=$(find "$dir" -type f ! -name lock 2>/dev/null)
+            
+            if [ -z "$files" ]; then
+              warn "$check"
+              warn "      * No files found in $dir."
+              all_pass=false
+            else
+              echo "$files" | while read -r file; do
+                ownership=$(stat -c %u%g "$file")
+                if [ "$ownership" -ne 00 ]; then
+                  all_pass=false
+                  fail_files="$fail_files\n      * Wrong ownership for $file (got $perm)"
                 fi
               done
+            fi
           else
-              warn "$check"
-              warn "      * File not found: $CONFIG_FILES" 
+            warn "$check"
+            warn "      * CNI data directory $dir not found."
+            all_pass=false
           fi
-        remediation: Run the below command (based on the file location on your system)
-          on the master node. For example, chown root:root /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
+
+          if [ "$all_pass" = true ]; then
+            pass "$check"
+          else
+            warn "$check"
+            warn "      * One or more files failed the ownership check, $fail_files"
+          fi
+        remediation: Run the below command (based on the file location on your system) on the control plane node. For example, chown root:root <path/to/cni/files>
       - id: K.1.1.11
         description: Ensure that the etcd data directory permissions are set to 700
           or more restrictive (Automated)
@@ -311,16 +243,20 @@ groups:
         audit: |
           check="$id  - $description"
           dir=$(append_prefix "$CONFIG_PREFIX" "/var/lib/rancher/k3s/server/db/etcd")
-          if [ -d "$dir" ]; then
-            if [ "$(stat -c %a $dir)" -eq 700 -o "$(stat -c %a $dir)" -eq 600 -o "$(stat -c %a $dir)" -eq 400 ]; then
-              pass "$check"
+          if [ -n "$ETCD_CMD" ]; then
+            if [ -d "$dir" ]; then
+              if [ "$(stat -c %a $dir)" -eq 700 -o "$(stat -c %a $dir)" -eq 600 -o "$(stat -c %a $dir)" -eq 400 ]; then
+                pass "$check"
+              else
+                warn "$check"
+                warn "      * Wrong permissions for $dir, get $(stat -c %a $dir)"
+              fi
             else
               warn "$check"
-              warn "      * Wrong permissions for $dir, get $(stat -c %a $dir)"
+              warn "      * etcd data directory $dir not found."
             fi
           else
-            warn "$check"
-            warn "      * etcd data directory $dir not found."
+            pass "$check"
           fi
         remediation: 'On the etcd server node, get the etcd data directory, passed
           as an argument --data-dir, from the below command: ps -ef | grep etcd Run
@@ -340,22 +276,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          dir=$(append_prefix "$CONFIG_PREFIX" "/var/lib/rancher/k3s/server/db/etcd")
-          if [ -d "$dir" ]; then
-            if [ "$(stat -c %U:%G $dir)" = "etcd:etcd" ]; then
-              pass "$check"
-            else
-              warn "$check"
-              warn "      * Wrong permissions for $dir, expect etcd:etcd, get $(stat -c %U:%G $dir)"
-            fi
-          else
-            warn "$check"
-            warn "      * etcd data directory: $dir not found."
-          fi
-        remediation: 'On the etcd server node, get the etcd data directory, passed
-          as an argument --data-dir, from the below command: ps -ef | grep etcd Run
-          the below command (based on the etcd data directory found above). For example,
-          chown etcd:etcd /var/lib/rancher/k3s/server/db/etcd'
+          pass "$check"
+        remediation: For K3s, etcd is embedded within the k3s process. There is no separate etcd process. Therefore the etcd data directory ownership is managed by the k3s process and should be root:root.
       - id: K.1.1.13
         description: Ensure that the admin.conf file permissions are set to 600 (Automated)
         type: master
@@ -544,10 +466,12 @@ groups:
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
           files=$(find $file)
           pass=true
+          incorrect_files=""
           for f in ${files}; do
-            if [ "$(stat -c %u%g $f)" != 00 ]; then
-              pass=false;
-              break;
+            ownership=$(stat -c %u%g $f)
+            if ! [ "$ownership" -eq 00 ]; then
+              pass=false
+              incorrect_files="$incorrect_files $f (ownership=$ownership)"
             fi
           done
 
@@ -555,6 +479,10 @@ groups:
             pass "$check"
           else
             warn "$check"
+            warn "      * Wrong ownership for the following files:"
+            for f in $incorrect_files; do
+              warn "      * - $f"
+            done
           fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chown -R root:root /var/lib/rancher/k3s/server/tls
@@ -574,10 +502,12 @@ groups:
           check="$id  - $description"
           files=$(find $file -name "*.crt")
           pass=true
+          incorrect_files=""
           for f in ${files}; do
-            if ! [ "$(stat -c %a $f)" -eq 600 -o "$(stat -c %a $f)" -eq 400 ]; then
-              pass=false;
-              break;
+            permissions=$(stat -c %a "$f")
+            if ! [ "$permissions" -eq 600 ] && ! [ "$permissions" -eq 400 ]; then
+              pass=false
+              incorrect_files="$incorrect_files $f (permissions=$permissions)"
             fi
           done
 
@@ -585,7 +515,11 @@ groups:
             pass "$check"
           else
             warn "$check"
-          fi        
+            warn "      * Wrong permissions for the following files:"
+            for f in $incorrect_files; do
+              warn "      * - $f"
+            done
+          fi              
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chmod -R 600 /var/lib/rancher/k3s/server/tls/*.crt
       - id: K.1.1.21
@@ -604,10 +538,12 @@ groups:
           check="$id  - $description"
           files=$(find $file -name "*.key")
           pass=true
+          incorrect_files=""
           for f in ${files}; do
-            if ! [ "$(stat -c %a $f)" -eq 600 ]; then
-              pass=false;
-              break;
+            permissions=$(stat -c %a "$f")
+            if ! [ "$permissions" -eq 600 ] && ! [ "$permissions" -eq 400 ]; then
+              pass=false
+              incorrect_files="$incorrect_files $f (permissions=$permissions)"
             fi
           done
 
@@ -615,6 +551,10 @@ groups:
             pass "$check"
           else
             warn "$check"
+            warn "      * Wrong permissions for the following files:"
+            for f in $incorrect_files; do
+              warn "      * - $f"
+            done
           fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
@@ -640,8 +580,10 @@ groups:
               warn "$check"
               warn "      * found: $(check_argument_from_journal "$KUBE_APISERVER_CMD" '--anonymous-auth=false')" 
           fi              
-        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
-          on the master node and set the below parameter. --anonymous-auth=false
+        remediation: |
+          By default, K3s sets the --anonymous-auth argument to false. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+            kube-apiserver-arg:
+              - "anonymous-auth=true"
       - id: K.1.2.2
         description: Ensure that the --token-auth-file parameter is not set (Automated)
         type: master
@@ -661,9 +603,10 @@ groups:
           else
               pass "$check"
           fi             
-        remediation: Follow the documentation and configure alternate mechanisms for
-          authentication. Then, edit the API server pod specification file /etc/rancher/k3s/config.yaml, if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory.
-          on the master node and remove the --token-auth-file=<filename> parameter.
+        remediation: |
+          Follow the documentation and configure alternate mechanisms for authentication. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+            - "token-auth-file=<path>"
       - id: K.1.2.3
         description: Ensure that the DenyServiceExternalIPs is set (Manual)
         type: master
@@ -685,7 +628,9 @@ groups:
               warn "$check"
           fi
         remediation: |
-          Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory) on the master node and remove the `--DenyServiceExternalIPs'parameter or The Kubernetes API server flag disable-admission-plugins takes a comma-delimited list of admission control plugins to be disabled, even if they are in the list of plugins enabled by default. kube-apiserver --disable-admission-plugins=DenyServiceExternalIPs,AlwaysDeny...
+          By default, K3s does not set DenyServiceExternalIPs. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=DenyServiceExternalIPs"
       - id: K.1.2.4
         description: Ensure that the --kubelet-client-certificate and --kubelet-client-key
           arguments are set as appropriate (Automated)
@@ -713,11 +658,11 @@ groups:
           else
               warn "$check"
           fi  
-        remediation: Follow the Kubernetes documentation and set up the TLS connection
-          between the apiserver and kubelets. Then, edit API server pod specification
-          file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory) on the master node and
-          set the kubelet client certificate and key parameters as below. --kubelet-client-certificate=<path/to/client-certificate-file>
-          --kubelet-client-key=<path/to/client-key-file>
+        remediation: |
+          By default, K3s automatically provides the kubelet client certificate and key. They are generated and located at /var/lib/rancher/k3s/server/tls/client-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/client-kube-apiserver.key If for some reason you need to provide your own certificate and key, you can set the below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kube-apiserver-arg:
+            - "kubelet-client-certificate=<path/to/client-cert-file>"
+            - "kubelet-client-key=<path/to/client-key-file>"
       - id: K.1.2.5
         description: Ensure that the --kubelet-certificate-authority argument is set
           as appropriate (Automated)
@@ -737,11 +682,10 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Follow the Kubernetes documentation and setup the TLS connection
-          between the apiserver and kubelets. Then, edit the API server pod specification
-          file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory) on the master node and
-          set the -- kubelet-certificate-authority parameter to the path to the cert
-          file for the certificate authority. --kubelet-certificate-authority=<ca-string>
+        remediation: |
+          By default, K3s automatically provides the kubelet CA cert file, at /var/lib/rancher/k3s/server/tls/server-ca.crt. If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "kubelet-certificate-authority=<path/to/ca-cert-file>"
       - id: K.1.2.6
         description: Ensure that the --authorization-mode argument is not set to AlwaysAllow
           (Automated)
@@ -761,9 +705,10 @@ groups:
           else
               pass "$check"
           fi        
-        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the --authorization-mode parameter to values
-          other than AlwaysAllow . One such example could be as below. --authorization-mode=RBAC
+        remediation: |
+          By default, K3s does not set the --authorization-mode to AlwaysAllow. If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+            - "authorization-mode=AlwaysAllow"
       - id: K.1.2.7
         description: Ensure that the --authorization-mode argument includes Node (Automated)
         type: master
@@ -782,9 +727,7 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the --authorization-mode parameter to a value
-          that includes Node . --authorization-mode=Node,RBAC
+        remediation: By default, K3s sets the --authorization-mode to Node and RBAC. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, ensure that you are not overriding authorization-mode.
       - id: K.1.2.8
         description: Ensure that the --authorization-mode argument includes RBAC (Automated)
         type: master
@@ -803,9 +746,7 @@ groups:
           else
               warn "$check"
           fi
-        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the --authorization-mode parameter to a value
-          that includes RBAC, for example:--authorization-mode=Node,RBAC
+        remediation: By default, K3s sets the --authorization-mode to Node and RBAC. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, ensure that you are not overriding authorization-mode.
       - id: K.1.2.9
         description: Ensure that the admission control plugin EventRateLimit is set
           (Manual)
@@ -824,10 +765,11 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Follow the Kubernetes documentation and set the desired limits
-          in a configuration file. Then, edit the API server pod specification file
-          /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory) and set the below parameters.  --enable-admission-plugins=...,EventRateLimit,...
-          --admission-control-config-file=<path/to/configuration/file>
+        remediation: |
+          Follow the Kubernetes documentation and set the desired limits in a configuration file. Then, edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameters.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=...,EventRateLimit,..."
+            - "admission-control-config-file=<path/to/configuration/file>"
       - id: K.1.2.10
         description: Ensure that the admission control plugin AlwaysAdmit is not set
           (Automated)
@@ -846,9 +788,10 @@ groups:
           else
               pass "$check"
           fi        
-        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and either remove the --enable-admission-plugins parameter,
-          or set it to a value that does not include AlwaysAdmit.
+        remediation: |
+          By default, K3s does not set the --enable-admission-plugins to AlwaysAdmit. If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=AlwaysAdmit"        
       - id: K.1.2.11
         description: Ensure that the admission control plugin AlwaysPullImages is
           set (Manual)
@@ -867,9 +810,10 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the --enable-admission-plugins parameter to include
-          AlwaysPullImages.  --enable-admission-plugins=...,AlwaysPullImages,...
+        remediation: |
+          Permissive, per CIS guidelines, "This setting could impact offline or isolated clusters, which have images pre-loaded and do not have access to a registry to pull in-use images. This setting is not appropriate for clusters which use this configuration." Edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameter.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=...,AlwaysPullImages,..."
       - id: K.1.2.12
         description: Ensure that the admission control plugin SecurityContextDeny
           is set if PodSecurityPolicy is not used (Manual)
@@ -883,18 +827,8 @@ groups:
           PCI: []
         audit: |
           check="$id  - $description"
-          if get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--enable-admission-plugins'| grep 'PodSecurityPolicy' >/dev/null 2>&1; then
-              pass "$check"
-          else
-            if get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--enable-admission-plugins'| grep 'SecurityContextDeny' >/dev/null 2>&1; then
-              pass "$check"
-            else
-              warn "$check"
-            fi
-          fi        
-        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the --enable-admission-plugins parameter to include
-          SecurityContextDeny, unless PodSecurityPolicy is already in place.  --enable-admission-plugins=...,SecurityContextDeny,...
+          pass "$check"     
+        remediation: Enabling Pod Security Policy is no longer supported on K3s v1.25+ and will cause applications to unexpectedly fail.
       - id: K.1.2.13
         description: Ensure that the admission control plugin ServiceAccount is set
           (Automated)
@@ -913,10 +847,10 @@ groups:
           else
               pass "$check"
           fi        
-        remediation: Follow the documentation and create ServiceAccount objects as
-          per your environment. Then, edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and ensure that the --disable-admission-plugins parameter
-          is set to a value that does not include ServiceAccount.
+        remediation: |
+          By default, K3s does not set the --disable-admission-plugins to anything. Follow the documentation and create ServiceAccount objects as per your environment. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.        
+          kube-apiserver-arg:
+            - "disable-admission-plugins=ServiceAccount"
       - id: K.1.2.14
         description: Ensure that the admission control plugin NamespaceLifecycle is
           set (Automated)
@@ -935,9 +869,10 @@ groups:
           else
               pass "$check"
           fi
-        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the --disable-admission-plugins parameter to
-          ensure it does not include NamespaceLifecycle.
+        remediation: |
+          By default, K3s does not set the --disable-admission-plugins to anything. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "disable-admission-plugins=...,NamespaceLifecycle,..."        
       - id: K.1.2.15
         description: Ensure that the admission control plugin NodeRestriction is set
           (Automated)
@@ -956,10 +891,10 @@ groups:
           else
               warn "$check"
           fi
-        remediation: Follow the Kubernetes documentation and configure NodeRestriction
-          plug-in on kubelets. Then, edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the --enable-admission-plugins parameter to a
-          value that includes NodeRestriction. --enable-admission-plugins=...,NodeRestriction,...
+        remediation: |
+          By default, K3s sets the --enable-admission-plugins to NodeRestriction. If using the K3s config file /etc/rancher/k3s/config.yaml, check that you are not overriding the admission plugins. If you are, include NodeRestriction in the list.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=...,NodeRestriction,..." 
       - id: K.1.2.16
         description: Ensure that the --profiling argument is set to false (Automated)
         type: master
@@ -975,8 +910,10 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the below parameter. --profiling=false
+        remediation: |
+          By default, K3s sets the --profiling argument to false. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "profiling=true"        
       - id: K.1.2.17
         description: Ensure that the --audit-log-path argument is set (Automated)
         type: master
@@ -994,10 +931,10 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: 'Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the --audit-log-path parameter to a suitable
-          path and file where you would like audit logs to be written, for example:
-          --audit-log-path=/var/log/apiserver/audit.log'
+        remediation: |
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the audit-log-path parameter to a suitable path and file where you would like audit logs to be written, for example,
+          kube-apiserver-arg:
+            - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
       - id: K.1.2.18
         description: Ensure that the --audit-log-maxage argument is set to 30 or as
           appropriate (Automated)
@@ -1023,9 +960,10 @@ groups:
           else
               warn "$check"
           fi 
-        remediation: 'Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the --audit-log-maxage parameter to 30 or as
-          an appropriate number of days: --audit-log-maxage=30'
+        remediation: |
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the audit-log-maxage parameter to 30 or as an appropriate number of days, for example,
+          kube-apiserver-arg:
+            - "audit-log-maxage=30"
       - id: K.1.2.19
         description: Ensure that the --audit-log-maxbackup argument is set to 10 or
           as appropriate (Automated)
@@ -1051,9 +989,10 @@ groups:
           else
               warn "$check"
           fi
-        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the --audit-log-maxbackup parameter to 10 or
-          to an appropriate value. --audit-log-maxbackup=10
+        remediation: |
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
+          kube-apiserver-arg:
+            - "audit-log-maxbackup=10"     
       - id: K.1.2.20
         description: Ensure that the --audit-log-maxsize argument is set to 100 or
           as appropriate (Automated)
@@ -1079,9 +1018,10 @@ groups:
           else
               warn "$check"
           fi
-        remediation: 'Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the --audit-log-maxsize parameter to an appropriate
-          size in MB. For example, to set it as 100 MB: --audit-log-maxsize=100'
+        remediation: |
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the audit-log-maxsize parameter to an appropriate size in MB. For example,
+          kube-apiserver-arg:
+            - "audit-log-maxsize=100"        
       - id: K.1.2.21
         description: Ensure that the --request-timeout argument is set as appropriate
           (Manual)
@@ -1093,15 +1033,11 @@ groups:
         tags: {}
         audit: |
           check="$id  - $description"
-          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--request-timeout' >/dev/null 2>&1; then
-              requestTimeout=$(get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--request-timeout')
-              pass "$check"
-              pass "      * request-timeout: $requestTimeout"
-          else
-              warn "$check"
-          fi        
-        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          and set the below parameter as appropriate and if needed. For example, --request-timeout=300s
+          pass "$check"     
+        remediation: |
+          Permissive, per CIS guidelines, "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed". Edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameter if needed. For example,
+          kube-apiserver-arg:
+            - "request-timeout=300s"
       - id: K.1.2.22
         description: Ensure that the --service-account-lookup argument is set to true
           (Automated)
@@ -1121,8 +1057,11 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the below parameter. --service-account-lookup=true
+        remediation: |
+          By default, K3s does not set the --service-account-lookup argument. Edit the K3s config file /etc/rancher/k3s/config.yaml and set the service-account-lookup. For example,
+          kube-apiserver-arg:
+            - "service-account-lookup=true"
+          Alternatively, you can delete the service-account-lookup parameter from this file so that the default takes effect.        
       - id: K.1.2.23
         description: Ensure that the --service-account-key-file argument is set as
           appropriate (Automated)
@@ -1145,9 +1084,10 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: 'Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the --service-account-key-file parameter to the
-          public key file for service accounts: --service-account-key-file=<filename>'
+        remediation: |
+          K3s automatically generates and sets the service account key file. It is located at /var/lib/rancher/k3s/server/tls/service.key. If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "service-account-key-file=<path>"       
       - id: K.1.2.24
         description: Ensure that the --etcd-certfile and --etcd-keyfile arguments
           are set as appropriate (Automated)
@@ -1177,11 +1117,11 @@ groups:
           else
               warn "$check"
           fi
-        remediation: Follow the Kubernetes documentation and set up the TLS connection
-          between the apiserver and etcd. Then, edit the API server pod specification
-          file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory) on the master node and
-          set the etcd certificate and key file parameters.  --etcd-certfile=<path/to/client-certificate-file>
-          --etcd-keyfile=<path/to/client-key-file>
+        remediation: |
+          K3s automatically generates and sets the etcd certificate and key files. They are located at /var/lib/rancher/k3s/server/tls/etcd/client.crt and /var/lib/rancher/k3s/server/tls/etcd/client.key. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "etcd-certfile=<path>"
+            - "etcd-keyfile=<path>"        
       - id: K.1.2.25
         description: Ensure that the --tls-cert-file and --tls-private-key-file arguments
           are set as appropriate (Automated)
@@ -1211,10 +1151,11 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Follow the Kubernetes documentation and set up the TLS connection
-          on the apiserver. Then, edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the TLS certificate and private key file parameters.
-          --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key-file=<path/to/tls-key-file>
+        remediation: |
+          By default, K3s automatically generates and provides the TLS certificate and private key for the apiserver. They are generated and located at /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.key If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "tls-cert-file=<path>"
+            - "tls-private-key-file=<path>"        
       - id: K.1.2.26
         description: Ensure that the --client-ca-file argument is set as appropriate
           (Automated)
@@ -1237,9 +1178,10 @@ groups:
           else
               warn "$check"
           fi
-        remediation: Follow the Kubernetes documentation and set up the TLS connection
-          on the apiserver. Then, edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the client certificate authority file. --client-ca-file=<path/to/client-ca-file>
+        remediation: |
+          By default, K3s automatically provides the client certificate authority file. It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt. If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "client-ca-file=<path>"
       - id: K.1.2.27
         description: Ensure that the --etcd-cafile argument is set as appropriate
           (Automated)
@@ -1262,10 +1204,10 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Follow the Kubernetes documentation and set up the TLS connection
-          between the apiserver and etcd. Then, edit the API server pod specification
-          file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory) on the master node and
-          set the etcd certificate authority file parameter. --etcd-cafile=<path/to/ca-file>
+        remediation: |
+          By default, K3s automatically provides the etcd certificate authority file. It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt. If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below. 
+          kube-apiserver-arg:
+            - "etcd-cafile=<path>"       
       - id: K.1.2.28
         description: Ensure that the --encryption-provider-config argument is set
           as appropriate (Manual)
@@ -1285,10 +1227,8 @@ groups:
           else
               warn "$check"
           fi     
-        remediation: 'Follow the Kubernetes documentation and configure a EncryptionConfig
-          file. Then, edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the --encryption-provider-config parameter to
-          the path of that file: --encryption-provider-config=</path/to/EncryptionConfig/File>'
+        remediation: |
+          K3s can be configured to use encryption providers to encrypt secrets at rest. Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter. secrets-encryption: true Secrets encryption can then be managed with the k3s secrets-encrypt command line tool. If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json.
       - id: K.1.2.29
         description: Ensure that encryption providers are appropriately configured
           (Manual)
@@ -1317,8 +1257,8 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Follow the Kubernetes documentation and configure a EncryptionConfig
-          file. In this file, choose aescbc, kms or secretbox as the encryption provider.
+        remediation: |
+          K3s can be configured to use encryption providers to encrypt secrets at rest. K3s will utilize the aescbc provider. Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter. secrets-encryption: true Secrets encryption can then be managed with the k3s secrets-encrypt command line tool. If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json
       - id: K.1.2.30
         description: Ensure that the API Server only makes use of Strong Cryptographic
           Ciphers (Manual)
@@ -1345,20 +1285,9 @@ groups:
               warn "$check"
           fi        
         remediation: |
-          Edit the API server pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory) on the Control Plane node and set the below parameter.
-          --tls-cipher-suites=TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384,
-          TLS_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-          TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-          TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-          TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-          TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-          TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-          TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-          TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-          TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-          TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256, TLS_RSA_WITH_3DES_EDE_CBC_SHA,
-          TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_128_GCM_SHA256,
-          TLS_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_256_GCM_SHA384.
+          By default, the K3s kube-apiserver complies with this test. Changes to these values may cause regression, therefore ensure that all apiserver clients support the new TLS configuration before applying it in production deployments. If a custom TLS configuration is required, consider also creating a custom version of this rule that aligns with your requirements. If this check fails, remove any custom configuration around tls-cipher-suites or update the /etc/rancher/k3s/config.yaml file to match the default by adding the following:
+          kube-apiserver-arg:
+            - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
   - id: 1.3
     title: 1.3 - Controller Manager
     checks:
@@ -1382,9 +1311,10 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: 'Edit the Controller Manager pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the --terminated-pod-gc-threshold to an appropriate
-          threshold, for example: --terminated-pod-gc-threshold=10'
+        remediation: |
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
+          kube-controller-manager-arg:
+            - "terminated-pod-gc-threshold=10"
       - id: K.1.3.2
         description: Ensure that the --profiling argument is set to false (Automated)
         type: master
@@ -1400,8 +1330,10 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Edit the Controller Manager pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the below parameter. --profiling=false
+        remediation: |
+          By default, K3s sets the --profiling argument to false. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "profiling=true"   
       - id: K.1.3.3
         description: Ensure that the --use-service-account-credentials argument is
           set to true (Automated)
@@ -1421,8 +1353,10 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Edit the Controller Manager pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node to set the below parameter. --use-service-account-credentials=true
+        remediation: |
+          By default, K3s sets the --use-service-account-credentials argument to true. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "use-service-account-credentials=false"     
       - id: K.1.3.4
         description: Ensure that the --service-account-private-key-file argument is
           set as appropriate (Automated)
@@ -1445,9 +1379,10 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Edit the Controller Manager pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the --service-account-privat-key-file parameter
-          to the private key file for service accounts. --service-account-private-key-file=<filename>
+        remediation: |
+          By default, K3s automatically provides the service account private key file. It is generated and located at /var/lib/rancher/k3s/server/tls/service.current.key. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "service-account-private-key-file=<path>"        
       - id: K.1.3.5
         description: Ensure that the --root-ca-file argument is set as appropriate
           (Automated)
@@ -1470,9 +1405,10 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Edit the Controller Manager pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the --root-ca-file parameter to the certificate
-          bundle file`. --root-ca-file=<path/to/file>
+        remediation: |
+          By default, K3s automatically provides the root CA file. It is generated and located at /var/lib/rancher/k3s/server/tls/server-ca.crt. If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "root-ca-file=<path>"
       - id: K.1.3.6
         description: Ensure that the RotateKubeletServerCertificate argument is set
           to true (Automated)
@@ -1498,9 +1434,10 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Edit the Controller Manager pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
-          --feature-gates=RotateKubeletServerCertificate=true
+        remediation: |
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate. If you have enabled this feature gate, you should remove it. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-controller-manager-arg:
+            - "feature-gate=RotateKubeletServerCertificate" 
       - id: K.1.3.7
         description: Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)
         type: master
@@ -1516,8 +1453,10 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Edit the Controller Manager pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and ensure the correct value for the --bind-address parameter.
+        remediation: |
+          By default, K3s sets the --bind-address argument to 127.0.0.1 If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "bind-address=<IP>"
   - id: 1.4
     title: 1.4 - Scheduler
     checks:
@@ -1536,8 +1475,10 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Edit the Scheduler pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          file on the master node and set the below parameter. --profiling=false
+        remediation: |
+          By default, K3s sets the --profiling argument to false. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+            - "profiling=true"
       - id: K.1.4.2
         description: Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)
         type: master
@@ -1553,5 +1494,7 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Edit the Scheduler pod specification file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on the master node and ensure the correct value for the --bind-address parameter
+        remediation: |
+          By default, K3s sets the --bind-address argument to 127.0.0.1 If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+            - "bind-address=<IP>"

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/master/1_control_plane_components.yaml
@@ -479,10 +479,7 @@ groups:
             pass "$check"
           else
             warn "$check"
-            warn "      * Wrong ownership for the following files:"
-            for f in $incorrect_files; do
-              warn "      * - $f"
-            done
+            warn "      * Wrong ownership for the following files: $incorrect_files"
           fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chown -R root:root /var/lib/rancher/k3s/server/tls
@@ -515,10 +512,7 @@ groups:
             pass "$check"
           else
             warn "$check"
-            warn "      * Wrong permissions for the following files:"
-            for f in $incorrect_files; do
-              warn "      * - $f"
-            done
+            warn "      * Wrong permissions for the following files: $incorrect_files"
           fi              
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chmod -R 600 /var/lib/rancher/k3s/server/tls/*.crt
@@ -551,10 +545,7 @@ groups:
             pass "$check"
           else
             warn "$check"
-            warn "      * Wrong permissions for the following files:"
-            for f in $incorrect_files; do
-              warn "      * - $f"
-            done
+            warn "      * Wrong permissions for the following files: $incorrect_files"
           fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/master/2_etcd.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/master/2_etcd.yaml
@@ -31,10 +31,8 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Follow the etcd service documentation and configure TLS encryption.
-          Then, edit the etcd pod specification file /var/lib/rancher/k3s/server/db/etcd/config
-          on the master node and set the below parameters.  --cert-file=</path/to/ca-file>
-          --key-file=</path/to/key-file>
+        remediation: |
+          If running on with sqlite or a external DB, etcd checks are Not Applicable. When running with embedded-etcd, K3s generates cert and key files for etcd. These are located in /var/lib/rancher/k3s/server/tls/etcd/. If this check fails, ensure that the configuration file /var/lib/rancher/k3s/server/db/etcd/config has not been modified to use custom cert and key files.        
   - id: 2.2
     title: ''
     checks:
@@ -57,8 +55,8 @@ groups:
           else
               warn "$check"
           fi        
-        remediation: Edit the etcd pod specification file /var/lib/rancher/k3s/server/db/etcd/config
-          on the master node and set the below parameter. --client-cert-auth="true"
+        remediation: |
+          If running on with sqlite or a external DB, etcd checks are Not Applicable. When running with embedded-etcd, K3s sets the --client-cert-auth parameter to true. If this check fails, ensure that the configuration file /var/lib/rancher/k3s/server/db/etcd/config has not been modified to disable client certificate authentication.        
   - id: 2.3
     title: ''
     checks:
@@ -81,9 +79,8 @@ groups:
           else
               warn "$check"
           fi    
-        remediation: Edit the etcd pod specification file /var/lib/rancher/k3s/server/db/etcd/config
-          on the master node and either remove the --auto-tls parameter or set it
-          to false. --auto-tls=false
+        remediation: |
+          If running on with sqlite or a external DB, etcd checks are Not Applicable. When running with embedded-etcd, K3s does not set the --auto-tls parameter. If this check fails, edit the etcd pod specification file /var/lib/rancher/k3s/server/db/etcd/config on the master node and either remove the --auto-tls parameter or set it to false. client-transport-security: auto-tls: false
   - id: 2.4
     title: ''
     checks:
@@ -112,11 +109,8 @@ groups:
           else
               warn "$check"
           fi    
-        remediation: Follow the etcd service documentation and configure peer TLS
-          encryption as appropriate for your etcd cluster. Then, edit the etcd pod
-          specification file /var/lib/rancher/k3s/server/db/etcd/config on the master node
-          and set the below parameters.  --peer-cert-file=</path/to/peer-cert-file>
-          --peer-key-file=</path/to/peer-key-file>
+        remediation: |
+          If running on with sqlite or a external DB, etcd checks are Not Applicable. When running with embedded-etcd, K3s generates peer cert and key files for etcd. These are located in /var/lib/rancher/k3s/server/tls/etcd/. If this check fails, ensure that the configuration file /var/lib/rancher/k3s/server/db/etcd/config has not been modified to use custom peer cert and key files.
   - id: 2.5
     title: ''
     checks:
@@ -140,8 +134,8 @@ groups:
           else
               warn "$check"
           fi    
-        remediation: Edit the etcd pod specification file /var/lib/rancher/k3s/server/db/etcd/config
-          on the master node and set the below parameter. --peer-client-cert-auth=true
+        remediation: |
+          If running on with sqlite or a external DB, etcd checks are Not Applicable. When running with embedded-etcd, K3s sets the --peer-cert-auth parameter to true. If this check fails, ensure that the configuration file /var/lib/rancher/k3s/server/db/etcd/config has not been modified to disable peer client certificate authentication.
   - id: 2.6
     title: ''
     checks:
@@ -164,9 +158,8 @@ groups:
           else
               warn "$check"
           fi      
-        remediation: Edit the etcd pod specification file /var/lib/rancher/k3s/server/db/etcd/config
-          on the master node and either remove the --peer-auto-tls parameter or set
-          it to false. --peer-auto-tls=false
+        remediation: |
+          If running on with sqlite or a external DB, etcd checks are Not Applicable. When running with embedded-etcd, K3s does not set the --peer-auto-tls parameter. If this check fails, edit the etcd pod specification file /var/lib/rancher/k3s/server/db/etcd/config on the master node and either remove the --peer-auto-tls parameter or set it to false. peer-transport-security: auto-tls: false
   - id: 2.7
     title: ''
     checks:
@@ -190,7 +183,5 @@ groups:
           else
               warn "$check"
           fi    
-        remediation: Follow the etcd documentation and create a dedicated certificate
-          authority setup for the etcd service. Then, edit the etcd pod specification
-          file /var/lib/rancher/k3s/server/db/etcd/config on the master node and set the
-          below parameter. --trusted-ca-file=</path/to/ca-file>
+        remediation: |
+          If running on with sqlite or a external DB, etcd checks are Not Applicable. When running with embedded-etcd, K3s generates a unique certificate authority for etcd. This is located at /var/lib/rancher/k3s/server/tls/etcd/peer-ca.crt. If this check fails, ensure that the configuration file /var/lib/rancher/k3s/server/db/etcd/config has not been modified to use a shared certificate authority.

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/master/2_etcd.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/master/2_etcd.yaml
@@ -1,0 +1,196 @@
+version: cis-k3s-1.8
+id: 2
+title: 2 - etcd
+type: master
+groups:
+  - id: 2.1
+    title: ''
+    checks:
+      - id: K.2.1
+        description: Ensure that the --cert-file and --key-file arguments are set
+          as appropriate (Automated)
+        type: master
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: true
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          etcdconf=$(append_prefix "$CONFIG_PREFIX" "/var/lib/rancher/k3s/server/db/etcd/config")
+          output=$(grep -A 4 'client-transport-security' $etcdconf | grep -E 'cert-file|key-file')
+          if [ -n "$output" ]; then
+            cfile=$(echo "$output" | grep 'cert-file' | awk '{print $2}')
+            kfile=$(echo "$output" | grep 'key-file' | awk '{print $2}')
+            pass "$check"
+            pass "      * cert-file: $cfile"
+            pass "      * key-file: $kfile"
+          else
+              warn "$check"
+          fi        
+        remediation: Follow the etcd service documentation and configure TLS encryption.
+          Then, edit the etcd pod specification file /var/lib/rancher/k3s/server/db/etcd/config
+          on the master node and set the below parameters.  --cert-file=</path/to/ca-file>
+          --key-file=</path/to/key-file>
+  - id: 2.2
+    title: ''
+    checks:
+      - id: K.2.2
+        description: Ensure that the --client-cert-auth argument is set to true (Automated)
+        type: master
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: true
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          output=$(grep -A 4 'client-transport-security' $etcdconf | grep 'client-cert-auth' | awk '{print $2}')
+          if [ $output = true ]; then
+              pass "$check"
+          else
+              warn "$check"
+          fi        
+        remediation: Edit the etcd pod specification file /var/lib/rancher/k3s/server/db/etcd/config
+          on the master node and set the below parameter. --client-cert-auth="true"
+  - id: 2.3
+    title: ''
+    checks:
+      - id: K.2.3
+        description: Ensure that the --auto-tls argument is not set to true (Automated)
+        type: master
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: true
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          output=$(grep 'auto-tls' $etcdconf | awk '{print $2}')
+          if [ $output = true ]; then
+              pass "$check"
+          else
+              warn "$check"
+          fi    
+        remediation: Edit the etcd pod specification file /var/lib/rancher/k3s/server/db/etcd/config
+          on the master node and either remove the --auto-tls parameter or set it
+          to false. --auto-tls=false
+  - id: 2.4
+    title: ''
+    checks:
+      - id: K.2.4
+        description: Ensure that the --peer-cert-file and --peer-key-file arguments
+          are set as appropriate (Automated)
+        type: master
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: true
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          etcdconf=$(append_prefix "$CONFIG_PREFIX" "/var/lib/rancher/k3s/server/db/etcd/config")
+          output=$(grep -A 4 'peer-transport-security' $etcdconf | grep -E 'cert-file|key-file')
+          if [ -n "$output" ]; then
+            cfile=$(echo "$output" | grep 'cert-file' | awk '{print $2}')
+            kfile=$(echo "$output" | grep 'key-file' | awk '{print $2}')
+            pass "$check"
+            pass "      * peer-cert-file: $cfile"
+            pass "      * peer-key-file: $kfile"
+          else
+              warn "$check"
+          fi    
+        remediation: Follow the etcd service documentation and configure peer TLS
+          encryption as appropriate for your etcd cluster. Then, edit the etcd pod
+          specification file /var/lib/rancher/k3s/server/db/etcd/config on the master node
+          and set the below parameters.  --peer-cert-file=</path/to/peer-cert-file>
+          --peer-key-file=</path/to/peer-key-file>
+  - id: 2.5
+    title: ''
+    checks:
+      - id: K.2.5
+        description: Ensure that the --peer-client-cert-auth argument is set to true
+          (Automated)
+        type: master
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: true
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          output=$(grep -A 4 'peer-transport-security' $etcdconf | grep 'client-cert-auth' | awk '{print $2}')
+          if [ $output = true ]; then
+              pass "$check"
+          else
+              warn "$check"
+          fi    
+        remediation: Edit the etcd pod specification file /var/lib/rancher/k3s/server/db/etcd/config
+          on the master node and set the below parameter. --peer-client-cert-auth=true
+  - id: 2.6
+    title: ''
+    checks:
+      - id: K.2.6
+        description: Ensure that the --peer-auto-tls argument is not set to true (Automated)
+        type: master
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: true
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          output=$(grep 'peer-auto-tls' $etcdconf | awk '{print $2}')
+          if [ $output = true ]; then
+              pass "$check"
+          else
+              warn "$check"
+          fi      
+        remediation: Edit the etcd pod specification file /var/lib/rancher/k3s/server/db/etcd/config
+          on the master node and either remove the --peer-auto-tls parameter or set
+          it to false. --peer-auto-tls=false
+  - id: 2.7
+    title: ''
+    checks:
+      - id: K.2.7
+        description: Ensure that a unique Certificate Authority is used for etcd (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 2
+        automated: false
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          output=$(grep -A 4 'client-transport-security' $etcdconf | grep 'trusted-ca-file' | awk '{print $2}')
+          if [ -n "$output" ]; then
+            pass "$check"
+            pass "      * trusted-ca-file: $output"
+          else
+              warn "$check"
+          fi    
+        remediation: Follow the etcd documentation and create a dedicated certificate
+          authority setup for the etcd service. Then, edit the etcd pod specification
+          file /var/lib/rancher/k3s/server/db/etcd/config on the master node and set the
+          below parameter. --trusted-ca-file=</path/to/ca-file>

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/master/3_control_plane_configuration.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/master/3_control_plane_configuration.yaml
@@ -1,0 +1,94 @@
+version: cis-k3s-1.8
+id: 3
+title: 3 - Control Plane Configuration
+type: master
+groups:
+  - id: 3.1
+    title: 3.1 - Authentication and Authorization
+    checks:
+      - id: K.3.1.1
+        description: Client certificate authentication should not be used for users
+          (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review user access to the cluster and ensure that users are not making use of Kubernetes client certificate authentication."
+        remediation: Alternative mechanisms provided by Kubernetes such as the use
+          of OIDC should be implemented in place of client certificates.
+      - id: K.3.1.2
+        description: Service account token authentication should not be used for users
+          (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review user access to the cluster and ensure that users are not making use of service account token authentication."
+        remediation: Alternative mechanisms provided by Kubernetes such as the use
+          of OIDC should be implemented in place of service account tokens.
+      - id: K.3.1.3
+        description: Bootstrap token authentication should not be used for users (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review user access to the cluster and ensure that users are not making use of bootstrap token authentication."
+        remediation: Alternative mechanisms provided by Kubernetes such as the use
+          of OIDC should be implemented in place of bootstrap tokens.
+  - id: 3.2
+    title: 3.2 - Logging
+    checks:
+      - id: K.3.2.1
+        description: Ensure that a minimal audit policy is created (Manual)
+        type: master
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: false
+        tags:
+          HIPAA: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          if check_argument_from_journal "$KUBE_APISERVER_CMD" '--audit-policy-file' >/dev/null 2>&1; then
+              auditPolicyFile=$(get_argument_value_from_journal "$KUBE_APISERVER_CMD" '--audit-policy-file')
+              auditPolicyFile=$(append_prefix "$CONFIG_PREFIX" "$auditPolicyFile")
+              pass "$check"
+              pass "      * audit-policy-file: $auditPolicyFile"
+          else
+              warn "$check"
+          fi        
+        remediation: Create an audit policy file for your cluster.
+      - id: K.3.2.2
+        description: Ensure that the audit policy covers key security concerns (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 2
+        automated: false
+        tags:
+          HIPAA: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Access to Secrets managed by the cluster. Care should be taken to only log Metadata for requests to Secrets, ConfigMaps, and TokenReviews, in order to avoid the risk of logging sensitive data."
+          manual "      * Modification of pod and deployment objects."
+          manual "      * Use of pods/exec, pods/portforward, pods/proxy and services/proxy."        
+        remediation: Consider modification of the audit policy in use on the cluster
+          to include these items, at a minimum.

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/master/5_policies.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/master/5_policies.yaml
@@ -1,0 +1,544 @@
+version: cis-k3s-1.8
+id: 5
+title: 5 - Policies
+type: master
+groups:
+  - id: 5.1
+    title: 5.1 - RBAC and Service Accounts
+    checks:
+      - id: K.5.1.1
+        description: Ensure that the cluster-admin role is only used where required
+          (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Run kubectl get clusterrolebindings -o=custom-columns=NAME:.metadata.name,ROLE:.roleRef.name,SUBJECT:.subjects[*].name, Review each principal listed and ensure that cluster-admin privilege is required for it."
+        remediation: 'Identify all clusterrolebindings to the cluster-admin role.
+          Check if they are used and if they need this role or if they could use a
+          role with fewer privileges. Where possible, first bind users to a lower
+          privileged role and then remove the clusterrolebinding to the cluster-admin
+          role : kubectl delete clusterrolebinding [name]'
+      - id: K.5.1.2
+        description: Minimize access to secrets (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review the users who have get, list or watch access to secrets objects in the Kubernetes API."
+        remediation: Where possible, remove get, list and watch access to secret objects
+          in the cluster.
+      - id: K.5.1.3
+        description: Minimize wildcard use in Roles and ClusterRoles (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Retrieve the roles defined across each namespaces in the cluster and review for wildcards kubectl get roles --all-namespaces -o yaml Retrieve the cluster roles defined in the cluster and review for wildcards kubectl get clusterroles -o yaml"
+        remediation: Where possible replace any use of wildcards in clusterroles and
+          roles with specific objects or actions.
+      - id: K.5.1.4
+        description: Minimize access to create pods (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review the users who have create access to pod objects in the Kubernetes API."
+        remediation: Where possible, remove create access to pod objects in the cluster.
+      - id: K.5.1.5
+        description: Ensure that default service accounts are not actively used. (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "     * For each namespace in the cluster, review the rights assigned to the default service account and ensure that it has no roles or cluster roles bound to it apart from the defaults. Additionally ensure that the automountServiceAccountToken: false setting is in place for each default service account."
+        remediation: 'Create explicit service accounts wherever a Kubernetes workload
+          requires specific access to the Kubernetes API server. Modify the configuration
+          of each default service account to include this value automountServiceAccountToken:
+          false'
+      - id: K.5.1.6
+        description: Ensure that Service Account Tokens are only mounted where necessary
+          (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review pod and service account objects in the cluster and ensure that the option below is set, unless the resource explicitly requires this access. automountServiceAccountToken: false"
+        remediation: Modify the definition of pods and service accounts which do not
+          need to mount service account tokens to disable it.
+      - id: K.5.1.7
+        description: Avoid use of system:masters group (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review a list of all credentials which have access to the cluster and ensure that the group system:masters is not used."
+        remediation: Remove the system:masters group from all users in the cluster.
+      - id: K.5.1.8
+        description: Limit use of the Bind, Impersonate and Escalate permissions in
+          the Kubernetes cluster (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review the users who have access to cluster roles or roles which provide the impersonate, bind or escalate privileges."
+        remediation: Where possible, remove the impersonate, bind and escalate rights
+          from subjects.
+      - id: K.5.1.9
+        description: Minimize access to create persistent volumes (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review the users who have create access to PersistentVolume objects in the Kubernetes API."
+        remediation: Where possible, remove create access to PersistentVolume objects
+          in the cluster.
+      - id: K.5.1.10
+        description: Minimize access to the proxy sub-resource of nodes (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review the users who have access to the proxy sub-resource of node objects in the Kubernetes API."
+        remediation: Where possible, remove access to the proxy sub-resource of node
+          objects.
+      - id: K.5.1.11
+        description: Minimize access to the approval sub-resource of certificatesigningrequests
+          objects (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review the users who have access to update the approval sub-resource of certificatesigningrequest objects in the Kubernetes API."
+        remediation: Where possible, remove access to the approval sub-resource of
+          certificatesigningrequest objects.
+      - id: K.5.1.12
+        description: Minimize access to webhook configuration objects (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review the users who have access to validatingwebhookconfigurations or mutatingwebhookconfigurations objects in the Kubernetes API."              
+        remediation: Where possible, remove the impersonate, bind and escalate rights
+          from subjects.
+      - id: K.5.1.13
+        description: Minimize access to the service account token creation (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review the users who have access to create the token sub-resource of serviceaccount objects in the Kubernetes API."
+        remediation: Where possible, remove access to the token sub-resource of serviceaccount
+          objects.
+  - id: 5.2
+    title: 5.2 - Pod Security Standards
+    checks:
+      - id: K.5.2.1
+        description: Ensure that the cluster has at least one active policy control
+          mechanism in place (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Run get pods -A -o=jsonpath={range .items[*]}{@.metadata.name}:{@..securityContext}\n{end}"
+          manual "      * It will produce an inventory of all the privileged use on the cluster, if any (please, refer to a sample below). Further grepping can be done to automate each specific violation detection.calico-kube-controllers-57b57c56f-jtmk4: {} << No Elevated Privileges calico-node-c4xv4: {} {privileged:true} {privileged:true} {privileged:true} {privileged:true} << Violates 5.2.2 dashboard-metrics-scraper-7bc864c59-2m2xw: {seccompProfile:{type:RuntimeDefault}} {allowPrivilegeEscalation:false,readOnlyRootFilesystem:true,runAsGroup:2001,ru nAsUser:1001}"
+        remediation: Ensure that either Pod Security Admission or an external policy
+          control system is in place for every namespace which contains user workloads.
+      - id: K.5.2.2
+        description: Minimize the admission of privileged containers (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Run get pods -A -o=jsonpath={range .items[*]}{@.metadata.name}:{@..securityContext}\n{end}"
+          manual "      * It will produce an inventory of all the privileged use on the cluster, if any (please, refer to a sample below). Further grepping can be done to automate each specific violation detection.calico-kube-controllers-57b57c56f-jtmk4: {} << No Elevated Privileges calico-node-c4xv4: {} {privileged:true} {privileged:true} {privileged:true} {privileged:true} << Violates 5.2.2 dashboard-metrics-scraper-7bc864c59-2m2xw: {seccompProfile:{type:RuntimeDefault}} {allowPrivilegeEscalation:false,readOnlyRootFilesystem:true,runAsGroup:2001,ru nAsUser:1001}"
+        remediation: Add policies to each namespace in the cluster which has user
+          workloads to restrict the admission of privileged containers.
+      - id: K.5.2.3
+        description: Minimize the admission of containers wishing to share the host
+          process ID namespace (Automated)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: true
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * List the policies in use for each namespace in the cluster, ensure that each policy disallows the admission of hostPID containers"
+        remediation: Add policies to each namespace in the cluster which has user
+          workloads to restrict the admission of hostPID containers.
+      - id: K.5.2.4
+        description: Minimize the admission of containers wishing to share the host
+          IPC namespace (Automated)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: true
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * List the policies in use for each namespace in the cluster, ensure that each policy disallows the admission of hostIPC containers."
+        remediation: Add policies to each namespace in the cluster which has user
+          workloads to restrict the admission of hostIPC containers.
+      - id: K.5.2.5
+        description: Minimize the admission of containers wishing to share the host
+          network namespace (Automated)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: true
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * List the policies in use for each namespace in the cluster, ensure that each policy disallows the admission of hostNetwork containers"
+        remediation: Add policies to each namespace in the cluster which has user
+          workloads to restrict the admission of hostNetwork containers..
+      - id: K.5.2.6
+        description: Minimize the admission of containers with allowPrivilegeEscalation
+          (Automated)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: true
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * List the policies in use for each namespace in the cluster, ensure that each policy disallows the admission of containers which allow privilege escalation."
+        remediation: Add policies to each namespace in the cluster which has user
+          workloads to restrict the admission of containers with .spec.allowPrivilegeEscalationset
+          to true.
+      - id: K.5.2.7
+        description: Minimize the admission of root containers (Automated)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 2
+        automated: true
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * List the policies in use for each namespace in the cluster, ensure that each policy restricts the use of root containers by setting MustRunAsNonRoot or MustRunAs with the range of UIDs not including 0."
+        remediation: Create a policy for each namespace in the cluster, ensuring that
+          either MustRunAsNonRoot or MustRunAs with the range of UIDs not including
+          0, is set.
+      - id: K.5.2.8
+        description: Minimize the admission of containers with the NET_RAW capability
+          (Automated)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: true
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * List the policies in use for each namespace in the cluster, ensure that at least one policy disallows the admission of containers with the NET_RAW capability."
+        remediation: Add policies to each namespace in the cluster which has user
+          workloads to restrict the admission of containers with the NET_RAW capability.
+      - id: K.5.2.9
+        description: Minimize the admission of containers with added capabilities
+          (Automated)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: true
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * List the policies in use for each namespace in the cluster, ensure that policies are present which prevent allowedCapabilities to be set to anything other than an empty array."
+        remediation: Ensure that allowedCapabilities is not present in policies for
+          the cluster unless it is set to an empty array.
+      - id: K.5.2.10
+        description: Minimize the admission of containers with capabilities assigned
+          (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * List the policies in use for each namespace in the cluster, ensure that at least one policy requires that capabilities are dropped by all containers."
+        remediation: Review the use of capabilities in applications running on your
+          cluster. Where a namespace contains applications which do not require any
+          Linux capabilities to operate consider adding a policy which forbids the
+          admission of containers which do not drop all capabilities.
+      - id: K.5.2.11
+        description: Minimize the admission of Windows HostProcess Containers (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: true
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * List the policies in use for each namespace in the cluster, ensure that each policy disallows the admission of hostProcess containers."
+        remediation: Add policies to each namespace in the cluster which has user
+          workloads to restrict the admission of hostProcess containers.
+      - id: K.5.2.12
+        description: Minimize the admission of HostPath volumes (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: true
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * List the policies in use for each namespace in the cluster, ensure that each policy disallows the admission of containers with hostPath volumes."
+        remediation: Add policies to each namespace in the cluster which has user
+          workloads to restrict the admission of containers which use hostPath volumes.
+      - id: K.5.2.13
+        description: Minimize the admission of containers which use HostPorts (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: true
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * List the policies in use for each namespace in the cluster, ensure that each policy disallows the admission of containers which have hostPort sections."
+        remediation: Add policies to each namespace in the cluster which has user
+          workloads to restrict the admission of containers which use hostPort sections.
+  - id: 5.3
+    title: 5.3 - Network Policies and CNI
+    checks:
+      - id: K.5.3.1
+        description: Ensure that the CNI in use supports Network Policies (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review the documentation of CNI plugin in use by the cluster, and confirm that it supports Ingress and Egress network policies."
+        remediation: If the CNI plugin in use does not support network policies, consideration
+          should be given to making use of a different plugin, or finding an alternate
+          mechanism for restricting traffic in the Kubernetes cluster.
+      - id: K.5.3.2
+        description: Ensure that all Namespaces have Network Policies defined (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 2
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Run kubectl get networkpolicy --all-namespaces , Ensure that each namespace defined in the cluster has at least one Network Policy."
+        remediation: Follow the documentation and create NetworkPolicy objects as
+          you need them.
+  - id: 5.4
+    title: 5.4 - Secrets Management
+    checks:
+      - id: K.5.4.1
+        description: Prefer using secrets as files over secrets as environment variables
+          (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 2
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Run the following command to find references to objects which use environment variables defined from secrets. kubectl get all -o jsonpath='{range .items[?(@..secretKeyRef)]} {.kind} {.metadata.name} {\"\\\\n\"}{end}' -A"
+        remediation: If possible, rewrite application code to read secrets from mounted
+          secret files, rather than from environment variables.
+      - id: K.5.4.2
+        description: Consider external secret storage (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 2
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review your secrets management implementation."
+        remediation: Refer to the secrets management options offered by your cloud
+          provider or a third-party secrets management solution.
+  - id: 5.5
+    title: 5.5 - Extensible Admission Control
+    checks:
+      - id: K.5.5.1
+        description: Configure Image Provenance using ImagePolicyWebhook admission
+          controller (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 2
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review the pod definitions in your cluster and verify that image provenance is configured as appropriate."
+        remediation: Follow the Kubernetes documentation and setup image provenance.
+  - id: 5.7
+    title: 5.7 - General Policies
+    checks:
+      - id: K.5.7.1
+        description: Create administrative boundaries between resources using namespaces
+          (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Run kubectl get namespaces . Ensure that these namespaces are the ones you need and are adequately administered as per your requirements."
+        remediation: Follow the documentation and create namespaces for objects in
+          your deployment as you need them.
+      - id: K.5.7.2
+        description: Ensure that the seccomp profile is set to docker/default in your
+          pod definitions (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 2
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Use security context to enable the docker/default seccomp profile in your pod definitions."
+        remediation: |
+          Use security context to enable the docker/default seccomp profile in your pod definitions. 
+          An example is as below:
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+      - id: K.5.7.3
+        description: Apply Security Context to Your Pods and Containers (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 2
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review the pod definitions in your cluster and verify that you have security contexts defined as appropriate."
+        remediation: Follow the Kubernetes documentation and apply security contexts
+          to your pods. For a suggested list of security contexts, you may refer to
+          the CIS Security Benchmark for Docker Containers.
+      - id: K.5.7.4
+        description: The default namespace should not be used (Manual)
+        type: master
+        category: kubernetes
+        scored: false
+        profile: Level 2
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Run this command in default namespace.  kubectl get \$(kubectl api-resources --verbs=list --namespaced=true -o name | paste -sd, -) --ignore-not-found -n default . The only entries there should be system managed resources such as the kubernetes service"
+        remediation: Ensure that namespaces are created to allow for appropriate segregation
+          of Kubernetes resources and that all new resources are created in a specific
+          namespace.

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/worker/4_worker_nodes.yaml
@@ -1,0 +1,664 @@
+version: cis-k3s-1.8
+id: 4
+title: 4 - Worker Nodes
+type: node
+groups:
+  - id: 4.1
+    title: 4.1 - Worker Node Configuration Files
+    checks:
+      - id: K.4.1.1
+        description: Ensure that the kubelet service file permissions are set to 600
+          or more restrictive (Automated)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: true
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          if [ -n "$CONFIG_FILES" ]; then
+              for config in $CONFIG_FILES; do
+                if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+                  pass "$check"
+                else
+                  warn "$check"
+                  warn "      * Wrong permissions for $file, get $(stat -c %a $file)"
+                fi
+              done
+          else
+              warn "$check"
+              warn "      * kubelet service file not found: $CONFIG_FILES" 
+          fi
+        remediation: Run the below command (based on the file location on your system)
+          on the each worker node. For example, chmod 600 /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
+      - id: K.4.1.2
+        description: Ensure that the kubelet service file ownership is set to root:root
+          (Automated)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: true
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          if [ -n "$CONFIG_FILES" ]; then
+              for config in $CONFIG_FILES; do
+                if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+                  pass "$check"
+                else
+                  warn "$check"
+                  warn "      * Wrong permissions for $file, expect root:root, get $(stat -c %U:%G $file)"
+                fi
+              done
+          else
+              warn "$check"
+              warn "      * The kubelet service file not found: $CONFIG_FILES" 
+          fi
+        remediation: Run the below command (based on the file location on your system)
+          on the each worker node. For example, chown root:root /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
+      - id: K.4.1.3
+        description: If proxy kubeconfig file exists ensure permissions are set to
+          600 or more restrictive (Manual)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: false
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          file=$(append_prefix "$CONFIG_PREFIX" "/var/lib/rancher/k3s/agent/kubeproxy.kubeconfig")
+          if [ -f "$file" ]; then
+            if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+              pass "$check"
+            else
+              warn "$check"
+              warn "      * Wrong permissions for $file"
+            fi
+          else
+            warn "$check"
+            warn "      * kubeconfig file: $file not found"
+          fi        
+        remediation: Run the below command (based on the file location on your system)
+          on the each worker node. For example, chmod 600 /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
+      - id: K.4.1.4
+        description: If proxy kubeconfig file exists ensure ownership is set to root:root
+          (Manual)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: false
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"           
+          if [ -f "$file" ]; then
+            if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+              pass "$check"
+            else
+              warn "$check"
+              warn "      * Wrong ownership for $file"
+            fi
+          else
+            warn "$check"
+            warn "      * kubeconfig file: $file not found"
+          fi        
+        remediation: Run the below command (based on the file location on your system)
+          on the each worker node. For example, chown root:root /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
+          file>
+      - id: K.4.1.5
+        description: Ensure that the --kubeconfig kubelet.conf file permissions are
+          set to 600 or more restrictive (Automated)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: true
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          file=$(append_prefix "$CONFIG_PREFIX" "/var/lib/rancher/k3s/agent/kubelet.kubeconfig")
+
+          if [ -f "$file" ]; then
+            if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+              pass "$check"
+            else
+              warn "$check"
+              warn "      * Wrong permissions for $file"
+            fi
+          else
+            warn "$check"
+            warn "      * File: $file not found"
+          fi        
+        remediation: Run the below command (based on the file location on your system)
+          on the each worker node. For example, chmod 600 /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+      - id: K.4.1.6
+        description: Ensure that the --kubeconfig kubelet.conf file ownership is set
+          to root:root (Automated)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: false
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          if [ -f "$file" ]; then
+            if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+              pass "$check"
+            else
+              warn "$check"
+              warn "      * Wrong ownership for $file"
+            fi
+          else
+            warn "$check"
+          fi
+        remediation: Run the below command (based on the file location on your system)
+          on the each worker node. For example, chown root:root /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+      - id: K.4.1.7
+        description: Ensure that the certificate authorities file permissions are
+          set to 600 or more restrictive (Manual)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: false
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          if check_argument_from_journal "$KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
+            file=$(get_argument_value_from_journal "$KUBELET_CMD" '--client-ca-file')
+            file=$(append_prefix "$CONFIG_PREFIX" "$file")
+            if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+              pass "$check"
+              pass "      * client-ca-file: $file"
+            else
+              warn "$check"
+              warn "      * Wrong permissions for $file"
+            fi
+          else
+            warn "$check"
+            warn "      * --client-ca-file not set"
+          fi
+        remediation: Run the following command to modify the file permissions of the
+          --client-ca-file chmod 600 <filename>
+      - id: K.4.1.8
+        description: Ensure that the client certificate authorities file ownership
+          is set to root:root (Manual)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: false
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          if check_argument_from_journal "$KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
+            file=$(get_argument_value_from_journal "$KUBELET_CMD" '--client-ca-file')
+            file=$(append_prefix "$CONFIG_PREFIX" "$file")
+            if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+              pass "$check"
+              pass "      * client-ca-file: $file"
+            else
+              warn "$check"
+              warn "      * Wrong ownership for $file"
+            fi
+          else
+            warn "$check"
+            warn "      * --client-ca-file not set"
+          fi 
+        remediation: Run the following command to modify the ownership of the --client-ca-file.
+          chown root:root <filename>
+      - id: K.4.1.9
+        description: if the kubelet config.yaml configuration file is being used validate
+          permissions set to 600 or more restrictive (Automated)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: false
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          if [ -n "$CONFIG_FILES" ]; then
+              for config in $CONFIG_FILES; do
+                if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+                  pass "$check"
+                else
+                  warn "$check"
+                  warn "      * Wrong permissions for $file, get $(stat -c %a $file)"
+                fi
+              done
+          else
+              warn "$check"
+              warn "      * File not found: $CONFIG_FILES" 
+          fi
+        remediation: Run the following command (using the config file location identied
+          in the Audit step) chmod 600 /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
+      - id: K.4.1.10
+        description: If the kubelet config.yaml configuration file is being used validate
+          file ownership is set to root:root (Automated)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: false
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          if [ -n "$CONFIG_FILES" ]; then
+              for config in $CONFIG_FILES; do
+                if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+                  pass "$check"
+                else
+                  warn "$check"
+                  warn "      * Wrong permissions for $file, expect root:root, get $(stat -c %U:%G $file)"
+                fi
+              done
+          else
+              warn "$check"
+              warn "      * File not found: $CONFIG_FILES" 
+          fi
+        remediation: Run the following command (using the config file location identied
+          in the Audit step) chown root:root /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
+  - id: 4.2
+    title: 4.2 - Kubelet
+    checks:
+      - id: K.4.2.1
+        description: Ensure that the --anonymous-auth argument is set to false (Automated)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: true
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          if check_argument_from_journal "$KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
+              pass "$check"
+          else
+              warn "$check"
+          fi
+        remediation: |
+          If using a Kubelet config file, edit the file to set authentication: anonymous: enabled to false.
+          If using executable arguments, edit the kubelet service file /etc/rancher/k3s/config.yaml on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.        
+          --anonymous-auth=false
+          Based on your system, restart the kubelet service. For example:   
+          systemctl daemon-reload 
+          systemctl restart kubelet.service                   
+      - id: K.4.2.2
+        description: Ensure that the --authorization-mode argument is not set to AlwaysAllow
+          (Automated)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: true
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          if check_argument_from_journal "$KUBELET_CMD" '--authorization-mode=AlwaysAllow' >/dev/null 2>&1; then
+              warn "$check"
+          else
+              pass "$check"
+          fi
+        remediation: |
+          If using a Kubelet config file, edit the file to set authorization: mode to Webhook.
+          If using executable arguments, edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.        
+          --authorization-mode=Webhook
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload 
+          systemctl restart kubelet.service
+      - id: K.4.2.3
+        description: Ensure that the --client-ca-file argument is set as appropriate
+          (Automated)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: true
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          if check_argument_from_journal "$KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
+              cafile=$(get_argument_value_from_journal "$KUBELET_CMD" '--client-ca-file')
+              cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
+              pass "$check"
+              pass "      * client-ca-file: $cafile"
+          else
+              warn "$check"
+          fi        
+        remediation: |
+          If using a Kubelet config file, edit the file to set authentication: x509: clientCAFile to the location of the client CA file.
+          If using command line arguments, edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
+          --client-ca-file=<path/to/client-ca-file>
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+      - id: K.4.2.4
+        description: Verify that the --read-only-port argument is set to 0 (Manual)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: false
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          if check_argument_from_journal "$KUBELET_CMD" '--read-only-port' >/dev/null 2>&1; then
+              port=$(get_argument_value_from_journal "$KUBELET_CMD" '--read-only-port' | cut -d " " -f 1)
+              if [ $port = "0" ]; then
+                  pass "$check"
+              else
+                  warn "$check"
+                  warn "      * read-only-port: $port"
+              fi
+          else
+              warn "$check"
+          fi        
+        remediation: |
+          If using a Kubelet config file, edit the file to set readOnlyPort to 0.
+          If using command line arguments, edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --read-only-port=0
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+      - id: K.4.2.5
+        description: Ensure that the --streaming-connection-idle-timeout argument
+          is not set to 0 (Manual)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          if check_argument_from_journal "$KUBELET_CMD" '--streaming-connection-idle-timeout=0' >/dev/null 2>&1; then
+              timeout=$(get_argument_value_from_journal "$KUBELET_CMD" '--streaming-connection-idle-timeout')
+              warn "$check"
+              warn "      * streaming-connection-idle-timeout: $timeout"
+          else
+              pass "$check"
+          fi        
+        remediation: |
+          If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a value other than 0. 
+          If using command line arguments, edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --streaming-connection-idle-timeout=5m
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload 
+          systemctl restart kubelet.service
+      - id: K.4.2.6
+        description: Ensure that the --make-iptables-util-chains argument is set to
+          true (Automated)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: true
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          if check_argument_from_journal "$KUBELET_CMD" '--make-iptables-util-chains=true' >/dev/null 2>&1; then
+              pass "$check"
+          else
+              warn "$check"
+          fi        
+        remediation: |
+          If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true. 
+          If using command line arguments, edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and remove the --mak-iptables-util-chains argument from the KUBELET_SYSTEM_PODS_ARGS variable. 
+          Based on your system, restart the kubelet service. For example:        
+          systemctl daemon-reload 
+          systemctl restart kubelet.service
+      - id: K.4.2.7
+        description: Ensure that the --hostname-override argument is not set (Manual)
+        type: worker
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          if check_argument_from_journal "$KUBELET_CMD" '--hostname-override' >/dev/null 2>&1; then
+              warn "$check"
+          else
+              pass "$check"
+          fi        
+        remediation: 'Edit the kubelet service file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
+          on each worker node and remove the --hostname-override argument from the
+          KUBELET_SYSTEM_PODS_ARGS variable. Based on your system, restart the kubelet
+          service. For example:  systemctl daemon-reload systemctl restart kubelet.service'
+      - id: K.4.2.8
+        description: Ensure that the eventRecordQPS argument is set to a level which
+          ensures appropriate event capture (Manual)
+        type: worker
+        category: kubernetes
+        scored: false
+        profile: Level 2
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          if check_argument_from_journal "$KUBELET_CMD" '--event-qps' >/dev/null 2>&1; then
+              qps=$(get_argument_value_from_journal "$KUBELET_CMD" '--event-qps' | cut -d " " -f 1)
+              if [ "$qps" -gt 0 ]; then
+                  pass "$check"
+              else
+                  warn "$check"
+                  warn "      * --event-qps: $qps is not set to a positive value"
+              fi
+          else
+              warn "$check"
+              warn "      * --event-qps is not set"
+          fi        
+        remediation: 'If using a Kubelet config file, edit the file to set eventRecordQPS:
+          to an appropriate level. If using command line arguments, edit the kubelet
+          service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each
+          worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:  systemctl
+          daemon-reload systemctl restart kubelet.service'
+      - id: K.4.2.9
+        description: Ensure that the --tls-cert-file and --tls-private-key-file arguments
+          are set as appropriate (Manual)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: false
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          if check_argument_from_journal "$KUBELET_CMD" '--tls-cert-file' >/dev/null 2>&1; then
+              if check_argument_from_journal "$KUBELET_CMD" '--tls-private-key-file' >/dev/null 2>&1; then
+                  cfile=$(get_argument_value_from_journal "$KUBELET_CMD" '--tls-cert-file')
+                  kfile=$(get_argument_value_from_journal "$KUBELET_CMD" '--tls-private-key-file')
+                  cfile=$(append_prefix "$CONFIG_PREFIX" "$cfile")
+                  kfile=$(append_prefix "$CONFIG_PREFIX" "$kfile")
+                  pass "$check"
+                  pass "      * tls-cert-file: $cfile"
+                  pass "      * tls-private-key-file: $kfile"
+              else
+                warn "$check"
+              fi
+          else
+              warn "$check"
+          fi        
+        remediation: |
+          If using a Kubelet config file, edit the file to set tlsCertFile to the location of the certificate file to use to identify this Kubelet, and tlsPrivateKeyFile to the location of the corresponding private key file. 
+          If using command line arguments, edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and set the below parameters in KUBELET_CERTIFICATE_ARGS variable.  
+          --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key-file=<path/to/tls-key-file> 
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload 
+          systemctl restart kubelet.service                    
+      - id: K.4.2.10
+        description: Ensure that the --rotate-certificates argument is not set to
+          false (Automated)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: true
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          if check_argument_from_journal "$KUBELET_CMD" '--rotate-certificates=false' >/dev/null 2>&1; then
+            warn "$check"
+          else
+            pass "$check"
+          fi        
+        remediation: |
+          If using a Kubelet config file, edit the file to add the line rotateCertificates: true or remove it altogether to use the default value.
+          If using command line arguments, edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and remove --rotat-certificates=false argument from the KUBELET_CERTIFICATE_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload 
+          systemctl restart kubelet.service 
+      - id: K.4.2.11
+        description: Verify that the RotateKubeletServerCertificate argument is set
+          to true (Manual)
+        type: worker
+        category: kubernetes
+        scored: true
+        profile: Level 1
+        automated: false
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          check="$id  - $description"
+          if check_argument_from_journal "$KUBELET_CMD" '--feature-gates' >/dev/null 2>&1; then
+              serverCert=$(get_argument_value_from_journal "$KUBELET_CMD" '--feature-gates')
+              found=$(echo $serverCert| grep 'RotateKubeletServerCertificate=true')
+              if [ ! -z $found ]; then
+                pass "$check"
+              else
+                warn "$check"
+              fi
+          else
+              warn "$check"
+          fi   
+        remediation: |
+          Edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
+          --feature-gates=RotateKubeletServerCertificate=true
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+      - id: K.4.2.12
+        description: Ensure that the Kubelet only makes use of Strong Cryptographic
+          Ciphers (Manual)
+        type: worker
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags:
+          HIPAA: []
+          PCI: []
+          GDPR: []
+        audit: |
+          check="$id  - $description"
+          success=1
+          SECURE_CIPHERS="TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305 TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 TLS_RSA_WITH_AES_256_GCM_SHA384 TLS_RSA_WITH_AES_128_GCM_SHA256"
+
+          # Function to check if a string is in the space-separated list
+          contains_element () {
+              for element in $2; do
+                  [ "$element" = "$1" ] && return 0
+              done
+              return 1
+          }
+
+          if check_argument_from_journal "$KUBELET_CMD" '--tls-cipher-suites' >/dev/null 2>&1; then
+              suit=$(get_argument_value_from_journal "$KUBELET_CMD" '--tls-cipher-suites' | cut -d " " -f 1)
+              # Split the cipher suites into a space-separated string
+              ciphers_string=$(echo "$suit" | tr ',' ' ')
+
+              # Check each cipher
+              for cipher in $ciphers_string; do
+                  if ! contains_element "$cipher" "$SECURE_CIPHERS"; then
+                      warn "$check"
+                      warn "      * Non-compliant cipher: $cipher"
+                      success=0
+                      break
+                  fi
+              done
+          fi
+
+          if [ "$success" -eq 1 ]; then
+              pass "$check"
+          fi
+        remediation: |
+          If using a Kubelet config file, edit the file to set TLSCipherSuites: to TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+          ,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256 or to a subset of these values.   
+          If using executable arguments, edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and set the --tls-cipher-suites parameter as follows, or to a subset of these values.                 
+          --tls-ciphe-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload 
+          systemctl restart kubelet.service     
+      - id: K.4.2.13
+        description: Ensure that a limit is set on pod PIDs (Manual)
+        type: worker
+        category: kubernetes
+        scored: false
+        profile: Level 1
+        automated: false
+        tags: {}
+        audit: |
+          check="$id  - $description"
+          manual "$check"
+          manual "      * Review the Kubelet's start-up parameters for the value of --pod-max-pids, and check the Kubelet configuration file for the PodPidsLimit . If neither of these values is set, then there is no limit in place."   
+        remediation: Decide on an appropriate level for this parameter and set it,
+          either via the --pod-max-pids command line parameter or the PodPidsLimit
+          configuration file setting.

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/worker/4_worker_nodes.yaml
@@ -20,21 +20,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -n "$CONFIG_FILES" ]; then
-              for config in $CONFIG_FILES; do
-                if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
-                  pass "$check"
-                else
-                  warn "$check"
-                  warn "      * Wrong permissions for $file, get $(stat -c %a $file)"
-                fi
-              done
-          else
-              warn "$check"
-              warn "      * kubelet service file not found: $CONFIG_FILES" 
-          fi
-        remediation: Run the below command (based on the file location on your system)
-          on the each worker node. For example, chmod 600 /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
+          pass "$check"
+        remediation: The kubelet is embedded in the k3s process. There is no kubelet service file, all configuration is passed in as arguments at runtime.
       - id: K.4.1.2
         description: Ensure that the kubelet service file ownership is set to root:root
           (Automated)
@@ -49,21 +36,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -n "$CONFIG_FILES" ]; then
-              for config in $CONFIG_FILES; do
-                if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-                  pass "$check"
-                else
-                  warn "$check"
-                  warn "      * Wrong permissions for $file, expect root:root, get $(stat -c %U:%G $file)"
-                fi
-              done
-          else
-              warn "$check"
-              warn "      * The kubelet service file not found: $CONFIG_FILES" 
-          fi
-        remediation: Run the below command (based on the file location on your system)
-          on the each worker node. For example, chown root:root /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
+          pass "$check"
+        remediation: The kubelet is embedded in the k3s process. There is no kubelet service file, all configuration is passed in as arguments at runtime.
       - id: K.4.1.3
         description: If proxy kubeconfig file exists ensure permissions are set to
           600 or more restrictive (Manual)
@@ -189,22 +163,20 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument_from_journal "$KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
-            file=$(get_argument_value_from_journal "$KUBELET_CMD" '--client-ca-file')
-            file=$(append_prefix "$CONFIG_PREFIX" "$file")
-            if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
+          file=$(append_prefix "$CONFIG_PREFIX" "/var/lib/rancher/k3s/agent/client-ca.crt")
+          if [ -f $file ]; then
+            if [ "$(stat -c %a $file)" -eq 600 ]; then
               pass "$check"
-              pass "      * client-ca-file: $file"
             else
               warn "$check"
               warn "      * Wrong permissions for $file"
             fi
           else
             warn "$check"
-            warn "      * --client-ca-file not set"
+            warn "      * File: $file not found"
           fi
-        remediation: Run the following command to modify the file permissions of the
-          --client-ca-file chmod 600 <filename>
+        remediation: |
+          Run the following command to modify the file permissions of the --client-ca-file chmod 600 /var/lib/rancher/k3s/agent/client-ca.crt        
       - id: K.4.1.8
         description: Ensure that the client certificate authorities file ownership
           is set to root:root (Manual)
@@ -219,9 +191,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument_from_journal "$KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
-            file=$(get_argument_value_from_journal "$KUBELET_CMD" '--client-ca-file')
-            file=$(append_prefix "$CONFIG_PREFIX" "$file")
+          if [ -f $file ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
               pass "      * client-ca-file: $file"
@@ -231,10 +201,10 @@ groups:
             fi
           else
             warn "$check"
-            warn "      * --client-ca-file not set"
-          fi 
-        remediation: Run the following command to modify the ownership of the --client-ca-file.
-          chown root:root <filename>
+            warn "      * File: $file not found"
+          fi
+        remediation: |
+          Run the following command to modify the ownership of the --client-ca-file. chown root:root /var/lib/rancher/k3s/agent/client-ca.crt
       - id: K.4.1.9
         description: if the kubelet config.yaml configuration file is being used validate
           permissions set to 600 or more restrictive (Automated)
@@ -249,21 +219,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -n "$CONFIG_FILES" ]; then
-              for config in $CONFIG_FILES; do
-                if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
-                  pass "$check"
-                else
-                  warn "$check"
-                  warn "      * Wrong permissions for $file, get $(stat -c %a $file)"
-                fi
-              done
-          else
-              warn "$check"
-              warn "      * File not found: $CONFIG_FILES" 
-          fi
-        remediation: Run the following command (using the config file location identied
-          in the Audit step) chmod 600 /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
+          pass "$check"
+        remediation: The kubelet is embedded in the k3s process. There is no kubelet config file, all configuration is passed in as arguments at runtime.
       - id: K.4.1.10
         description: If the kubelet config.yaml configuration file is being used validate
           file ownership is set to root:root (Automated)
@@ -278,21 +235,8 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -n "$CONFIG_FILES" ]; then
-              for config in $CONFIG_FILES; do
-                if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-                  pass "$check"
-                else
-                  warn "$check"
-                  warn "      * Wrong permissions for $file, expect root:root, get $(stat -c %U:%G $file)"
-                fi
-              done
-          else
-              warn "$check"
-              warn "      * File not found: $CONFIG_FILES" 
-          fi
-        remediation: Run the following command (using the config file location identied
-          in the Audit step) chown root:root /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
+          pass "$check"
+        remediation: The kubelet is embedded in the k3s process. There is no kubelet config file, all configuration is passed in as arguments at runtime.
   - id: 4.2
     title: 4.2 - Kubelet
     checks:
@@ -315,12 +259,10 @@ groups:
               warn "$check"
           fi
         remediation: |
-          If using a Kubelet config file, edit the file to set authentication: anonymous: enabled to false.
-          If using executable arguments, edit the kubelet service file /etc/rancher/k3s/config.yaml on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.        
-          --anonymous-auth=false
-          Based on your system, restart the kubelet service. For example:   
-          systemctl daemon-reload 
-          systemctl restart kubelet.service                   
+          By default, K3s sets the --anonymous-auth to false. If you have set this to a different value, you should set it back to false. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kubelet-arg:
+            - "anonymous-auth=true"
+          If using the command line, edit the K3s service file and remove the below argument. --kubelet-arg="anonymous-auth=true" Based on your system, restart the k3s service. For example, systemctl daemon-reload systemctl restart k3s.service               
       - id: K.4.2.2
         description: Ensure that the --authorization-mode argument is not set to AlwaysAllow
           (Automated)
@@ -341,12 +283,10 @@ groups:
               pass "$check"
           fi
         remediation: |
-          If using a Kubelet config file, edit the file to set authorization: mode to Webhook.
-          If using executable arguments, edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.        
-          --authorization-mode=Webhook
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service
+          By default, K3s does not set the --authorization-mode to AlwaysAllow. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kubelet-arg:
+            - "authorization-mode=AlwaysAllow"
+          If using the command line, edit the K3s service file and remove the below argument. --kubelet-arg="authorization-mode=AlwaysAllow" Based on your system, restart the k3s service. For example, systemctl daemon-reload systemctl restart k3s.service
       - id: K.4.2.3
         description: Ensure that the --client-ca-file argument is set as appropriate
           (Automated)
@@ -370,12 +310,7 @@ groups:
               warn "$check"
           fi        
         remediation: |
-          If using a Kubelet config file, edit the file to set authentication: x509: clientCAFile to the location of the client CA file.
-          If using command line arguments, edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
-          --client-ca-file=<path/to/client-ca-file>
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s automatically provides the client ca certificate for the Kubelet. It is generated and located at /var/lib/rancher/k3s/agent/client-ca.crt
       - id: K.4.2.4
         description: Verify that the --read-only-port argument is set to 0 (Manual)
         type: worker
@@ -401,12 +336,10 @@ groups:
               warn "$check"
           fi        
         remediation: |
-          If using a Kubelet config file, edit the file to set readOnlyPort to 0.
-          If using command line arguments, edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --read-only-port=0
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s sets the --read-only-port to 0. If you have set this to a different value, you should set it back to 0. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kubelet-arg:
+            - "read-only-port=XXXX"
+          If using the command line, edit the K3s service file and remove the below argument. --kubelet-arg="read-only-port=XXXX" Based on your system, restart the k3s service. For example, systemctl daemon-reload systemctl restart k3s.service
       - id: K.4.2.5
         description: Ensure that the --streaming-connection-idle-timeout argument
           is not set to 0 (Manual)
@@ -426,12 +359,10 @@ groups:
               pass "$check"
           fi        
         remediation: |
-          If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a value other than 0. 
-          If using command line arguments, edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --streaming-connection-idle-timeout=5m
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kubelet-arg:
+            - "streaming-connection-idle-timeout=5m"
+          If using the command line, run K3s with --kubelet-arg="streaming-connection-idle-timeout=5m". Based on your system, restart the k3s service. For example, systemctl restart k3s.service
       - id: K.4.2.6
         description: Ensure that the --make-iptables-util-chains argument is set to
           true (Automated)
@@ -449,11 +380,10 @@ groups:
               warn "$check"
           fi        
         remediation: |
-          If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true. 
-          If using command line arguments, edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and remove the --mak-iptables-util-chains argument from the KUBELET_SYSTEM_PODS_ARGS variable. 
-          Based on your system, restart the kubelet service. For example:        
-          systemctl daemon-reload 
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
+          kubelet-arg:
+            - "make-iptables-util-chains=true"
+          If using the command line, run K3s with --kubelet-arg="make-iptables-util-chains=true". Based on your system, restart the k3s service. For example, systemctl restart k3s.service
       - id: K.4.2.7
         description: Ensure that the --hostname-override argument is not set (Manual)
         type: worker
@@ -464,15 +394,9 @@ groups:
         tags: {}
         audit: |
           check="$id  - $description"
-          if check_argument_from_journal "$KUBELET_CMD" '--hostname-override' >/dev/null 2>&1; then
-              warn "$check"
-          else
-              pass "$check"
-          fi        
-        remediation: 'Edit the kubelet service file /etc/rancher/k3s/config.yaml (if file does not exist, then use files in the /etc/rancher/k3s/config.yaml.d directory)
-          on each worker node and remove the --hostname-override argument from the
-          KUBELET_SYSTEM_PODS_ARGS variable. Based on your system, restart the kubelet
-          service. For example:  systemctl daemon-reload systemctl restart kubelet.service'
+          pass "$check"     
+        remediation: |
+          By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply with cloud providers that require this flag to ensure that hostname matches node names.      
       - id: K.4.2.8
         description: Ensure that the eventRecordQPS argument is set to a level which
           ensures appropriate event capture (Manual)
@@ -496,12 +420,11 @@ groups:
               warn "$check"
               warn "      * --event-qps is not set"
           fi        
-        remediation: 'If using a Kubelet config file, edit the file to set eventRecordQPS:
-          to an appropriate level. If using command line arguments, edit the kubelet
-          service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each
-          worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example:  systemctl
-          daemon-reload systemctl restart kubelet.service'
+        remediation: |
+          By default, K3s sets the event-qps to 0. Should you wish to change this, If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kubelet-arg:
+            - "event-qps=<value>"
+          If using the command line, run K3s with --kubelet-arg="event-qps=<value>". Based on your system, restart the k3s service. For example, systemctl restart k3s.service             
       - id: K.4.2.9
         description: Ensure that the --tls-cert-file and --tls-private-key-file arguments
           are set as appropriate (Manual)
@@ -532,12 +455,10 @@ groups:
               warn "$check"
           fi        
         remediation: |
-          If using a Kubelet config file, edit the file to set tlsCertFile to the location of the certificate file to use to identify this Kubelet, and tlsPrivateKeyFile to the location of the corresponding private key file. 
-          If using command line arguments, edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and set the below parameters in KUBELET_CERTIFICATE_ARGS variable.  
-          --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key-file=<path/to/tls-key-file> 
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service                    
+          By default, K3s automatically provides the TLS certificate and private key for the Kubelet. They are generated and located at /var/lib/rancher/k3s/agent/serving-kubelet.crt and /var/lib/rancher/k3s/agent/serving-kubelet.key If for some reason you need to provide your own certificate and key, you can set the below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kubelet-arg:
+            - "tls-cert-file=<path/to/tls-cert-file>"
+            - "tls-private-key-file=<path/to/tls-private-key-file>"                
       - id: K.4.2.10
         description: Ensure that the --rotate-certificates argument is not set to
           false (Automated)
@@ -558,11 +479,7 @@ groups:
             pass "$check"
           fi        
         remediation: |
-          If using a Kubelet config file, edit the file to add the line rotateCertificates: true or remove it altogether to use the default value.
-          If using command line arguments, edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and remove --rotat-certificates=false argument from the KUBELET_CERTIFICATE_ARGS variable.
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service 
+          By default, K3s does not set the --rotate-certificates argument. If you have set this flag with a value of false, you should either set it to true or completely remove the flag. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter. If using the command line, remove the K3s flag --kubelet-arg="rotate-certificates". Based on your system, restart the k3s service. For example, systemctl restart k3s.service
       - id: K.4.2.11
         description: Verify that the RotateKubeletServerCertificate argument is set
           to true (Manual)
@@ -590,11 +507,7 @@ groups:
               warn "$check"
           fi   
         remediation: |
-          Edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
-          --feature-gates=RotateKubeletServerCertificate=true
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate. If you have enabled this feature gate, you should remove it. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter. If using the command line, remove the K3s flag --kubelet-arg="feature-gate=RotateKubeletServerCertificate". Based on your system, restart the k3s service. For example, systemctl restart k3s.service
       - id: K.4.2.12
         description: Ensure that the Kubelet only makes use of Strong Cryptographic
           Ciphers (Manual)
@@ -640,13 +553,10 @@ groups:
               pass "$check"
           fi
         remediation: |
-          If using a Kubelet config file, edit the file to set TLSCipherSuites: to TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-          ,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256 or to a subset of these values.   
-          If using executable arguments, edit the kubelet service file /var/lib/rancher/k3s/agent/kubelet.kubeconfig on each worker node and set the --tls-cipher-suites parameter as follows, or to a subset of these values.                 
-          --tls-ciphe-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service     
+          If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set TLSCipherSuites to
+          kubelet-arg:
+            - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
+          or to a subset of these values. If using the command line, add the K3s flag --kubelet-arg="tls-cipher-suites=<same values as above>" Based on your system, restart the k3s service. For example, systemctl restart k3s.service 
       - id: K.4.2.13
         description: Ensure that a limit is set on pod PIDs (Manual)
         type: worker
@@ -659,6 +569,7 @@ groups:
           check="$id  - $description"
           manual "$check"
           manual "      * Review the Kubelet's start-up parameters for the value of --pod-max-pids, and check the Kubelet configuration file for the PodPidsLimit . If neither of these values is set, then there is no limit in place."   
-        remediation: Decide on an appropriate level for this parameter and set it,
-          either via the --pod-max-pids command line parameter or the PodPidsLimit
-          configuration file setting.
+        remediation: |
+          Decide on an appropriate level for this parameter and set it, If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set podPidsLimit to
+          kubelet-arg:
+            - "pod-max-pids=<value>"        

--- a/agent/nvbench/utils/utils.sh
+++ b/agent/nvbench/utils/utils.sh
@@ -53,3 +53,29 @@ append_prefix() {
   # Concatenate and return the result
   echo "$prefix/$file"
 }
+
+#get an argument value from command line
+get_argument_value_from_journal() {
+    CMD="$1"
+    OPTION="$2"
+
+    echo "$CMD" |
+    sed \
+        -e 's/\-\-/\n--/g' \
+        |
+    grep "^${OPTION}" |
+    sed \
+        -e "s/^${OPTION}=//g"
+}
+
+#check whether an argument exist in command line
+check_argument_from_journal() {
+    CMD="$1"
+    OPTION="$2"
+
+    echo "$CMD" |
+    sed \
+        -e 's/\-\-/\n--/g' \
+        |
+    grep "^${OPTION}"
+}

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -110,6 +110,8 @@ var kubeProcs map[string]int = map[string]int{
 	"kubelet":        1,
 	"kube-apiserver": 1,
 	"hyperkube":      1,
+	"k3s-agent":      1, // represent the worker node in k3s
+	"k3s-server":     1, // represent the master node in k3s
 }
 
 //var linuxShells utils.Set = utils.NewSet("sh", "dash", "bash", "rbash")
@@ -3279,7 +3281,7 @@ func (p *Probe) BuildProcessFamilyGroups(id string, rootPid int, bSandboxPod, bP
 	c.rootPid = rootPid
 	c.bPrivileged = bPrivileged
 	if healthCheck != nil {
-		c.healthCheck = healthCheck		// no override
+		c.healthCheck = healthCheck // no override
 	}
 	allPids := c.outsider.Union(c.children)
 	allPids.Add(rootPid) // all collections: add rootPid as a pivot point

--- a/agent/probe/process_linux.go
+++ b/agent/probe/process_linux.go
@@ -46,12 +46,12 @@ func (p *Probe) openProcMonitor() (*netlink.NetlinkSocket, error) {
 	}
 
 	/*
-	// Reduce thread operations
-	err = ns.SetFilter(ProcFilters)
-	if err != nil {
-		log.WithFields(log.Fields{"error": err}).Error("Unable to set socket filter")
-	}
-*/
+		// Reduce thread operations
+		err = ns.SetFilter(ProcFilters)
+		if err != nil {
+			log.WithFields(log.Fields{"error": err}).Error("Unable to set socket filter")
+		}
+	*/
 	return ns, nil
 }
 

--- a/share/scan/compliance.go
+++ b/share/scan/compliance.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
@@ -30,6 +31,7 @@ var (
 	kube123           = "cis-1.23"
 	kube124           = "cis-1.24"
 	kube180           = "cis-1.8.0"
+	k3s180            = "cis-k3s-1.8.0"
 	rh140             = "rh-1.4.0"
 	gke140            = "gke-1.4.0"
 	aks140            = "aks-1.4.0"
@@ -3040,6 +3042,8 @@ func GetCISFolder(platform, flavor, cloudPlatform string) {
 			} else {
 				cisVersion = defaultCISVersion
 			}
+		} else if strings.Contains(k8sVer, "k3s") {
+			cisVersion = k3s180
 		} else {
 			kVer, err := version.NewVersion(k8sVer)
 			if err != nil {


### PR DESCRIPTION
### Problem
CIS benchmark is not support k3s before.

### Solution
- support CIS benchmark k3s
- Read the journalctl for the command processing. (use nstools)
- add `isKubeProcess` to detect the executable of k3s not proc name, since the proc name could change over time, and I keep the original logic for backward compatible.

### Test perform
Set up the k3s env, and make sure the other env works as well.