### PR TITLE
NVSHAS-9525: Resolve existing Go linter issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,3 +19,11 @@ issues:
       linters:
         - staticcheck
       text: 'SA5008: unknown JSON option ("cloak"|"overflow")'
+  exclude:
+    - "SA1019: grpc.RPCCompressor is deprecated: use encoding.RegisterCompressor"
+    - "SA1019: grpc.RPCDecompressor is deprecated: use encoding.RegisterCompressor"
+    - "SA1019: grpc.WithDecompressor is deprecated: use encoding.RegisterCompressor"
+    - "SA1019: grpc.WithCompressor is deprecated: use UseCompressor"
+    - "SA1019: grpc.WithInsecure is deprecated: use WithTransportCredentials and insecure.NewCredentials()"
+    - "SA1019: grpc.WithDialer is deprecated: use WithContextDialer"
+    - "SA1019: grpc.WithTimeout is deprecated: use DialContext instead of Dial and context.WithTimeout"


### PR DESCRIPTION
exclude grpc-related SA1019 warnings that will be supported throughout golang 1.x, including:
```
SA1019: grpc.RPCCompressor is deprecated: use encoding.RegisterCompressor instead. Will be supported throughout 1.x. (staticcheck)
SA1019: grpc.RPCDecompressor is deprecated: use encoding.RegisterCompressor instead. Will be supported throughout 1.x. (staticcheck)
SA1019: grpc.WithDecompressor is deprecated: use encoding.RegisterCompressor instead.  Will be supported throughout 1.x. (staticcheck)
SA1019: grpc.WithCompressor is deprecated: use UseCompressor instead.  Will be supported throughout 1.x. (staticcheck)
SA1019: grpc.WithInsecure is deprecated: use WithTransportCredentials and insecure.NewCredentials() instead. Will be supported throughout 1.x. (staticcheck)
SA1019: grpc.WithDialer is deprecated: use WithContextDialer instead.  Will be supported throughout 1.x. (staticcheck)
SA1019: grpc.WithTimeout is deprecated: use DialContext instead of Dial and context.WithTimeout instead.  Will be supported throughout 1.x. (staticcheck)

```