### PR TITLE
fix: NVSHAS-9336 secret controller not work

### DIFF
--- a/share/migration/migration_informer.go
+++ b/share/migration/migration_informer.go
@@ -253,7 +253,8 @@ func (c *InternalSecretController) secretUpdate(old, new interface{}) {
 	// Note: There is no guarantee that oldSecret will be available, but for checking it's enough.
 	if reflect.DeepEqual(oldSecret.Data[ACTIVE_SECRET_PREFIX+CACERT_FILENAME], newSecret.Data[ACTIVE_SECRET_PREFIX+CACERT_FILENAME]) &&
 		reflect.DeepEqual(oldSecret.Data[ACTIVE_SECRET_PREFIX+CERT_FILENAME], newSecret.Data[ACTIVE_SECRET_PREFIX+CERT_FILENAME]) &&
-		reflect.DeepEqual(oldSecret.Data[ACTIVE_SECRET_PREFIX+KEY_FILENAME], newSecret.Data[ACTIVE_SECRET_PREFIX+KEY_FILENAME]) {
+		reflect.DeepEqual(oldSecret.Data[ACTIVE_SECRET_PREFIX+KEY_FILENAME], newSecret.Data[ACTIVE_SECRET_PREFIX+KEY_FILENAME]) &&
+		reflect.DeepEqual(oldSecret.Annotations, newSecret.Annotations) {
 
 		log.WithField("rev", newSecret.ResourceVersion).Debug("Internal certs has been applied before.")
 		healthz.UpdateStatus("cert.revision", newSecret.ResourceVersion)


### PR DESCRIPTION
In the previous version, annotation changes get ignored, which lead to these components wait indefinitely if annotation is the only part changed.

This commit fixes the issue by not ignoring the annotation change.