### PR TITLE
NVSHAS-9589: Managed clusters disconnected - Version mismatch with primary cluster

### DIFF
--- a/controller/cache/federation.go
+++ b/controller/cache/federation.go
@@ -229,6 +229,7 @@ func fedConfigUpdate(nType cluster.ClusterNotifyType, key string, value []byte) 
 					}
 					cache.cluster.Disabled = cluster.Disabled
 					cache.cluster.ProxyRequired = cluster.ProxyRequired
+					cache.cluster.RestVersion = cluster.RestVersion
 				}
 				if isLeader() && cluster.Disabled {
 					data := share.CLUSFedClusterStatus{Status: 207} // _fedLicenseDisallowed


### PR DESCRIPTION
Reason: managed clusters' REST version is not stored in primary cluster's cache