### PR TITLE
NVSHAS-9667: Setting CTRL_PATH_DEBUG env to error in controller deplo…

### DIFF
--- a/controller/cache/config.go
+++ b/controller/cache/config.go
@@ -101,7 +101,7 @@ func setControllerDebug(debug []string, debugCPath bool) {
 	if hasConn {
 		cctx.ConnLog.Level = log.DebugLevel
 	} else {
-		cctx.ConnLog.Level = cctx.DefaultLogLevel
+		cctx.ConnLog.Level = log.InfoLevel
 	}
 	if hasScan || debugCPath || hasCPath {
 		cctx.ScanLog.Level = log.DebugLevel
@@ -111,7 +111,7 @@ func setControllerDebug(debug []string, debugCPath bool) {
 	if hasMutex {
 		cctx.MutexLog.Level = log.DebugLevel
 	} else {
-		cctx.MutexLog.Level = cctx.DefaultLogLevel
+		cctx.MutexLog.Level = log.InfoLevel
 	}
 	if hasCluster || debugCPath {
 		cluster.SetLogLevel(log.DebugLevel)


### PR DESCRIPTION
…yment is not working

For connection/mutex logging, enable debug_level only when it is specified by cli