### PR TITLE
fix: NVSHAS-9358 image scan using proxy would fail

### DIFF
--- a/share/scan/registry/registry.go
+++ b/share/scan/registry/registry.go
@@ -8,7 +8,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/httpclient"
 	"github.com/neuvector/neuvector/share/httptrace"
 )
@@ -35,14 +34,7 @@ const longTimeout = 300 * time.Second
 func New(registryUrl, token, username, password, proxy string, trace httptrace.HTTPTrace) (*Registry, uint, error) {
 	var transport *http.Transport
 
-	proxyURL := httpclient.ParseProxy(&share.CLUSProxy{
-		Enable:   true,
-		URL:      proxy,
-		Username: username,
-		Password: password,
-	})
-
-	t, err := httpclient.GetTransport(proxyURL)
+	t, err := httpclient.GetTransport(proxy)
 	if err != nil {
 		log.WithError(err).Warn("failed to get transport")
 		return nil, 0, fmt.Errorf("failed to get transport: %w", err)


### PR DESCRIPTION
In the previous version, proxy setting is incorrectly derived from wrong fields.  This commit fixes the issue.