### PR TITLE
NVSHAS-9751: add not-listed family process rule alert

### DIFF
--- a/agent/probe/faccess_linux.go
+++ b/agent/probe/faccess_linux.go
@@ -782,6 +782,8 @@ func (fa *FileAccessCtrl) processEvent(ev *fanotify.EventMetadata) (bool, string
 							msg = "Process profile violation, not from an image file: execution denied"
 						case share.CLUSReservedUuidShieldMode:
 							msg = "Process profile violation, not from its root process: execution denied"
+						case share.CLUSReservedUuidShieldNotListMode:
+							msg = "Process profile violation, from its root process but not in the list: execution denied"
 						default:
 							msg = "Process profile violation: execution denied"
 						}

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -2592,6 +2592,8 @@ func (p *Probe) sendProcessIncident(bDenied bool, id, uuid, group, derivedGroup 
 		s = p.makeProcessReport(id, proc, "Process profile violation, not from an image file", nil, false, group, uuid)
 	case share.CLUSReservedUuidShieldMode: // zero-drift incident
 		s = p.makeProcessReport(id, proc, "Process profile violation, not from its root process", nil, false, group, uuid)
+	case share.CLUSReservedUuidShieldNotListMode:
+		s = p.makeProcessReport(id, proc, "Process profile violation, not a listed family process", nil, false, group, uuid)
 	default: // rules-based incident
 		s = p.makeProcessReport(id, proc, "Process profile violation", nil, false, derivedGroup, uuid)
 	}
@@ -3172,7 +3174,11 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 					mLog.WithFields(log.Fields{"proc": proc, "id": id}).Debug("SHD: rissky session")
 					break
 				}
-
+				if mode == share.PolicyModeEvaluate {
+					// report as incidents
+					ppe.Uuid = share.CLUSReservedUuidShieldNotListMode
+					break
+				}
 			}
 
 			bPass = true
@@ -3195,7 +3201,7 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 					ppe.Action = share.PolicyActionAllow
 				}
 			} else {
-				ppe.Uuid = share.CLUSReservedUuidNotAlllowed
+				ppe.Uuid = share.CLUSReservedUuidShieldNotListMode
 			}
 		}
 	} else {

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -2675,13 +2675,14 @@ type CLUSCrdEventQueueInfo struct {
 const CLUSReservedUuidPrefix string = "00000000-0000-0000-0000-0000000000" // reserved the last 2 digits
 
 // ////
-const CLUSReservedUuidNotAlllowed string = "00000000-0000-0000-0000-000000000000"    // processes beyond white list
-const CLUSReservedUuidRiskyApp string = "00000000-0000-0000-0000-000000000001"       // riskApp
-const CLUSReservedUuidTunnelProc string = "00000000-0000-0000-0000-000000000002"     // tunnel
-const CLUSReservedUuidRootEscalation string = "00000000-0000-0000-0000-000000000003" // root privilege escallation
-const CLUSReservedUuidDockerCp string = "00000000-0000-0000-0000-000000000004"       // docker cp
-const CLUSReservedUuidAnchorMode string = "00000000-0000-0000-0000-000000000005"     // rejected by anchor mode
-const CLUSReservedUuidShieldMode string = "00000000-0000-0000-0000-000000000006"     // rejected by non-family process
+const CLUSReservedUuidNotAlllowed string = "00000000-0000-0000-0000-000000000000"       // processes beyond white list
+const CLUSReservedUuidRiskyApp string = "00000000-0000-0000-0000-000000000001"          // riskApp
+const CLUSReservedUuidTunnelProc string = "00000000-0000-0000-0000-000000000002"        // tunnel
+const CLUSReservedUuidRootEscalation string = "00000000-0000-0000-0000-000000000003"    // root privilege escallation
+const CLUSReservedUuidDockerCp string = "00000000-0000-0000-0000-000000000004"          // docker cp
+const CLUSReservedUuidAnchorMode string = "00000000-0000-0000-0000-000000000005"        // rejected by anchor mode
+const CLUSReservedUuidShieldMode string = "00000000-0000-0000-0000-000000000006"        // rejected by non-family process
+const CLUSReservedUuidShieldNotListMode string = "00000000-0000-0000-0000-000000000007" // rejected by Monitor mode for not-listed family process
 
 type ProcRule struct {
 	Active int                     `json:"active"`


### PR DESCRIPTION
Backported:

(1) During Monitor mode, set alerts on not listed family processes. 
(2) Add process violation messages on above incidents