### PR TITLE
fix: remove AWS keys in API docs

### DIFF
--- a/controller/api/apis.yaml
+++ b/controller/api/apis.yaml
@@ -5873,10 +5873,10 @@ definitions:
         example: "831010404316"
       access_key_id:
         type: string
-        example: AKIAIHUHS4BTYUDKVV4Q
+        example: "<access key id from AWS>"
       secret_access_key:
         type: string
-        example: D7XGZO34AMUfTbunL
+        example: "<secret access key from AWS>"
       region:
         type: string
         example: us-west-2


### PR DESCRIPTION
I'm getting a lot of this warning when pushing into my fork:

```
remote: - GITHUB PUSH PROTECTION
remote:   —————————————————————————————————————————
remote:     Resolve the following violations before pushing again
remote: 
remote:     - Push cannot contain secrets
```

This commit removes the invalid AWS keys which trigger the alerts.  