### PR TITLE
Remove unused property remote_permissions in Swagger documentation of RESTUser

### DIFF
--- a/controller/api/apis.yaml
+++ b/controller/api/apis.yaml
@@ -11702,11 +11702,6 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/RESTRolePermission'
-      remote_permissions:
-        description: permissions on managed clusters in fed. only for Rancher SSO
-        type: object
-        items:
-          $ref: '#/definitions/RESTRemoteRolePermits'
       timeout:
         type: integer
         format: uint32


### PR DESCRIPTION
Based on the API definition in `controller/api/apis.go`, `remote_permissions` is not a property of `RESTUser`.

As it does not exist in the actual API, I think it makes sense to remove it from the Swagger documentation.