### PR TITLE
Use base image tag: pre54

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: fleet
 
 STAGE_DIR = stage
-BASE_IMAGE_TAG = latest
+BASE_IMAGE_TAG = alpine
 BUILD_IMAGE_TAG = latest
 
 copy_ctrl:


### PR DESCRIPTION
Since 5.4, our latest base image has been upgraded to BCI. The change enable the backport with alpine containers.