### PR TITLE
feat: golangci-lint as git hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+-   repo: local
+    hooks:
+    -   id: golangci-lint-staged
+        name: golangci-lint-staged
+        entry: ./build/pre-commit/golangci-lint-staged
+        language: golang
+        types: [go]
+        require_serial: true

--- a/build/pre-commit/golangci-lint-staged
+++ b/build/pre-commit/golangci-lint-staged
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+GOLANGCI_LINT=`which golangci-lint`
+
+# Check for golangci-lint
+if [[ ! -x "$GOLANGCI_LINT" ]]; then
+  echo "Please install golangci-lint"
+  exit 1
+fi
+
+echo "Running golangci-lint"
+
+cleanup() {
+    rm /tmp/stage.patch
+}
+
+git diff --cached > /tmp/stage.patch
+trap cleanup EXIT
+golangci-lint run --new-from-patch=/tmp/stage.patch
+if [[ $? != 0 ]]; then
+  echo "Linting failed"
+  exit 1
+else
+ echo "Linting passed"
+fi


### PR DESCRIPTION
Adding golangci-lint for developers to scan local changes before committing.

To use this feature, you will need to install [pre-commit](https://pre-commit.com/). 
After that, use `pre-commit install` to install pre-commit hooks and use `pre-commit uninstall` to remove the hooks.
