### PR TITLE
[NVSHAS-8799] Not to remove the prime yaml

### DIFF
--- a/share/scan/compliance.go
+++ b/share/scan/compliance.go
@@ -3247,23 +3247,6 @@ func UpdateComplianceConfigs() {
 		MetaMap: imageBenchMetaMap,
 	}
 
-	defer func() {
-		files, err := os.ReadDir(primeConfigFolder)
-		if err != nil {
-			log.WithFields(log.Fields{"err": err}).Info("Failed to read directory: ")
-		}
-
-		for _, file := range files {
-			if !file.IsDir() {
-				filePath := filepath.Join(primeConfigFolder, file.Name())
-				err = os.Remove(filePath)
-				if err != nil {
-					log.WithFields(log.Fields{"err": err}).Info("Failed to remove file: ")
-				}
-			}
-		}
-	}()
-
 	cisConfigLoaded := LoadConfig(primeCISConfig, complianceMetaConfig, true)
 	dockerConfigLoaded := LoadConfig(primeDockerConfig, complianceMetaConfig, true)
 	dockerImageConfigLoaded := LoadConfig(primeDockerImageConfig, complianceMetaConfig, true)

--- a/share/scan/compliance_test.go
+++ b/share/scan/compliance_test.go
@@ -497,15 +497,6 @@ func TestUpdateComplianceConfigs(t *testing.T) {
 		}
 	}
 
-	// Ensure the primeConfigFolder is empty
-	files, err := os.ReadDir(primeConfigFolder)
-	if err != nil {
-		t.Errorf("failed to read directory: %v", err)
-	}
-	if len(files) != 0 {
-		t.Errorf("Files: %v in primeConfigFolder should be removed", files)
-	}
-
 	// Case 2: Some of the prime file exist, ReadPrimeConfig should be false
 	if ReadPrimeConfig {
 		t.Errorf("Expected ReadPrimeConfig to be false, but get %v", ReadPrimeConfig)


### PR DESCRIPTION
### Summary

- not to remove prime to make sure the user is able to see the prime data