### PR TITLE
NVSHAS-9669: Overall security score through REST API

### DIFF
--- a/controller/access/access.go
+++ b/controller/access/access.go
@@ -910,6 +910,7 @@ func CompileUriPermitsMapping() {
 				"v1/system/license",
 				"v1/system/summary",
 				"v1/internal/system",
+				"v1/system/score/metrics",
 			},
 			CONST_API_FED: {
 				"v1/fed/member",

--- a/controller/access/access_test.go
+++ b/controller/access/access_test.go
@@ -1345,6 +1345,7 @@ func TestCompileApiUrisMappingMapping(t *testing.T) {
 			"v1/system/license",
 			"v1/system/summary",
 			"v1/internal/system",
+			"v1/system/score/metrics",
 		},
 		CONST_API_FED: {
 			"v1/fed/member",


### PR DESCRIPTION
It sets the required permission for calling GET(v1/system/score/metrics)