### PR TITLE
[NVSHAS-9784] NV returning 404 during Jfrog image repository scanning

### DIFF
--- a/share/scan/registry/manifest.go
+++ b/share/scan/registry/manifest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -76,10 +77,12 @@ func (r *Registry) ManifestRequest(ctx context.Context, repository, reference st
 				req.Header.Add("Accept", MediaTypeOCIIndex)
 			}
 		case 2:
-			req.Header.Add("Accept", manifestV2.MediaTypeManifest)
-			if withOCIManifest {
-				req.Header.Add("Accept", MediaTypeOCIManifest)
-			}
+			// Add Accept headers for manifest types:
+			// - Docker V2 manifest format
+			// - OCI manifest format
+			// This allows the registry to return the appropriate manifest format based on what's available
+			fuseMediaType := fmt.Sprintf("%s,%s", manifestV2.MediaTypeManifest, MediaTypeOCIManifest)
+			req.Header.Add("Accept", fuseMediaType)
 			if withOCIIndex {
 				req.Header.Add("Accept", MediaTypeOCIIndex)
 			}


### PR DESCRIPTION
### Summary
- Append header to support the OCI format of a manifest. 

### Root cause
The current implementation will call the following for any jfrog build when scanning

```bash
curl -u usr:pwd\
     -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
     https://nvdebug.jfrog.io/v2/{repo}/{image}/manifests/{tag}
 ```

But the header is always, this header is compatible with Docker V2 image manifests.

```bash
application/vnd.docker.distribution.manifest.v2+json 
```

However, to support OCI-compliant images (e.g., OCI build images), the header must also accept:
```bash
application/vnd.oci.image.manifest.v1+json 
```

Thus we use consigned-image as fallback function to work with it