### PR TITLE
CVE-2024-41110: Upgrade docker package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/containerd/typeurl v1.0.3-0.20220422153119-7f6e6d160d67
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/docker/distribution v2.8.3+incompatible
-	github.com/docker/docker v24.0.9+incompatible
+	github.com/docker/docker v26.1.5+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/doug-martin/goqu/v9 v9.19.0
 	github.com/fsnotify/fsnotify v1.7.0
@@ -78,7 +78,7 @@ require (
 	github.com/containerd/cgroups/v3 v3.0.2 // indirect
 	github.com/containerd/continuity v0.4.2 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect
-	github.com/containerd/log v0.1.0 // indirect
+	github.com/containerd/log v0.1.0
 	github.com/containerd/ttrpc v1.2.4 // indirect
 	github.com/containerd/typeurl/v2 v2.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -89,7 +89,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/google/go-cmp v0.6.0
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK
 github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v24.0.9+incompatible h1:HPGzNmwfLZWdxHqK9/II92pyi1EpYKsAqcl4G0Of9v0=
-github.com/docker/docker v24.0.9+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v26.1.5+incompatible h1:NEAxTwEjxV6VbBMBoGG3zPqbiJosIApZjxlbrG9q3/g=
+github.com/docker/docker v26.1.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c h1:+pKlWGMw7gf6bQ+oDZB4KHQFypsfjYlq/C4rfL7D3g8=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=

--- a/vendor/github.com/docker/docker/AUTHORS
+++ b/vendor/github.com/docker/docker/AUTHORS
@@ -27,6 +27,7 @@ Adam Miller <admiller@redhat.com>
 Adam Mills <adam@armills.info>
 Adam Pointer <adam.pointer@skybettingandgaming.com>
 Adam Singer <financeCoding@gmail.com>
+Adam Thornton <adam.thornton@maryville.com>
 Adam Walz <adam@adamwalz.net>
 Adam Williams <awilliams@mirantis.com>
 AdamKorcz <adam@adalogics.com>
@@ -173,6 +174,7 @@ Andy Rothfusz <github@developersupport.net>
 Andy Smith <github@anarkystic.com>
 Andy Wilson <wilson.andrew.j+github@gmail.com>
 Andy Zhang <andy.zhangtao@hotmail.com>
+Aneesh Kulkarni <askthefactorcamera@gmail.com>
 Anes Hasicic <anes.hasicic@gmail.com>
 Angel Velazquez <angelcar@amazon.com>
 Anil Belur <askb23@gmail.com>
@@ -236,6 +238,7 @@ Ben Golub <ben.golub@dotcloud.com>
 Ben Gould <ben@bengould.co.uk>
 Ben Hall <ben@benhall.me.uk>
 Ben Langfeld <ben@langfeld.me>
+Ben Lovy <ben@deciduously.com>
 Ben Sargent <ben@brokendigits.com>
 Ben Severson <BenSeverson@users.noreply.github.com>
 Ben Toews <mastahyeti@gmail.com>
@@ -262,7 +265,7 @@ Billy Ridgway <wrridgwa@us.ibm.com>
 Bily Zhang <xcoder@tenxcloud.com>
 Bin Liu <liubin0329@gmail.com>
 Bingshen Wang <bingshen.wbs@alibaba-inc.com>
-Bjorn Neergaard <bneergaard@mirantis.com>
+Bjorn Neergaard <bjorn@neersighted.com>
 Blake Geno <blakegeno@gmail.com>
 Boaz Shuster <ripcurld.github@gmail.com>
 bobby abbott <ttobbaybbob@gmail.com>
@@ -279,6 +282,7 @@ Brandon Liu <bdon@bdon.org>
 Brandon Philips <brandon.philips@coreos.com>
 Brandon Rhodes <brandon@rhodesmill.org>
 Brendan Dixon <brendand@microsoft.com>
+Brennan Kinney <5098581+polarathene@users.noreply.github.com>
 Brent Salisbury <brent.salisbury@docker.com>
 Brett Higgins <brhiggins@arbor.net>
 Brett Kochendorfer <brett.kochendorfer@gmail.com>
@@ -363,6 +367,7 @@ chenyuzhu <chenyuzhi@oschina.cn>
 Chetan Birajdar <birajdar.chetan@gmail.com>
 Chewey <prosto-chewey@users.noreply.github.com>
 Chia-liang Kao <clkao@clkao.org>
+Chiranjeevi Tirunagari <vchiranjeeviak.tirunagari@gmail.com>
 chli <chli@freewheel.tv>
 Cholerae Hu <choleraehyq@gmail.com>
 Chris Alfonso <calfonso@redhat.com>
@@ -433,8 +438,8 @@ Cristian Staretu <cristian.staretu@gmail.com>
 cristiano balducci <cristiano.balducci@gmail.com>
 Cristina Yenyxe Gonzalez Garcia <cristina.yenyxe@gmail.com>
 Cruceru Calin-Cristian <crucerucalincristian@gmail.com>
+cui fliter <imcusg@gmail.com>
 CUI Wei <ghostplant@qq.com>
-cuishuang <imcusg@gmail.com>
 Cuong Manh Le <cuong.manhle.vn@gmail.com>
 Cyprian Gracz <cyprian.gracz@micro-jumbo.eu>
 Cyril F <cyrilf7x@gmail.com>
@@ -513,6 +518,7 @@ David Dooling <dooling@gmail.com>
 David Gageot <david@gageot.net>
 David Gebler <davidgebler@gmail.com>
 David Glasser <glasser@davidglasser.net>
+David Karlsson <35727626+dvdksn@users.noreply.github.com>
 David Lawrence <david.lawrence@docker.com>
 David Lechner <david@lechnology.com>
 David M. Karr <davidmichaelkarr@gmail.com>
@@ -602,6 +608,7 @@ Donald Huang <don.hcd@gmail.com>
 Dong Chen <dongluo.chen@docker.com>
 Donghwa Kim <shanytt@gmail.com>
 Donovan Jones <git@gamma.net.nz>
+Dorin Geman <dorin.geman@docker.com>
 Doron Podoleanu <doronp@il.ibm.com>
 Doug Davis <dug@us.ibm.com>
 Doug MacEachern <dougm@vmware.com>
@@ -636,6 +643,7 @@ Emily Rose <emily@contactvibe.com>
 Emir Ozer <emirozer@yandex.com>
 Eng Zer Jun <engzerjun@gmail.com>
 Enguerran <engcolson@gmail.com>
+Enrico Weigelt, metux IT consult <info@metux.net>
 Eohyung Lee <liquidnuker@gmail.com>
 epeterso <epeterson@breakpoint-labs.com>
 er0k <er0k@er0k.net>
@@ -661,6 +669,7 @@ Erik Hollensbe <github@hollensbe.org>
 Erik Inge Bolsø <knan@redpill-linpro.com>
 Erik Kristensen <erik@erikkristensen.com>
 Erik Sipsma <erik@sipsma.dev>
+Erik Sjölund <erik.sjolund@gmail.com>
 Erik St. Martin <alakriti@gmail.com>
 Erik Weathers <erikdw@gmail.com>
 Erno Hopearuoho <erno.hopearuoho@gmail.com>
@@ -676,6 +685,7 @@ Evan Allrich <evan@unguku.com>
 Evan Carmi <carmi@users.noreply.github.com>
 Evan Hazlett <ejhazlett@gmail.com>
 Evan Krall <krall@yelp.com>
+Evan Lezar <elezar@nvidia.com>
 Evan Phoenix <evan@fallingsnow.net>
 Evan Wies <evan@neomantra.net>
 Evelyn Xu <evelynhsu21@gmail.com>
@@ -722,6 +732,7 @@ Feroz Salam <feroz.salam@sourcegraph.com>
 Ferran Rodenas <frodenas@gmail.com>
 Filipe Brandenburger <filbranden@google.com>
 Filipe Oliveira <contato@fmoliveira.com.br>
+Filipe Pina <hzlu1ot0@duck.com>
 Flavio Castelli <fcastelli@suse.com>
 Flavio Crisciani <flavio.crisciani@docker.com>
 Florian <FWirtz@users.noreply.github.com>
@@ -744,6 +755,7 @@ Frank Groeneveld <frank@ivaldi.nl>
 Frank Herrmann <fgh@4gh.tv>
 Frank Macreery <frank@macreery.com>
 Frank Rosquin <frank.rosquin+github@gmail.com>
+Frank Villaro-Dixon <frank.villarodixon@merkle.com>
 Frank Yang <yyb196@gmail.com>
 Fred Lifton <fred.lifton@docker.com>
 Frederick F. Kautz IV <fkautz@redhat.com>
@@ -865,6 +877,8 @@ Hsing-Yu (David) Chen <davidhsingyuchen@gmail.com>
 hsinko <21551195@zju.edu.cn>
 Hu Keping <hukeping@huawei.com>
 Hu Tao <hutao@cn.fujitsu.com>
+Huajin Tong <fliterdashen@gmail.com>
+huang-jl <1046678590@qq.com>
 HuanHuan Ye <logindaveye@gmail.com>
 Huanzhong Zhang <zhanghuanzhong90@gmail.com>
 Huayi Zhang <irachex@gmail.com>
@@ -959,6 +973,7 @@ Jannick Fahlbusch <git@jf-projects.de>
 Januar Wayong <januar@gmail.com>
 Jared Biel <jared.biel@bolderthinking.com>
 Jared Hocutt <jaredh@netapp.com>
+Jaroslav Jindrak <dzejrou@gmail.com>
 Jaroslaw Zabiello <hipertracker@gmail.com>
 Jasmine Hegman <jasmine@jhegman.com>
 Jason A. Donenfeld <Jason@zx2c4.com>
@@ -983,6 +998,7 @@ Jean Rouge <rougej+github@gmail.com>
 Jean-Baptiste Barth <jeanbaptiste.barth@gmail.com>
 Jean-Baptiste Dalido <jeanbaptiste@appgratis.com>
 Jean-Christophe Berthon <huygens@berthon.eu>
+Jean-Michel Rouet <jm.rouet@gmail.com>
 Jean-Paul Calderone <exarkun@twistedmatrix.com>
 Jean-Pierre Huynh <jean-pierre.huynh@ounet.fr>
 Jean-Tiare Le Bigot <jt@yadutaf.fr>
@@ -1001,6 +1017,7 @@ Jeffrey Bolle <jeffreybolle@gmail.com>
 Jeffrey Morgan <jmorganca@gmail.com>
 Jeffrey van Gogh <jvg@google.com>
 Jenny Gebske <jennifer@gebske.de>
+Jeongseok Kang <piono623@naver.com>
 Jeremy Chambers <jeremy@thehipbot.com>
 Jeremy Grosser <jeremy@synack.me>
 Jeremy Huntwork <jhuntwork@lightcubesolutions.com>
@@ -1013,10 +1030,12 @@ Jeroen Jacobs <github@jeroenj.be>
 Jesse Dearing <jesse.dearing@gmail.com>
 Jesse Dubay <jesse@thefortytwo.net>
 Jessica Frazelle <jess@oxide.computer>
+Jeyanthinath Muthuram <jeyanthinath10@gmail.com>
 Jezeniel Zapanta <jpzapanta22@gmail.com>
 Jhon Honce <jhonce@redhat.com>
 Ji.Zhilong <zhilongji@gmail.com>
 Jian Liao <jliao@alauda.io>
+Jian Zeng <anonymousknight96@gmail.com>
 Jian Zhang <zhangjian.fnst@cn.fujitsu.com>
 Jiang Jinyang <jjyruby@gmail.com>
 Jianyong Wu <jianyong.wu@arm.com>
@@ -1141,6 +1160,7 @@ junxu <xujun@cmss.chinamobile.com>
 Jussi Nummelin <jussi.nummelin@gmail.com>
 Justas Brazauskas <brazauskasjustas@gmail.com>
 Justen Martin <jmart@the-coder.com>
+Justin Chadwell <me@jedevc.com>
 Justin Cormack <justin.cormack@docker.com>
 Justin Force <justin.force@gmail.com>
 Justin Keller <85903732+jk-vb@users.noreply.github.com>
@@ -1183,6 +1203,7 @@ Ke Xu <leonhartx.k@gmail.com>
 Kei Ohmura <ohmura.kei@gmail.com>
 Keith Hudgins <greenman@greenman.org>
 Keli Hu <dev@keli.hu>
+Ken Bannister <kb2ma@runbox.com>
 Ken Cochrane <kencochrane@gmail.com>
 Ken Herner <kherner@progress.com>
 Ken ICHIKAWA <ichikawa.ken@jp.fujitsu.com>
@@ -1192,7 +1213,7 @@ Kenjiro Nakayama <nakayamakenjiro@gmail.com>
 Kent Johnson <kentoj@gmail.com>
 Kenta Tada <Kenta.Tada@sony.com>
 Kevin "qwazerty" Houdebert <kevin.houdebert@gmail.com>
-Kevin Alvarez <crazy-max@users.noreply.github.com>
+Kevin Alvarez <github@crazymax.dev>
 Kevin Burke <kev@inburke.com>
 Kevin Clark <kevin.clark@gmail.com>
 Kevin Feyrer <kevin.feyrer@btinternet.com>
@@ -1225,6 +1246,7 @@ Konstantin Gribov <grossws@gmail.com>
 Konstantin L <sw.double@gmail.com>
 Konstantin Pelykh <kpelykh@zettaset.com>
 Kostadin Plachkov <k.n.plachkov@gmail.com>
+kpcyrd <git@rxv.cc>
 Krasi Georgiev <krasi@vip-consult.solutions>
 Krasimir Georgiev <support@vip-consult.co.uk>
 Kris-Mikael Krister <krismikael@protonmail.com>
@@ -1306,6 +1328,7 @@ Lorenzo Fontana <fontanalorenz@gmail.com>
 Lotus Fenn <fenn.lotus@gmail.com>
 Louis Delossantos <ldelossa.ld@gmail.com>
 Louis Opter <kalessin@kalessin.fr>
+Luboslav Pivarc <lpivarc@redhat.com>
 Luca Favatella <luca.favatella@erlang-solutions.com>
 Luca Marturana <lucamarturana@gmail.com>
 Luca Orlandi <luca.orlandi@gmail.com>
@@ -1344,6 +1367,7 @@ Manuel Meurer <manuel@krautcomputing.com>
 Manuel Rüger <manuel@rueg.eu>
 Manuel Woelker <github@manuel.woelker.org>
 mapk0y <mapk0y@gmail.com>
+Marat Radchenko <marat@slonopotamus.org>
 Marc Abramowitz <marc@marc-abramowitz.com>
 Marc Kuo <kuomarc2@gmail.com>
 Marc Tamsky <mtamsky@gmail.com>
@@ -1383,6 +1407,7 @@ Martijn van Oosterhout <kleptog@svana.org>
 Martin Braun <braun@neuroforge.de>
 Martin Dojcak <martin.dojcak@lablabs.io>
 Martin Honermeyer <maze@strahlungsfrei.de>
+Martin Jirku <martin@jirku.sk>
 Martin Kelly <martin@surround.io>
 Martin Mosegaard Amdisen <martin.amdisen@praqma.com>
 Martin Muzatko <martin@happy-css.com>
@@ -1461,6 +1486,7 @@ Michael Holzheu <holzheu@linux.vnet.ibm.com>
 Michael Hudson-Doyle <michael.hudson@canonical.com>
 Michael Huettermann <michael@huettermann.net>
 Michael Irwin <mikesir87@gmail.com>
+Michael Kebe <michael.kebe@hkm.de>
 Michael Kuehn <micha@kuehn.io>
 Michael Käufl <docker@c.michael-kaeufl.de>
 Michael Neale <michael.neale@gmail.com>
@@ -1509,10 +1535,11 @@ Mike Lundy <mike@fluffypenguin.org>
 Mike MacCana <mike.maccana@gmail.com>
 Mike Naberezny <mike@naberezny.com>
 Mike Snitzer <snitzer@redhat.com>
+Mike Sul <mike.sul@foundries.io>
 mikelinjie <294893458@qq.com>
 Mikhail Sobolev <mss@mawhrin.net>
 Miklos Szegedi <miklos.szegedi@cloudera.com>
-Milas Bowman <milasb@gmail.com>
+Milas Bowman <devnull@milas.dev>
 Milind Chawre <milindchawre@gmail.com>
 Miloslav Trmač <mitr@redhat.com>
 mingqing <limingqing@cyou-inc.com>
@@ -1524,6 +1551,7 @@ mlarcher <github@ringabell.org>
 Mohammad Banikazemi <MBanikazemi@gmail.com>
 Mohammad Nasirifar <farnasirim@gmail.com>
 Mohammed Aaqib Ansari <maaquib@gmail.com>
+Mohd Sadiq <mohdsadiq058@gmail.com>
 Mohit Soni <mosoni@ebay.com>
 Moorthy RS <rsmoorthy@gmail.com>
 Morgan Bauer <mbauer@us.ibm.com>
@@ -1606,6 +1634,7 @@ Noah Treuhaft <noah.treuhaft@docker.com>
 NobodyOnSE <ich@sektor.selfip.com>
 noducks <onemannoducks@gmail.com>
 Nolan Darilek <nolan@thewordnerd.info>
+Nolan Miles <nolanpmiles@gmail.com>
 Noriki Nakamura <noriki.nakamura@miraclelinux.com>
 nponeccop <andy.melnikov@gmail.com>
 Nurahmadie <nurahmadie@gmail.com>
@@ -1661,6 +1690,7 @@ Paul Lietar <paul@lietar.net>
 Paul Liljenberg <liljenberg.paul@gmail.com>
 Paul Morie <pmorie@gmail.com>
 Paul Nasrat <pnasrat@gmail.com>
+Paul Seiffert <paul.seiffert@jimdo.com>
 Paul Weaver <pauweave@cisco.com>
 Paulo Gomes <pjbgf@linux.com>
 Paulo Ribeiro <paigr.io@gmail.com>
@@ -1674,6 +1704,7 @@ Pavlos Ratis <dastergon@gentoo.org>
 Pavol Vargovcik <pallly.vargovcik@gmail.com>
 Pawel Konczalski <mail@konczalski.de>
 Paweł Gronowski <pawel.gronowski@docker.com>
+payall4u <payall4u@qq.com>
 Peeyush Gupta <gpeeyush@linux.vnet.ibm.com>
 Peggy Li <peggyli.224@gmail.com>
 Pei Su <sillyousu@gmail.com>
@@ -1703,7 +1734,9 @@ Phil Estes <estesp@gmail.com>
 Phil Sphicas <phil.sphicas@att.com>
 Phil Spitler <pspitler@gmail.com>
 Philip Alexander Etling <paetling@gmail.com>
+Philip K. Warren <pkwarren@gmail.com>
 Philip Monroe <phil@philmonroe.com>
+Philipp Fruck <dev@p-fruck.de>
 Philipp Gillé <philipp.gille@gmail.com>
 Philipp Wahala <philipp.wahala@gmail.com>
 Philipp Weissensteiner <mail@philippweissensteiner.com>
@@ -1741,6 +1774,7 @@ Quentin Brossard <qbrossard@gmail.com>
 Quentin Perez <qperez@ocs.online.net>
 Quentin Tayssier <qtayssier@gmail.com>
 r0n22 <cameron.regan@gmail.com>
+Rachit Sharma <rachitsharma613@gmail.com>
 Radostin Stoyanov <rstoyanov1@gmail.com>
 Rafal Jeczalik <rjeczalik@gmail.com>
 Rafe Colton <rafael.colton@gmail.com>
@@ -1773,6 +1807,7 @@ Rich Horwood <rjhorwood@apple.com>
 Rich Moyse <rich@moyse.us>
 Rich Seymour <rseymour@gmail.com>
 Richard Burnison <rburnison@ebay.com>
+Richard Hansen <rhansen@rhansen.org>
 Richard Harvey <richard@squarecows.com>
 Richard Mathie <richard.mathie@amey.co.uk>
 Richard Metzler <richard@paadee.com>
@@ -1788,6 +1823,7 @@ Ritesh H Shukla <sritesh@vmware.com>
 Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>
 Rob Cowsill <42620235+rcowsill@users.noreply.github.com>
 Rob Gulewich <rgulewich@netflix.com>
+Rob Murray <rob.murray@docker.com>
 Rob Vesse <rvesse@dotnetrdf.org>
 Robert Bachmann <rb@robertbachmann.at>
 Robert Bittle <guywithnose@gmail.com>
@@ -1869,6 +1905,7 @@ ryancooper7 <ryan.cooper7@gmail.com>
 RyanDeng <sheldon.d1018@gmail.com>
 Ryo Nakao <nakabonne@gmail.com>
 Ryoga Saito <contact@proelbtn.com>
+Régis Behmo <regis@behmo.com>
 Rémy Greinhofer <remy.greinhofer@livelovely.com>
 s. rannou <mxs@sbrk.org>
 Sabin Basyal <sabin.basyal@gmail.com>
@@ -1885,6 +1922,7 @@ Sam J Sharpe <sam.sharpe@digital.cabinet-office.gov.uk>
 Sam Neirinck <sam@samneirinck.com>
 Sam Reis <sreis@atlassian.com>
 Sam Rijs <srijs@airpost.net>
+Sam Thibault <sam.thibault@docker.com>
 Sam Whited <sam@samwhited.com>
 Sambuddha Basu <sambuddhabasu1@gmail.com>
 Sami Wagiaalla <swagiaal@redhat.com>
@@ -1908,6 +1946,7 @@ Satoshi Tagomori <tagomoris@gmail.com>
 Scott Bessler <scottbessler@gmail.com>
 Scott Collier <emailscottcollier@gmail.com>
 Scott Johnston <scott@docker.com>
+Scott Moser <smoser@brickies.net>
 Scott Percival <scottp@lastyard.com>
 Scott Stamp <scottstamp851@gmail.com>
 Scott Walls <sawalls@umich.edu>
@@ -1923,6 +1962,7 @@ Sebastiaan van Steenis <mail@superseb.nl>
 Sebastiaan van Stijn <github@gone.nl>
 Sebastian Höffner <sebastian.hoeffner@mevis.fraunhofer.de>
 Sebastian Radloff <sradloff23@gmail.com>
+Sebastian Thomschke <sebthom@users.noreply.github.com>
 Sebastien Goasguen <runseb@gmail.com>
 Senthil Kumar Selvaraj <senthil.thecoder@gmail.com>
 Senthil Kumaran <senthil@uthcode.com>
@@ -1934,6 +1974,7 @@ Sergey Evstifeev <sergey.evstifeev@gmail.com>
 Sergii Kabashniuk <skabashnyuk@codenvy.com>
 Sergio Lopez <slp@redhat.com>
 Serhat Gülçiçek <serhat25@gmail.com>
+Serhii Nakon <serhii.n@thescimus.com>
 SeungUkLee <lsy931106@gmail.com>
 Sevki Hasirci <s@sevki.org>
 Shane Canon <scanon@lbl.gov>
@@ -1996,6 +2037,7 @@ Stanislav Bondarenko <stanislav.bondarenko@gmail.com>
 Stanislav Levin <slev@altlinux.org>
 Steeve Morin <steeve.morin@gmail.com>
 Stefan Berger <stefanb@linux.vnet.ibm.com>
+Stefan Gehrig <stefan.gehrig.hn@googlemail.com>
 Stefan J. Wernli <swernli@microsoft.com>
 Stefan Praszalowicz <stefan@greplin.com>
 Stefan S. <tronicum@user.github.com>
@@ -2003,6 +2045,7 @@ Stefan Scherer <stefan.scherer@docker.com>
 Stefan Staudenmeyer <doerte@instana.com>
 Stefan Weil <sw@weilnetz.de>
 Steffen Butzer <steffen.butzer@outlook.com>
+Stephan Henningsen <stephan-henningsen@users.noreply.github.com>
 Stephan Spindler <shutefan@gmail.com>
 Stephen Benjamin <stephen@redhat.com>
 Stephen Crosby <stevecrozz@gmail.com>
@@ -2204,6 +2247,7 @@ Vinod Kulkarni <vinod.kulkarni@gmail.com>
 Vishal Doshi <vishal.doshi@gmail.com>
 Vishnu Kannan <vishnuk@google.com>
 Vitaly Ostrosablin <vostrosablin@virtuozzo.com>
+Vitor Anjos <bartier@users.noreply.github.com>
 Vitor Monteiro <vmrmonteiro@gmail.com>
 Vivek Agarwal <me@vivek.im>
 Vivek Dasgupta <vdasgupt@redhat.com>
@@ -2217,6 +2261,7 @@ VladimirAus <v_roudakov@yahoo.com>
 Vladislav Kolesnikov <vkolesnikov@beget.ru>
 Vlastimil Zeman <vlastimil.zeman@diffblue.com>
 Vojtech Vitek (V-Teq) <vvitek@redhat.com>
+voloder <110066198+voloder@users.noreply.github.com>
 Walter Leibbrandt <github@wrl.co.za>
 Walter Stanish <walter@pratyeka.org>
 Wang Chao <chao.wang@ucloud.cn>
@@ -2250,6 +2295,7 @@ Wenxuan Zhao <viz@linux.com>
 Wenyu You <21551128@zju.edu.cn>
 Wenzhi Liang <wenzhi.liang@gmail.com>
 Wes Morgan <cap10morgan@gmail.com>
+Wesley Pettit <wppttt@amazon.com>
 Wewang Xiaorenfine <wang.xiaoren@zte.com.cn>
 Wiktor Kwapisiewicz <wiktor@metacode.biz>
 Will Dietz <w@wdtz.org>
@@ -2289,7 +2335,7 @@ xiekeyang <xiekeyang@huawei.com>
 Ximo Guanter Gonzálbez <joaquin.guantergonzalbez@telefonica.com>
 xin.li <xin.li@daocloud.io>
 Xinbo Weng <xihuanbo_0521@zju.edu.cn>
-Xinfeng Liu <xinfeng.liu@gmail.com>
+Xinfeng Liu <XinfengLiu@icloud.com>
 Xinzi Zhou <imdreamrunner@gmail.com>
 Xiuming Chen <cc@cxm.cc>
 Xuecong Liao <satorulogic@gmail.com>
@@ -2355,6 +2401,7 @@ Zen Lin(Zhinan Lin) <linzhinan@huawei.com>
 Zhang Kun <zkazure@gmail.com>
 Zhang Wei <zhangwei555@huawei.com>
 Zhang Wentao <zhangwentao234@huawei.com>
+zhangguanzhang <zhangguanzhang@qq.com>
 ZhangHang <stevezhang2014@gmail.com>
 zhangxianwei <xianwei.zw@alibaba-inc.com>
 Zhenan Ye <21551168@zju.edu.cn>
@@ -2381,6 +2428,7 @@ Zuhayr Elahi <zuhayr.elahi@docker.com>
 Zunayed Ali <zunayed@gmail.com>
 Álvaro Lázaro <alvaro.lazaro.g@gmail.com>
 Átila Camurça Alves <camurca.home@gmail.com>
+吴小白 <296015668@qq.com>
 尹吉峰 <jifeng.yin@gmail.com>
 屈骏 <qujun@tiduyun.com>
 徐俊杰 <paco.xu@daocloud.io>

--- a/vendor/github.com/docker/docker/api/types/registry/registry.go
+++ b/vendor/github.com/docker/docker/api/types/registry/registry.go
@@ -92,7 +92,9 @@ type SearchResult struct {
 	IsOfficial bool `json:"is_official"`
 	// Name is the name of the repository
 	Name string `json:"name"`
-	// IsAutomated indicates whether the result is automated
+	// IsAutomated indicates whether the result is automated.
+	//
+	// Deprecated: the "is_automated" field is deprecated and will always be "false".
 	IsAutomated bool `json:"is_automated"`
 	// Description is a textual description of the repository
 	Description string `json:"description"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -251,7 +251,7 @@ github.com/docker/distribution/manifest
 github.com/docker/distribution/manifest/manifestlist
 github.com/docker/distribution/manifest/schema1
 github.com/docker/distribution/manifest/schema2
-# github.com/docker/docker v24.0.9+incompatible
+# github.com/docker/docker v26.1.5+incompatible
 ## explicit
 github.com/docker/docker/api/types/registry
 # github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c


### PR DESCRIPTION
Upgrade docker's vendor package to v26.1.5
