### PR TITLE
fix: NVSHAS-9705 disable consul gRPC server

### DIFF
--- a/share/cluster/consul.go
+++ b/share/cluster/consul.go
@@ -140,6 +140,7 @@ func createConfigFile(cc *ClusterConfig) error {
 		Server   uint `json:"server"`
 		Serf_lan uint `json:"serf_lan"`
 		Serf_wan int  `json:"serf_wan"`
+		GrpcTls  int  `json:"grpc_tls"`
 	}
 
 	type tConsulConfigPerformance struct {
@@ -201,6 +202,7 @@ func createConfigFile(cc *ClusterConfig) error {
 			Server:   rpcPort,
 			Serf_lan: lanPort,
 			Serf_wan: -1,
+			GrpcTls:  -1,
 		},
 		Tls_cipher_suites: "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
 		Performance: tConsulConfigPerformance{


### PR DESCRIPTION
The previous [PR](https://github.com/neuvector/neuvector/pull/1701) has wrong target branch specified: 
This PR ported the change from https://github.com/neuvector/neuvector/pull/1697#pullrequestreview-2501086890 to 5.4.2.