### PR TITLE
[NVSHAS-9507] Fix JFrog fetch tag issue.

### DIFF
--- a/share/scan/registry/tags.go
+++ b/share/scan/registry/tags.go
@@ -8,14 +8,14 @@ type tagsResponse struct {
 	Tags []string `json:"tags"`
 }
 
-func (r *Registry) FetchTagsPaginated(url, repositoryStr string) ([]string, error) {
+func (r *Registry) FetchTagsPaginated(url, repository string) ([]string, error) {
 	tags := make([]string, 0)
 	var response tagsResponse
 	var err error
 
 	r.Client.SetTimeout(longTimeout)
 	for {
-		log.WithFields(log.Fields{"url": url, "repository": repositoryStr}).Debug()
+		log.WithFields(log.Fields{"url": url, "repository": repository}).Debug()
 		url, err = r.getPaginatedJson(url, &response)
 		switch err {
 		case ErrNoMorePages:


### PR DESCRIPTION
### Summary

- The old API for fetching JFrog resources encounters issues with the newer jfrog version.
- Created a backup function specifically for handling JFrog tag retrieval.
- Ensures compatibility with JFrog's updated API while preserving existing registry functionality.

### Test perform

- repository scan with jfrog
- reposiorty scan with docker