### PR TITLE
NVSHAS-7687 & 9006: Redesign LogLevel setting in enforcer and controller

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -246,13 +246,14 @@ func dumpGoroutineStack() {
 func main() {
 	var joinAddr, advAddr, bindAddr string
 	var err error
+	debug := false
 
 	log.SetOutput(os.Stdout)
-	log.SetLevel(share.CLUSGetSyslogLevel(gInfo.agentConfig.SyslogLevel))
+	log.SetLevel(share.CLUSGetLogLevel(gInfo.agentConfig.LogLevel))
 	log.SetFormatter(&utils.LogFormatter{Module: "AGT"})
 
 	connLog.Out = os.Stdout
-	connLog.Level = share.CLUSGetSyslogLevel(gInfo.agentConfig.SyslogLevel)
+	connLog.Level = share.CLUSGetLogLevel(gInfo.agentConfig.LogLevel)
 	connLog.Formatter = &utils.LogFormatter{Module: "AGT"}
 
 	log.WithFields(log.Fields{"version": Version}).Info("START")
@@ -264,7 +265,7 @@ func main() {
 	// }
 
 	withCtlr := flag.Bool("c", false, "Coexist controller and ranger")
-	debug := flag.Bool("d", false, "Enable control path debug")
+	log_level := flag.String("log_level", share.LogLevel_Info, "Enforcer log level")
 	debug_level := flag.String("v", "", "debug level")
 	join := flag.String("j", "", "Cluster join address")
 	adv := flag.String("a", "", "Cluster advertise address")
@@ -283,27 +284,24 @@ func main() {
 	policy_puller := flag.Int("policy_puller", 0, "set policy pulling period")
 	autoProfile := flag.Int("apc", 1, "Enable auto profile collection")
 	custom_check_control := flag.String("cbench", share.CustomCheckControl_Disable, "Custom check control")
-	syslog_level := flag.String("enf_syslog_level", share.SyslogLevel_Info, "Enforcer syslog level")
 	flag.Parse()
 
-	// debug setting will overrite syslog_level setting
-	if *debug {
-		log.SetLevel(log.DebugLevel)
-		gInfo.agentConfig.Debug = []string{"ctrl"}
-	} else if *syslog_level != "" && *syslog_level != gInfo.agentConfig.SyslogLevel {
-		gInfo.agentConfig.SyslogLevel = *syslog_level
-		log.SetLevel(share.CLUSGetSyslogLevel(gInfo.agentConfig.SyslogLevel))
-		connLog.Level = share.CLUSGetSyslogLevel(gInfo.agentConfig.SyslogLevel)
-		if *syslog_level == share.SyslogLevel_Debug {
+	// default log_level is LogLevel_Info
+	if *log_level == share.LogLevel_Debug ||
+	   *log_level == share.LogLevel_Warn || 
+	   *log_level == share.LogLevel_Error {
+		gInfo.agentConfig.LogLevel = *log_level
+		log.SetLevel(share.CLUSGetLogLevel(gInfo.agentConfig.LogLevel))
+		if *log_level == share.LogLevel_Debug {
+			debug = true
 			gInfo.agentConfig.Debug = []string{"ctrl"}
+		} else {
+			connLog.Level = share.CLUSGetLogLevel(gInfo.agentConfig.LogLevel)
 		}
 	}
 
-	if *debug_level != "" {
+	if debug && *debug_level != "" {
 		levels := utils.NewSetFromSliceKind(append(gInfo.agentConfig.Debug, strings.Split(*debug_level, " ")...))
-		if !*debug && *syslog_level != share.SyslogLevel_Debug && levels.Contains("ctrl") {
-			levels.Remove("ctrl")
-		}
 		gInfo.agentConfig.Debug = levels.ToStringSlice()
 	}
 
@@ -601,7 +599,7 @@ func main() {
 	clusterCfg.BindAddr = bindAddr
 	clusterCfg.LANPort = *lanPort
 	clusterCfg.DataCenter = cluster.DefaultDataCenter
-	clusterCfg.EnableDebug = *debug
+	clusterCfg.EnableDebug = debug
 
 	if err = clusterStart(&clusterCfg); err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Failed to start cluster. Exit!")
@@ -674,7 +672,7 @@ func main() {
 		WalkHelper:           walkerTask,
 	}
 
-	if prober, err = probe.New(&probeConfig, gInfo.agentConfig.SyslogLevel); err != nil {
+	if prober, err = probe.New(&probeConfig, gInfo.agentConfig.LogLevel); err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Failed to probe. Exit!")
 		os.Exit(-2)
 	}
@@ -692,7 +690,7 @@ func main() {
 		EstRule:        cbEstimateFileAlertByGroup,
 	}
 
-	if fileWatcher, err = fsmon.NewFileWatcher(&fmonConfig, gInfo.agentConfig.SyslogLevel); err != nil {
+	if fileWatcher, err = fsmon.NewFileWatcher(&fmonConfig, gInfo.agentConfig.LogLevel); err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Failed to open file monitor!")
 		os.Exit(-2)
 	}

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -146,7 +146,7 @@ var gInfo localSystemInfo = localSystemInfo{
 	internalSubnets:  make(map[string]share.CLUSSubnet),
 	containerConfig:  make(map[string]*share.CLUSWorkloadConfig),
 	policyMode:       defaultPolicyMode,
-	agentConfig:      share.CLUSAgentConfig{Debug: make([]string, 0), SyslogLevel: "info"},
+	agentConfig:      share.CLUSAgentConfig{Debug: make([]string, 0), LogLevel: "info"},
 	hostIPs:          utils.NewSet(),
 	tapProxymesh:     defaultTapProxymesh,
 	jumboFrameMTU:    false,

--- a/agent/probe/probe.go
+++ b/agent/probe/probe.go
@@ -458,7 +458,7 @@ func (p *Probe) delayProcReportService() {
 	}
 }
 
-func New(pc *ProbeConfig, syslogLevel string) (*Probe, error) {
+func New(pc *ProbeConfig, logLevel string) (*Probe, error) {
 	log.Info()
 	p := &Probe{
 		bProfileEnable:       pc.ProfileEnable,
@@ -503,7 +503,7 @@ func New(pc *ProbeConfig, syslogLevel string) (*Probe, error) {
 
 	// for process
 	mLog.Out = os.Stdout
-	mLog.Level = share.CLUSGetSyslogLevel(syslogLevel)
+	mLog.Level = share.CLUSGetLogLevel(logLevel)
 	mLog.Formatter = &utils.LogFormatter{Module: "AGT"}
 	if pc.EnableTrace {
 		mLog.SetLevel(log.DebugLevel)

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -2883,11 +2883,11 @@ func (p *Probe) HandleProcessPolicyChange(id string, pid int, pg *share.CLUSProc
 	}
 }
 
-func (p *Probe) SetMonitorTrace(bEnable bool, syslogLevel string) {
+func (p *Probe) SetMonitorTrace(bEnable bool, logLevel string) {
 	if bEnable {
 		mLog.Level = log.DebugLevel
 	} else {
-		mLog.Level = share.CLUSGetSyslogLevel(syslogLevel)
+		mLog.Level = share.CLUSGetLogLevel(logLevel)
 	}
 }
 

--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -1472,7 +1472,7 @@ type RESTAgentConfig struct {
 	Debug            *[]string `json:"debug,omitempty"`
 	DisableNvProtect *bool     `json:"disable_nvprotect,omitempty"`
 	DisableKvCCtl    *bool     `json:"disable_kvcctl,omitempty"`
-	SyslogLevel      *string   `json:"syslog_level,omitempty"`
+	LogLevel         *string   `json:"log_level,omitempty"`
 }
 
 type RESTAgentConfigData struct {
@@ -1492,7 +1492,8 @@ type RESTControllerCounterData struct {
 }
 
 type RESTControllerConfig struct {
-	Debug *[]string `json:"debug,omitempty"`
+	Debug    *[]string `json:"debug,omitempty"`
+	LogLevel *string   `json:"log_level,omitempty"`
 }
 
 type RESTControllerConfigData struct {

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -1029,7 +1029,8 @@ func (m CacheMethod) GetControllerConfig(id string, acc *access.AccessControl) (
 		}
 
 		return &api.RESTControllerConfig{
-			Debug: &cache.config.Debug,
+			Debug:    &cache.config.Debug,
+			LogLevel: &cache.config.LogLevel,
 		}, nil
 	}
 	return nil, common.ErrObjectNotFound
@@ -1090,7 +1091,8 @@ func (m CacheMethod) GetAgentConfig(id string, acc *access.AccessControl) (*api.
 		}
 
 		return &api.RESTAgentConfig{
-			Debug: &cache.config.Debug,
+			Debug:    &cache.config.Debug,
+			LogLevel: &cache.config.LogLevel,
 		}, nil
 	}
 	return nil, common.ErrObjectNotFound

--- a/controller/common/common.go
+++ b/controller/common/common.go
@@ -32,6 +32,9 @@ const ReservedUserNameIBMSA string = "~nv.reserved.ibmsa"
 
 const ScanPlatformID = "platform"
 
+const DefaultCtrlLogLevel string = "info"
+var CtrlLogLevel string = DefaultCtrlLogLevel
+
 type LocalDevice struct {
 	Host   *share.CLUSHost
 	Ctrler *share.CLUSController

--- a/controller/rest/device.go
+++ b/controller/rest/device.go
@@ -418,6 +418,26 @@ func handlerControllerConfig(w http.ResponseWriter, r *http.Request, ps httprout
 			cconf.Debug = *rconf.Config.Debug
 		}
 
+		if rconf.Config.LogLevel != nil {
+			cconf.LogLevel = *rconf.Config.LogLevel
+			if cconf.LogLevel == share.LogLevel_Error ||
+			   cconf.LogLevel == share.LogLevel_Warn ||
+			   cconf.LogLevel == share.LogLevel_Info {
+				cconf.Debug = nil
+			} else if cconf.LogLevel == share.LogLevel_Debug {
+				if cconf.Debug == nil {
+					cconf.Debug = make([]string, 0)
+					cconf.Debug = append(cconf.Debug, "cpath")
+				}
+			}
+		} else {
+			if rconf.Config.Debug != nil {
+				cconf.LogLevel = share.LogLevel_Debug
+			} else {
+				cconf.LogLevel = ""
+			}
+		}
+
 		if !acc.Authorize(&cconf, nil) {
 			restRespAccessDenied(w, login)
 			return
@@ -515,8 +535,24 @@ func handlerAgentConfig(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 			cconf.DisableKvCongestCtl = *rconf.Config.DisableKvCCtl
 		}
 
-		if rconf.Config.SyslogLevel != nil {
-			cconf.SyslogLevel = *rconf.Config.SyslogLevel
+		if rconf.Config.LogLevel != nil {
+			cconf.LogLevel = *rconf.Config.LogLevel
+			if cconf.LogLevel == share.LogLevel_Error ||
+			   cconf.LogLevel == share.LogLevel_Warn ||
+			   cconf.LogLevel == share.LogLevel_Info {
+				cconf.Debug = nil
+			} else if cconf.LogLevel == share.LogLevel_Debug {
+				if cconf.Debug == nil {
+					cconf.Debug = make([]string, 0)
+					cconf.Debug = append(cconf.Debug, "cpath")
+				}
+			}
+		} else {
+			if rconf.Config.Debug != nil {
+				cconf.LogLevel = share.LogLevel_Debug
+			} else {
+				cconf.LogLevel = ""
+			}
 		}
 
 		if !acc.Authorize(&cconf, nil) {

--- a/monitor/monitor.c
+++ b/monitor/monitor.c
@@ -59,7 +59,6 @@
 #define ENV_CSP_PAUSE_INTERVAL "CSP_PAUSE_INTERVAL"
 #define ENV_AUTOPROFILE_CLT    "AUTO_PROFILE_COLLECT"
 #define ENV_SET_CUSTOM_BENCH   "CUSTOM_CHECK_CONTROL"
-#define ENV_ENF_SYSLOG_LEVEL   "ENF_SYSLOG_LEVEL"
 
 #define ENV_SCANNER_DOCKER_URL  "SCANNER_DOCKER_URL"
 #define ENV_SCANNER_LICENSE     "SCANNER_LICENSE"
@@ -217,7 +216,7 @@ static pid_t fork_exec(int i)
     char *license, *registry, *repository, *tag, *user, *pass, *base, *api_user, *api_pass, *enable;
     char *on_demand, *pwd_valid_unit, *rancher_ep, *debug_level, *policy_pull_period, *search_regs;
     char *telemetry_neuvector_ep, *telemetry_current_ver, *telemetry_freq, *csp_env, *csp_pause_interval;
-    char *custom_check_control, *enf_syslog_level;
+    char *custom_check_control, *log_level;
     int a;
 
     switch (i) {
@@ -337,11 +336,13 @@ static pid_t fork_exec(int i)
             args[a ++] = "-b";
         }
 */
-        if ((enable = getenv(ENV_CTRL_PATH_DEBUG)) != NULL) {
-            if (checkImplicitEnableFlag(enable) == 1) {
-                args[a ++] = "-d";
+        if ((log_level = getenv(ENV_CTRL_PATH_DEBUG)) != NULL) {
+            if (checkImplicitEnableFlag(log_level) == 1) {
+                log_level = "debug";
                 g_debugOpa = 1;
             }
+            args[a ++] = "-log_level";
+            args[a ++] = log_level;
         }
         if ((search_regs = getenv(ENV_CTRL_SEARCH_REGS)) != NULL) {
             args[a ++] = "-search_registries";
@@ -492,10 +493,12 @@ static pid_t fork_exec(int i)
             args[a ++] = "-u";
             args[a ++] = url;
         }
-        if ((enable = getenv(ENV_CTRL_PATH_DEBUG)) != NULL) {
-            if (checkImplicitEnableFlag(enable) == 1) {
-                args[a ++] = "-d";
+        if ((log_level = getenv(ENV_CTRL_PATH_DEBUG)) != NULL) {
+            if (checkImplicitEnableFlag(log_level) == 1) {
+                log_level = "debug";
             }
+            args[a ++] = "-log_level";
+            args[a ++] = log_level;
         }
         if ((debug_level = getenv(ENV_DEBUG_LEVEL)) != NULL) {
             args[a ++] = "-v";
@@ -534,10 +537,6 @@ static pid_t fork_exec(int i)
         if ((custom_check_control = getenv(ENV_SET_CUSTOM_BENCH)) != NULL) {
             args[a++] = "-cbench";
             args[a++] = custom_check_control;
-        }
-        if ((enf_syslog_level = getenv(ENV_ENF_SYSLOG_LEVEL)) != NULL) {
-            args[a ++] = "-enf_syslog_level";
-            args[a ++] = enf_syslog_level;
         }
         args[a] = NULL;
         break;

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -1262,11 +1262,12 @@ type CLUSAgentConfig struct {
 	Debug                []string `json:"debug,omitempty"`
 	DisableNvProtectMode bool     `json:"disable_nvprotect"`
 	DisableKvCongestCtl  bool     `json:"disable_kvcctl"`
-	SyslogLevel          string   `json:"syslog_level,omitempty"`
+	LogLevel             string   `json:"log_level,omitempty"`
 }
 
 type CLUSControllerConfig struct {
-	Debug []string `json:"debug,omitempty"`
+	Debug    []string `json:"debug,omitempty"`
+	LogLevel string   `json:"log_level,omitempty"`
 }
 
 type CLUSVolume struct {
@@ -1713,34 +1714,25 @@ const (
 )
 
 const (
-	SyslogLevel_Panic = "panic"
-	SyslogLevel_Fatal = "fatal"
-	SyslogLevel_Error = "error"
-	SyslogLevel_Warn  = "warn"
-	SyslogLevel_Info  = "info"
-	SyslogLevel_Debug = "debug"
-	SyslogLevel_Trace = "trace"
+	LogLevel_Error = "error"
+	LogLevel_Warn  = "warn"
+	LogLevel_Info  = "info"
+	LogLevel_Debug = "debug"
 )
 
-func CLUSGetSyslogLevel(syslogLevel string) log.Level {
-	switch syslogLevel {
-	case SyslogLevel_Panic:
-		return log.PanicLevel
-	case SyslogLevel_Fatal:
-		return log.FatalLevel
-	case SyslogLevel_Error:
+func CLUSGetLogLevel(logLevel string) log.Level {
+	switch logLevel {
+	case LogLevel_Error:
 		return log.ErrorLevel
-	case SyslogLevel_Warn:
+	case LogLevel_Warn:
 		return log.WarnLevel
-	case SyslogLevel_Debug:
+	case LogLevel_Info:
+		return log.InfoLevel
+	case LogLevel_Debug:
 		return log.DebugLevel
-	case SyslogLevel_Trace:
-		return log.TraceLevel
-	case SyslogLevel_Info:
 	default:
 		return log.InfoLevel
 	}
-	return log.InfoLevel
 }
 
 type CLUSCustomCheck struct {

--- a/share/cluster/intfs.go
+++ b/share/cluster/intfs.go
@@ -1073,14 +1073,11 @@ func SetLogLevel(level log.Level) {
 	}
 
 	switch level {
-	case log.PanicLevel:
-	case log.FatalLevel:
 	case log.ErrorLevel:
 	case log.WarnLevel:
 	case log.InfoLevel:
 		clusterCfg.Debug = false
 	case log.DebugLevel:
-	case log.TraceLevel:
 		clusterCfg.Debug = true
 	default:
 		log.WithFields(log.Fields{"level": level}).Error("Not supported")

--- a/share/fsmon/monitor.go
+++ b/share/fsmon/monitor.go
@@ -222,10 +222,10 @@ type FileMonitorConfig struct {
 	EstRule        EstimateRuleSrcCallback
 }
 
-func NewFileWatcher(config *FileMonitorConfig, syslogLevel string) (*FileWatch, error) {
+func NewFileWatcher(config *FileMonitorConfig, logLevel string) (*FileWatch, error) {
 	// for file monitor
 	mLog.Out = os.Stdout
-	mLog.Level = share.CLUSGetSyslogLevel(syslogLevel)
+	mLog.Level = share.CLUSGetLogLevel(logLevel)
 	mLog.Formatter = &utils.LogFormatter{Module: "AGT"}
 	if config.EnableTrace {
 		mLog.SetLevel(log.DebugLevel)
@@ -972,11 +972,11 @@ func (w *FileWatch) GetProbeData() *FmonProbeData {
 	return &probeData
 }
 
-func (w *FileWatch) SetMonitorTrace(bEnable bool, syslogLevel string) {
+func (w *FileWatch) SetMonitorTrace(bEnable bool, logLevel string) {
 	if bEnable {
 		mLog.Level = log.DebugLevel
 	} else {
-		mLog.Level = share.CLUSGetSyslogLevel(syslogLevel)
+		mLog.Level = share.CLUSGetLogLevel(logLevel)
 	}
 }
 


### PR DESCRIPTION
1. Rename shared variables with enforcer & controller
2. Introduce "error", "warn", "info", "debug" level for config via helm & runtime