### PR TITLE
NVSHAS-9532: The image scan is completed but deployment is still not allowed

### DIFF
--- a/controller/rest/rest_test.go
+++ b/controller/rest/rest_test.go
@@ -630,3 +630,26 @@ func TestNewestVersion(t *testing.T) {
 		t.Errorf("Incorrect newest version: %v %s", vers, getNewestVersion(vers))
 	}
 }
+
+func TestInitSearchRegistries(t *testing.T) {
+	var ctx Context
+
+	ctx.SearchRegistries = "docker.io, index.docker.io/library ,http://registry.hub.docker.com:8080/lib,https://registry-1.docker.io/ , http://local.registry.net:8080/abc "
+	initSearchRegistries(&ctx)
+	expected := []string{
+		"https://docker.io/",
+		"https://index.docker.io/",
+		"http://registry.hub.docker.com:8080/",
+		"https://registry-1.docker.io/",
+		"http://local.registry.net:8080/",
+	}
+	if searchRegistries.Cardinality() != len(expected) {
+		t.Errorf("Unexpected searchRegistries result: %+v\n", searchRegistries)
+	} else {
+		for _, reg := range expected {
+			if !searchRegistries.Contains(reg) {
+				t.Errorf("Expected element not found in searchRegistries: %+v\n", reg)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR will allow configuring non-https URL for default registry used in admission control rules evaluation.
When the container image specified in a pod spec doesn't contain the registry, for example:
```
spec:
      containers:
        - name: iperfserver
          image: iperf
```
NV controller uses the following 4 registries to find the scan result of the image:
```
https://docker.io/
https://index.docker.io/
https://registry.hub.docker.com/
https://registry-1.docker.io/
```
If user wants to use different registries as the default registries for admission control rule evaluation, they can specify an env var in NV controller deployment like:
```
env:
  - name: CTRL_SEARCH_REGISTRIES
    value: "http://myregistry1.net,https://myregistry2.net"
```
However, the logic in NV 5.4 doesn't support http scheme in the value.
For above example, NV controller uses https://myregistry1.net & https://myregistry2.net, not http://myregistry1.net & https://myregistry2.net, as the default registries for admission control rule evaluation.
In NVSHAS-9532, we see the user's registry server is http://harbor.freeit-gyh.com/ (http scheme) whose image scan result can not be referenced for admission control rule evaluation.

This PR is to support http scheme specified in the CTRL_SEARCH_REGISTRIES env var of NV controller pod