### PR TITLE
fix: NVSHAS-9442 create lease object for ArgoCD

### DIFF
--- a/upgrader/main.go
+++ b/upgrader/main.go
@@ -93,7 +93,7 @@ func CreateLocker(client dynamic.Interface, namespace string, lockName string) (
 		k8slock.Namespace(namespace),
 		k8slock.TTL(time.Hour*1),
 		k8slock.ClientID(hostname),
-		k8slock.CreateLease(false),
+		k8slock.CreateLease(true),
 	)
 }
 


### PR DESCRIPTION
ArgoCD doesn't support creating lease object per
https://github.com/argoproj/argo-cd/issues/12722

This change will enable k8slock to try to create lease object when it's absent.