### PR TITLE
NVSHAS-9752: replace md5 keys by sha256

### DIFF
--- a/agent/probe/incident_reporter.go
+++ b/agent/probe/incident_reporter.go
@@ -1,7 +1,7 @@
 package probe
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"path/filepath"
@@ -39,27 +39,27 @@ const expireCountdown = 4 + 1   // 5 seconds: triggered in 20-25 sec
 func genUniqEventKey(msgtype, pid int, id string) string {
 	keyString := fmt.Sprintf("%d:%d:%s:%v", msgtype, pid, id, time.Now())
 	// log.WithFields(log.Fields{"keyString": keyString}).Debug("PROC:")
-	b := md5.Sum([]byte(keyString))
+	b := sha256.Sum256([]byte(keyString))
 	return hex.EncodeToString(b[:])
 }
 
 func genEscalReportKey(msgtype int, pmsg *ProbeEscalation) string {
 	keyString := fmt.Sprintf("%d:%d:%d:%s:%s:%s", msgtype, pmsg.RUid, pmsg.EUid, pmsg.RealUser, pmsg.EffUser, pmsg.ID)
-	b := md5.Sum([]byte(keyString))
+	b := sha256.Sum256([]byte(keyString))
 	return string(b[:])
 }
 
 func genProcessReportKey(msgtype int, pmsg *ProbeProcess) string {
 	keyString := fmt.Sprintf("%d:%s:%s:%v:%s", msgtype, pmsg.Name, pmsg.Path, pmsg.Cmds, pmsg.ID)
 	// log.WithFields(log.Fields{"keyString": keyString}).Debug("PROC:")
-	b := md5.Sum([]byte(keyString))
+	b := sha256.Sum256([]byte(keyString))
 	return hex.EncodeToString(b[:])
 }
 
 func genFsMonReportKey(msgtype int, pmsg *fsmon.MonitorMessage) (string, string) {
 	keyString := fmt.Sprintf("%d:%s:%s:%s", msgtype, pmsg.ID, pmsg.Path, pmsg.Msg)
 	// log.WithFields(log.Fields{"keyString": keyString}).Debug("PROC:")
-	b := md5.Sum([]byte(keyString))
+	b := sha256.Sum256([]byte(keyString))
 	return hex.EncodeToString(b[:]), genUniqEventKey(msgtype, pmsg.ProcPid, pmsg.ID)
 }
 


### PR DESCRIPTION
Enforcer: replace the insecure cryptography (MD5) with the SHA-256