### PR TITLE
NVSHAS-9338:Alert 'Managed cluster [id] is disconnected from primary …

### DIFF
--- a/controller/access/access.go
+++ b/controller/access/access.go
@@ -743,7 +743,7 @@ func CompileUriPermitsMapping() {
 				"v1/session/summary",
 				"v1/file_monitor_file",
 				"v1/system/usage",
-				"v1/system/rbac",
+				"v1/system/alerts",
 			},
 			CONST_API_RT_SCAN: []string{
 				"v1/scan/config",

--- a/controller/access/access_test.go
+++ b/controller/access/access_test.go
@@ -1179,7 +1179,7 @@ func TestCompileApiUrisMappingMapping(t *testing.T) {
 			"v1/session/summary",
 			"v1/file_monitor_file",
 			"v1/system/usage",
-			"v1/system/rbac",
+			"v1/system/alerts",
 		},
 		CONST_API_RT_SCAN: []string{
 			"v1/scan/config",

--- a/controller/cache/federation.go
+++ b/controller/cache/federation.go
@@ -471,7 +471,7 @@ func (m CacheMethod) GetFedJoinedClusterNameList(acc *access.AccessControl) []st
 	fedCacheMutexRLock()
 	defer fedCacheMutexRUnlock()
 
-	if acc.Authorize(&fedMembershipCache, nil) {
+	if acc.Authorize(&fedMembershipCache, nil) || acc.HasPermFed() {
 		list := make([]string, 0, len(fedJoinedClustersCache))
 		for _, c := range fedJoinedClustersCache {
 			list = append(list, c.cluster.Name)
@@ -497,7 +497,7 @@ func (m CacheMethod) GetFedJoinedClusterStatus(id string, acc *access.AccessCont
 	fedCacheMutexRLock()
 	defer fedCacheMutexRUnlock()
 
-	if acc.Authorize(&fedMembershipCache, nil) {
+	if acc.Authorize(&fedMembershipCache, nil) || acc.HasPermFed() {
 		if s, ok := fedJoinedClusterStatusCache[id]; ok {
 			return s
 		}


### PR DESCRIPTION
…cluster' is incorrectly displayed even when the managed cluster is connected