### PR TITLE
[NVSHAS-9393] Add init platform for docker in getPlatform

### DIFF
--- a/share/global/global.go
+++ b/share/global/global.go
@@ -156,6 +156,7 @@ func getPlatform(containers []*container.ContainerMeta) (string, string, string,
 		}
 		// continue parsing flavor and network
 	case "":
+		platform = share.PlatformDocker
 		for _, c := range containers {
 			containerPlatform, containerCloudPlatform := getContainerPlatform(c)
 			// Find the first platform is not docker then update it


### PR DESCRIPTION
### Summary
Add docker as platform default, or it will return "" when the platform is docker.

### Test perform

1. check the platform will be empty in current build
2. check the platform will be correct in custom build