### PR TITLE
fix: NVSHAS-9289 allow upgrade when RBAC missed

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -482,7 +482,7 @@ func main() {
 		ctx, internalCertControllerCancel = context.WithCancel(context.Background())
 		defer internalCertControllerCancel()
 		// Initialize secrets.  Most of services are not running at this moment, so skip their reload functions.
-		err = migration.InitializeInternalSecretController(ctx, []func([]byte, []byte, []byte) error{
+		capable, err := migration.InitializeInternalSecretController(ctx, []func([]byte, []byte, []byte) error{
 			// Reload consul
 			func(cacert []byte, cert []byte, key []byte) error {
 				log.Info("Reloading consul config")
@@ -505,7 +505,16 @@ func main() {
 			log.WithError(err).Error("failed to initialize internal secret controller")
 			os.Exit(-2)
 		}
-		log.Info("internal certificate is initialized")
+		if capable {
+			log.Info("internal certificate is initialized")
+		} else {
+			if os.Getenv("NO_FALLBACK") == "" {
+				log.Warn("required permission is missing...fallback to the built-in certificate if it exists")
+			} else {
+				log.Error("required permission is missing...ending now")
+				os.Exit(-2)
+			}
+		}
 	}
 
 	err = cluster.ReloadInternalCert()

--- a/controller/resource/kubernetes_rbac.go
+++ b/controller/resource/kubernetes_rbac.go
@@ -144,6 +144,8 @@ var ctrlerSubjectsWanted []string = []string{"controller"}
 var scannerSubjecstWanted []string = []string{"updater", "controller"}
 var secretSubjecstWanted []string = []string{"enforcer", "controller", "scanner", "registry-adapter"}
 var enforcerSubjecstWanted []string = []string{"enforcer", "controller"}
+var jobCreationSubjecstWanted []string = []string{"controller"}
+var certUpgraderSubjecstWanted []string = []string{"cert-upgrader"}
 
 var _k8sFlavor string // share.FlavorRancher or share.FlavorOpenShift
 
@@ -281,6 +283,48 @@ var rbacRolesWanted map[string]*k8sRbacRoleInfo = map[string]*k8sRbacRoleInfo{ /
 			},
 		},
 	},
+	NvJobCreationRole: &k8sRbacRoleInfo{
+		name:      NvJobCreationRole,
+		namespace: constNvNamespace,
+		rules: []*k8sRbacRoleRuleInfo{
+			&k8sRbacRoleRuleInfo{
+				apiGroup:  "batch",
+				resources: utils.NewSet(K8sResJobs),
+				verbs:     utils.NewSet("create", "get", "delete"),
+			},
+			&k8sRbacRoleRuleInfo{
+				apiGroup:  "batch",
+				resources: utils.NewSet(K8sResCronjobs, K8sResCronjobsFinalizer),
+				verbs:     utils.NewSet("update", "patch"),
+			},
+		},
+	},
+	NvCertUpgraderRole: &k8sRbacRoleInfo{
+		name:      NvCertUpgraderRole,
+		namespace: constNvNamespace,
+		rules: []*k8sRbacRoleRuleInfo{
+			&k8sRbacRoleRuleInfo{
+				apiGroup:  "",
+				resources: utils.NewSet(k8sResSecrets),
+				verbs:     utils.NewSet("get", "update", "watch", "list"),
+			},
+			&k8sRbacRoleRuleInfo{
+				apiGroup:  "",
+				resources: utils.NewSet(K8sResPods),
+				verbs:     utils.NewSet("get", "list"),
+			},
+			&k8sRbacRoleRuleInfo{
+				apiGroup:  "apps",
+				resources: utils.NewSet(K8sResDeployments, K8sResDaemonsets),
+				verbs:     utils.NewSet("get", "list", "watch"),
+			},
+			&k8sRbacRoleRuleInfo{
+				apiGroup:  "batch",
+				resources: utils.NewSet(K8sResCronjobs),
+				verbs:     utils.NewSet("update"),
+			},
+		},
+	},
 	k8sClusterRoleView: &k8sRbacRoleInfo{
 		k8sReserved:   true,
 		name:          k8sClusterRoleView,
@@ -349,6 +393,16 @@ var rbacRoleBindingsWanted map[string]*k8sRbacBindingInfo = map[string]*k8sRbacB
 		namespace: constNvNamespace,
 		subjects:  secretSubjecstWanted,
 		rbacRole:  rbacRolesWanted[NvSecretRole],
+	},
+	NvJobCreationRoleBinding: &k8sRbacBindingInfo{
+		namespace: constNvNamespace,
+		subjects:  jobCreationSubjecstWanted,
+		rbacRole:  rbacRolesWanted[NvJobCreationRole],
+	},
+	NvCertUpgraderRoleBinding: &k8sRbacBindingInfo{
+		namespace: constNvNamespace,
+		subjects:  certUpgraderSubjecstWanted,
+		rbacRole:  rbacRolesWanted[NvCertUpgraderRole],
 	},
 	NvAdminRoleBinding: &k8sRbacBindingInfo{ // for updater pod (5.1.x-)
 		namespace: constNvNamespace,

--- a/controller/resource/kubernetes_resource.go
+++ b/controller/resource/kubernetes_resource.go
@@ -51,6 +51,7 @@ const (
 	K8sApiVersionV1Beta1          = "v1beta1"
 	K8sApiVersionV1Beta2          = "v1beta2"
 	K8sResCronjobs                = "cronjobs"
+	K8sResCronjobsFinalizer       = "cronjobs/finalizers"
 	K8sResDaemonsets              = "daemonsets"
 	K8sResDeployments             = "deployments"
 	K8sResDeploymentConfigs       = "deploymentconfigs"
@@ -109,6 +110,10 @@ const (
 	nvSecretRoleBinding         = NvSecretRole
 	NvAdminRoleBinding          = "neuvector-admin"
 	nvViewRoleBinding           = "neuvector-binding-view"
+	NvJobCreationRole           = "neuvector-binding-job-creation"
+	NvJobCreationRoleBinding    = NvJobCreationRole
+	NvCertUpgraderRole          = "neuvector-binding-cert-upgrader"
+	NvCertUpgraderRoleBinding   = NvCertUpgraderRole
 )
 
 const (

--- a/share/k8sutils/k8sutils.go
+++ b/share/k8sutils/k8sutils.go
@@ -1,0 +1,47 @@
+package k8sutils
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const NV_NAMESPACE = "{nv_namespace}"
+const ALL_NAMESPACE = "{all_namespace}"
+
+func CanI(clientset *kubernetes.Clientset, ra authorizationv1.ResourceAttributes, namespace string) (bool, error) {
+
+	if ra.Namespace == NV_NAMESPACE {
+		ra.Namespace = namespace
+	} else if ra.Namespace == ALL_NAMESPACE {
+		ra.Namespace = ""
+	}
+
+	client := clientset.AuthorizationV1()
+
+	sar := &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &ra,
+		},
+	}
+
+	response, err := client.SelfSubjectAccessReviews().Create(context.TODO(), sar, metav1.CreateOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	if response.Status.Allowed {
+		return true, nil
+	} else {
+		log.WithFields(log.Fields{
+			"resource":         ra,
+			"reason":           response.Status.Reason,
+			"evaluation_error": response.Status.EvaluationError,
+		}).Info("the action is not allowed")
+		return false, nil
+	}
+}

--- a/share/k8sutils/permissions.go
+++ b/share/k8sutils/permissions.go
@@ -1,0 +1,209 @@
+package k8sutils
+
+import (
+	authorizationv1 "k8s.io/api/authorization/v1"
+)
+
+var UpgraderPresyncRequiredPermissions = []authorizationv1.ResourceAttributes{
+	// jobs
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "create",
+		Group:       "batch",
+		Resource:    "jobs",
+		Subresource: "",
+		Name:        "",
+	},
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "get",
+		Group:       "batch",
+		Resource:    "jobs",
+		Subresource: "",
+		Name:        "",
+	},
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "delete",
+		Group:       "batch",
+		Resource:    "jobs",
+		Subresource: "",
+		Name:        "",
+	},
+	// cronjobs
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "update",
+		Group:       "batch",
+		Resource:    "cronjobs",
+		Subresource: "",
+		Name:        "",
+	},
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "patch",
+		Group:       "batch",
+		Resource:    "cronjobs",
+		Subresource: "",
+		Name:        "",
+	},
+	// cronjobs/finalizers
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "update",
+		Group:       "batch",
+		Resource:    "cronjobs",
+		Subresource: "finalizers",
+		Name:        "",
+	},
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "patch",
+		Group:       "batch",
+		Resource:    "cronjobs",
+		Subresource: "finalizers",
+		Name:        "",
+	},
+}
+
+var UpgraderPostsyncRequiredPermissions = []authorizationv1.ResourceAttributes{
+	// secrets
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "get",
+		Group:       "",
+		Resource:    "secrets",
+		Subresource: "",
+		Name:        "",
+	},
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "update",
+		Group:       "",
+		Resource:    "secrets",
+		Subresource: "",
+		Name:        "",
+	},
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "list",
+		Group:       "",
+		Resource:    "secrets",
+		Subresource: "",
+		Name:        "",
+	},
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "watch",
+		Group:       "",
+		Resource:    "secrets",
+		Subresource: "",
+		Name:        "",
+	},
+	// pods
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "get",
+		Group:       "",
+		Resource:    "pods",
+		Subresource: "",
+		Name:        "",
+	},
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "list",
+		Group:       "",
+		Resource:    "pods",
+		Subresource: "",
+		Name:        "",
+	},
+	// deployments
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "get",
+		Group:       "apps",
+		Resource:    "deployments",
+		Subresource: "",
+		Name:        "",
+	},
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "list",
+		Group:       "apps",
+		Resource:    "deployments",
+		Subresource: "",
+		Name:        "",
+	},
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "watch",
+		Group:       "apps",
+		Resource:    "deployments",
+		Subresource: "",
+		Name:        "",
+	},
+	// daemonsets
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "get",
+		Group:       "apps",
+		Resource:    "daemonsets",
+		Subresource: "",
+		Name:        "",
+	},
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "list",
+		Group:       "apps",
+		Resource:    "daemonsets",
+		Subresource: "",
+		Name:        "",
+	},
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "watch",
+		Group:       "apps",
+		Resource:    "daemonsets",
+		Subresource: "",
+		Name:        "",
+	},
+	// cronjobs
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "update",
+		Group:       "batch",
+		Resource:    "cronjobs",
+		Subresource: "",
+		Name:        "",
+	},
+}
+
+var SecretInformerRequiredPermissions = []authorizationv1.ResourceAttributes{
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "get",
+		Group:       "",
+		Version:     "v1",
+		Resource:    "secrets",
+		Subresource: "",
+		Name:        "",
+	},
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "list",
+		Group:       "",
+		Version:     "v1",
+		Resource:    "secrets",
+		Subresource: "",
+		Name:        "",
+	},
+	{
+		Namespace:   NV_NAMESPACE,
+		Verb:        "watch",
+		Group:       "",
+		Version:     "v1",
+		Resource:    "secrets",
+		Subresource: "",
+		Name:        "",
+	},
+}


### PR DESCRIPTION
This PR contains two parts of changes:

### Allow NV to start when RBAC settings are out-of date

It's possible that users have out-of-date RBAC settings in their environment, for example, these settings are maintained by other team.  Without proper RBAC settings, NV components can fail to start.

This commit fixes the issue by checking required RBAC permission and falling back if the check fails.

### Generate alerts when required RBAC settings not not present

When the resources are missing, controller will remind users by generating alerts.