### PR TITLE
NVSHAS-9425: create nfq when container has vxlan 

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1306,11 +1306,8 @@ func updateContainerNetworks(c *containerData, info *container.ContainerMetaExtr
 
 func isMultiNetworkContainer(c *containerData) bool {
 	if c.intcpPairs != nil {
-		if len(c.intcpPairs) < 2 {
-			return false
-		}
 		for _, pair := range c.intcpPairs {
-			if pair.Peer == "" {
+			if pair.Peer == "" || pair.Vxlan {
 				return true
 			}
 		}


### PR DESCRIPTION
Container has vxlan setup, in protect mode if we split veth interface into veth bridge the vxlan setup will be affected, so we use nfq(iptable rules) instead in this scenario.