### PR TITLE
fix: allow ut to run with ubuntu-latest runner

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: stable
+      - name: Install dependencies
+        run: |
+          sudo apt update && sudo apt install -y libpcre3-dev
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/unitest.yaml
+++ b/.github/workflows/unitest.yaml
@@ -12,6 +12,9 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version: '1.22.9'
+    - name: Install dependencies
+      run: |
+        sudo apt update && sudo apt install -y libpcre3-dev
     - run: |
         ./unitest.sh
     - uses: actions/setup-node@v4


### PR DESCRIPTION
`pcre.h` is missing due to GitHub's recent change to move from ubuntu 22.04 to ubuntu 24.04 in ubuntu-latest runner.  For example, [this run](https://github.com/neuvector/neuvector/actions/runs/12750162538/job/35534278327?pr=1722).

This PR installs `libpcre3-dev` so unit test can run without problem.  