### PR TITLE
fix: NVSHAS-9624 rewrite swagger validation

### DIFF
--- a/.github/workflows/unitest.yaml
+++ b/.github/workflows/unitest.yaml
@@ -9,12 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v5
       with:
-        go-version: '1.22.1'
+        go-version: '1.22.9'
     - run: |
         ./unitest.sh
-    - name: openapi-lint 
-      uses: mbowman100/swagger-validator-action@master
+    - uses: actions/setup-node@v4
       with:
-        files: controller/api/apis.yaml
+        node-version: 18
+    - name: openapi-lint 
+      run: |
+        npm install -g @apidevtools/swagger-cli
+        swagger-cli validate controller/api/apis.yaml
+        swagger-cli validate controller/api/internal_apis.yaml

--- a/controller/api/internal_apis.yaml
+++ b/controller/api/internal_apis.yaml
@@ -33,6 +33,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/RESTGenerateServerLoginRequest'
+        - name: server
+          in: path
+          description: the resource name
+          type: string
+          required: true
       produces:
         - application/json
       responses:
@@ -55,6 +60,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/RESTGenerateServerLoginRequest'
+        - name: server
+          in: path
+          description: the resource name
+          type: string
+          required: true
       produces:
         - application/json
       responses:
@@ -80,6 +90,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/RESTGenerateServerLogoutRequest'
+        - name: server
+          in: path
+          description: the resource name
+          type: string
+          required: true
       produces:
         - application/json
       responses:
@@ -113,8 +128,6 @@ definitions:
         type: string
         example: 'https://<server>/token_auth_server'
   RESTGenerateServerLoginResponse:
-    required:
-      - 'redirect_endpoint'
     type: object
     properties:
       redirect:


### PR DESCRIPTION
Rewrite swagger validation action using swagger CLI.
1. Use swagger-cli to replace swagger-validator-action.
2. Validate internal_apis.yaml