### PR TITLE
[NVSHAS-9576] Clear password field for registry data when user use controller mode with Jenkins to scan

### DIFF
--- a/controller/rest/repository.go
+++ b/controller/rest/repository.go
@@ -219,6 +219,8 @@ func handlerScanRepositoryReq(w http.ResponseWriter, r *http.Request, ps httprou
 		w.WriteHeader(http.StatusNotModified)
 	} else {
 		ret := result.(*repoScanResult)
+		// Clear password field for registry data
+		data.Request.Password = ""
 		if ret.errCode == api.RESTErrClusterRPCError {
 			restRespError(w, http.StatusInternalServerError, ret.errCode)
 		} else if ret.errCode != 0 {


### PR DESCRIPTION
### Summary

- Clear password field for registry data when user use controller mode with Jenkins to scan

### Test done
Run the jenkins with controller, make sure no password in it.
<img width="1794" alt="Screen Shot 2024-10-24 at 2 21 05 PM" src="https://github.com/user-attachments/assets/4900d543-f662-443a-a413-eb027937489c">
