### PR TITLE
NVSHAS-9292: Fix Ingress Egress esposure shows 0 Vulnerabilities

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -283,7 +283,7 @@ func main() {
 	policy_puller := flag.Int("policy_puller", 0, "set policy pulling period")
 	autoProfile := flag.Int("apc", 1, "Enable auto profile collection")
 	custom_check_control := flag.String("cbench", share.CustomCheckControl_Disable, "Custom check control")
-	syslog_level := flag.String("syslog_level", share.SyslogLevel_Info, "Syslog level")
+	syslog_level := flag.String("enf_syslog_level", share.SyslogLevel_Info, "Enforcer syslog level")
 	flag.Parse()
 
 	// debug setting will overrite syslog_level setting

--- a/monitor/monitor.c
+++ b/monitor/monitor.c
@@ -59,7 +59,7 @@
 #define ENV_CSP_PAUSE_INTERVAL "CSP_PAUSE_INTERVAL"
 #define ENV_AUTOPROFILE_CLT    "AUTO_PROFILE_COLLECT"
 #define ENV_SET_CUSTOM_BENCH   "CUSTOM_CHECK_CONTROL"
-#define ENV_AGT_SYSLOG_LEVEL   "AGT_SYSLOG_LEVEL"
+#define ENV_ENF_SYSLOG_LEVEL   "ENF_SYSLOG_LEVEL"
 
 #define ENV_SCANNER_DOCKER_URL  "SCANNER_DOCKER_URL"
 #define ENV_SCANNER_LICENSE     "SCANNER_LICENSE"
@@ -217,7 +217,7 @@ static pid_t fork_exec(int i)
     char *license, *registry, *repository, *tag, *user, *pass, *base, *api_user, *api_pass, *enable;
     char *on_demand, *pwd_valid_unit, *rancher_ep, *debug_level, *policy_pull_period, *search_regs;
     char *telemetry_neuvector_ep, *telemetry_current_ver, *telemetry_freq, *csp_env, *csp_pause_interval;
-    char *custom_check_control, *syslog_level;
+    char *custom_check_control, *enf_syslog_level;
     int a;
 
     switch (i) {
@@ -535,9 +535,9 @@ static pid_t fork_exec(int i)
             args[a++] = "-cbench";
             args[a++] = custom_check_control;
         }
-        if ((syslog_level = getenv(ENV_AGT_SYSLOG_LEVEL)) != NULL) {
-            args[a ++] = "-syslog_level";
-            args[a ++] = syslog_level;
+        if ((enf_syslog_level = getenv(ENV_ENF_SYSLOG_LEVEL)) != NULL) {
+            args[a ++] = "-enf_syslog_level";
+            args[a ++] = enf_syslog_level;
         }
         args[a] = NULL;
         break;


### PR DESCRIPTION
1. Fix Ingress Egress esposure shows 0 Vulnerabilities
2. Rename AGE_SYSLOG_LEVEL to ENF_SYSLOG_LEVEL to make naming consistent