### PR TITLE
fix: NVSHAS-9443 ArgoCD issue

### DIFF
--- a/upgrader/main.go
+++ b/upgrader/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"time"
@@ -11,9 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/urfave/cli/v2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -76,16 +73,6 @@ func CreateLocker(client dynamic.Interface, namespace string, lockName string) (
 		log.Info("failed to get hostname: %w", err)
 	}
 	hostname += "_" + uuid.New().String()
-
-	if _, err := client.Resource(
-		schema.GroupVersionResource{
-			Resource: "leases",
-			Version:  "v1",
-			Group:    "coordination.k8s.io",
-		},
-	).Namespace(namespace).Get(context.TODO(), lockName, metav1.GetOptions{}); err != nil {
-		return nil, fmt.Errorf("failed to find lease object: %w", err)
-	}
 
 	return k8slock.NewLocker(
 		lockName,


### PR DESCRIPTION
Do not check the lease object's presence, so it can be created correctly on ArgoCD.