### PR TITLE
NVSHAS-9678:excessive errors after linter change

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1382,7 +1382,7 @@ func programPorts(c *containerData, restore bool) ([]*pipe.InterceptPair, error)
 			}
 		}
 		newPairs, err := pipe.InspectContainerPorts(c.pid, c.intcpPairs)
-		if err != nil {
+		if err != nil && !os.IsNotExist(err) {
 			log.WithFields(log.Fields{"container": c.id, "error": err}).Error("Failed to inspect port")
 		}
 		return newPairs, err
@@ -2126,9 +2126,9 @@ func taskStopContainer(id string, pid int) {
 	}
 
 	log.WithFields(log.Fields{"container": c.id, "c.pid": c.pid, "pid": pid}).Info("")
-	info, err := global.RT.GetContainer(id)
-	if err != nil {
-		log.WithFields(log.Fields{"id": id, "error": err}).Error("Failed to read container. Use cached info.")
+	info, dbgErr := global.RT.GetContainer(id)
+	if dbgErr != nil {
+		log.WithFields(log.Fields{"id": id, "dbgErr": dbgErr}).Debug("Failed to read container. Use cached info.")
 		info = c.info
 		info.Running = false
 	} else if info.Running {

--- a/share/fsmon/fanotify_linux.go
+++ b/share/fsmon/fanotify_linux.go
@@ -1,6 +1,7 @@
 package fsmon
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -103,8 +104,8 @@ func (fn *FaNotify) checkConfigPerm() bool {
 	}
 
 	err = fn.fa.Mark(faMarkDelFlags, mask, 0, tmpDir)
-	if err != nil {
-		log.WithFields(log.Fields{"err": err}).Debug("delete mark fail")
+	if err != nil && !os.IsNotExist(errors.Unwrap(err)) {
+		log.WithFields(log.Fields{"err": err}).Error("delete mark fail")
 	}
 	return true
 }
@@ -162,8 +163,8 @@ func (fn *FaNotify) RemoveMonitorFile(path string) {
 		if ifd, exist := r.paths[rPath]; exist {
 			// if the file removed, the mark will be removed automaticly
 			err := fn.fa.Mark(faMarkDelFlags, ifd.mask, unix.AT_FDCWD, path)
-			if err != nil {
-				log.WithFields(log.Fields{"path": ifd.path, "err": err}).Debug("file")
+			if err != nil && !os.IsNotExist(errors.Unwrap(err)) {
+				log.WithFields(log.Fields{"path": ifd.path, "err": err}).Error("file")
 			}
 			delete(r.paths, rPath)
 			return
@@ -171,8 +172,8 @@ func (fn *FaNotify) RemoveMonitorFile(path string) {
 
 		if ifd, exist := r.dirs[rPath]; exist {
 			err := fn.fa.Mark(faMarkDelFlags, ifd.mask, unix.AT_FDCWD, path)
-			if err != nil {
-				log.WithFields(log.Fields{"path": ifd.path, "err": err}).Debug("dir")
+			if err != nil && !os.IsNotExist(errors.Unwrap(err)) {
+				log.WithFields(log.Fields{"path": ifd.path, "err": err}).Error("dir")
 			}
 			delete(r.dirs, rPath)
 			return
@@ -199,7 +200,7 @@ func (fn *FaNotify) removeMarks(r *rootFd) {
 	ppath := fmt.Sprintf(procRootMountPoint, r.pid)
 	for dir, mask := range r.dirMonitorMap {
 		path := ppath + dir
-		if err := fn.fa.Mark(unix.FAN_MARK_REMOVE, mask, unix.AT_FDCWD, path); err != nil {
+		if err := fn.fa.Mark(unix.FAN_MARK_REMOVE, mask, unix.AT_FDCWD, path); err != nil && !os.IsNotExist(errors.Unwrap(err)) {
 			log.WithFields(log.Fields{"err": err, "dir": path}).Error()
 		}
 	}
@@ -209,7 +210,7 @@ func (fn *FaNotify) removeMarks(r *rootFd) {
 		if ifile, ok := r.paths[file]; ok {
 			path := ppath + file
 			mask := ifile.mask
-			if err := fn.fa.Mark(unix.FAN_MARK_REMOVE, mask, unix.AT_FDCWD, path); err != nil {
+			if err := fn.fa.Mark(unix.FAN_MARK_REMOVE, mask, unix.AT_FDCWD, path); err != nil && !os.IsNotExist(errors.Unwrap(err)) {
 				log.WithFields(log.Fields{"err": err, "path": path}).Error()
 			}
 		}
@@ -373,8 +374,8 @@ func (fn *FaNotify) addSingleFile(r *rootFd, path string, mask uint64) bool {
 		return false
 	}
 
-	if err := fn.fa.Mark(faMarkAddFlags, mask, unix.AT_FDCWD, path); err != nil {
-		log.WithFields(log.Fields{"path": path, "error": err}).Debug("FMON:")
+	if err := fn.fa.Mark(faMarkAddFlags, mask, unix.AT_FDCWD, path); err != nil && !os.IsNotExist(errors.Unwrap(err)) {
+		log.WithFields(log.Fields{"path": path, "error": err}).Error("FMON:")
 		return false
 	}
 
@@ -424,8 +425,8 @@ func (fn *FaNotify) StartMonitor(rootPid int) bool {
 	ppath := fmt.Sprintf(procRootMountPoint, rootPid)
 	for dir, mask := range r.dirMonitorMap {
 		path := ppath + dir
-		if err := fn.fa.Mark(faMarkAddFlags, mask, unix.AT_FDCWD, path); err != nil {
-			log.WithFields(log.Fields{"path": path, "error": err}).Debug("FMON:")
+		if err := fn.fa.Mark(faMarkAddFlags, mask, unix.AT_FDCWD, path); err != nil && !os.IsNotExist(errors.Unwrap(err)) {
+			log.WithFields(log.Fields{"path": path, "error": err}).Error("FMON:")
 		} else {
 			mLog.WithFields(log.Fields{"path": path, "mask": fmt.Sprintf("0x%08x", mask)}).Debug("FMON:")
 		}
@@ -549,7 +550,7 @@ func (fn *FaNotify) MonitorFileEvents() {
 		}
 
 		if (pfd[0].Revents & unix.POLLIN) != 0 {
-			if err := fn.handleEvents(); err != nil && err != unix.EINTR {
+			if err := fn.handleEvents(); err != nil && !errors.Is(errors.Unwrap(err), unix.EINTR) {
 				log.WithFields(log.Fields{"err": err}).Error("FMON: handle")
 				break
 			}

--- a/share/orchestration/kubernetes.go
+++ b/share/orchestration/kubernetes.go
@@ -229,7 +229,7 @@ func GetK8sVersion(reGetK8sVersion, reGetOcVersion bool) (string, string) {
 				break
 			}
 		}
-		if k8sVer == "" && err != nil {
+		if k8sVer == "" && err != nil && !strings.HasPrefix(err.Error(), "Read File fail") {
 			log.Error(err.Error())
 		}
 		err = nil
@@ -243,7 +243,7 @@ func GetK8sVersion(reGetK8sVersion, reGetOcVersion bool) (string, string) {
 				break
 			}
 		}
-		if ocVer == "" && err != nil {
+		if ocVer == "" && err != nil && !strings.HasPrefix(err.Error(), "Read File fail") {
 			log.Error(err.Error())
 		}
 	}


### PR DESCRIPTION
(1) Ignore error traces when the container exited. 
(2) Ignore the supplemental information errors if the file does not exist.