### PR TITLE
fix: NVSHAS-9387 get namespace from k8s token

### DIFF
--- a/upgrader/postsync.go
+++ b/upgrader/postsync.go
@@ -948,6 +948,14 @@ func PostSyncHook(ctx *cli.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx.Context, timeout)
 	defer cancel()
 
+	log.Info("Getting running namespace")
+
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		namespace = string(data)
+	} else {
+		log.WithError(err).Warn("failed to open namespace file.")
+	}
+
 	log.Info("Creating k8s client")
 
 	client, err := NewK8sClient(kubeconfig)

--- a/upgrader/presync.go
+++ b/upgrader/presync.go
@@ -300,6 +300,14 @@ func PreSyncHook(ctx *cli.Context) error {
 	secretName := ctx.String("internal-secret-name")
 	timeout := ctx.Duration("timeout")
 
+	log.Info("Getting running namespace")
+
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		namespace = string(data)
+	} else {
+		log.WithError(err).Warn("failed to open namespace file.")
+	}
+
 	log.WithFields(log.Fields{
 		"namespace":  namespace,
 		"kubeconfig": kubeconfig,


### PR DESCRIPTION
In one of the previous changes, POD_NAMESPACE environment is removed from cert-upgrader.  This leads to not being able to get the correct namespace when running in a non-default namespace, e.g., `cattle-system`.

This PR fixes the issue by getting namespace from service account folder.