### PR TITLE
NVSHAS-9700/NVSHAS-9699 Retool logic for parseDotNetPackage

### DIFF
--- a/controller/access/access.go
+++ b/controller/access/access.go
@@ -910,6 +910,7 @@ func CompileUriPermitsMapping() {
 				"v1/system/license",
 				"v1/system/summary",
 				"v1/internal/system",
+				"v1/system/score/metrics",
 			},
 			CONST_API_FED: {
 				"v1/fed/member",

--- a/controller/access/access_test.go
+++ b/controller/access/access_test.go
@@ -1345,6 +1345,7 @@ func TestCompileApiUrisMappingMapping(t *testing.T) {
 			"v1/system/license",
 			"v1/system/summary",
 			"v1/internal/system",
+			"v1/system/score/metrics",
 		},
 		CONST_API_FED: {
 			"v1/fed/member",


### PR DESCRIPTION
Retool logic for parseDotNetPackage to fix an issue where module count and contents could be inconsistent. Add/update related unit tests.

removed unnecessary debug logging.