### PR TITLE
NVSHAS-9525: Resolve existing Go linter issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,3 +8,9 @@ linters:
     - staticcheck
     - unused
     - gofmt
+
+issues:
+  exclude-rules:
+    - linters:
+        - staticcheck
+      text: 'SA5008: unknown JSON option ("cloak"|"overflow")'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,11 @@ linters:
 
 issues:
   exclude-rules:
-    - linters:
+    - path: share/
+      linters:
+        - staticcheck
+      text: 'SA5008: unknown JSON option ("cloak"|"overflow")'
+    - path: controller/
+      linters:
         - staticcheck
       text: 'SA5008: unknown JSON option ("cloak"|"overflow")'


### PR DESCRIPTION
exclude reports for NV's json tag extension