### PR TITLE
NVSHAS-9759: Add timestamp in RESTConversationReportEntry

### DIFF
--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -1116,6 +1116,7 @@ type RESTConversationReportEntry struct {
 	CIP          string `json:"client_ip,omitempty"`
 	SIP          string `json:"server_ip,omitempty"`
 	FQDN         string `json:"fqdn,omitempty"`
+	LastSeenAt   int64  `json:"last_seen_at"`
 }
 
 type RESTConversationReport struct {
@@ -1758,7 +1759,6 @@ type RESTRiskScoreMetrics struct {
 	WLs              RESTRiskScoreMetricsWL    `json:"workloads"`
 	Groups           RESTRiskScoreMetricsGroup `json:"groups"`
 	CVEs             RESTRiskScoreMetricsCVE   `json:"cves"`
-	TimeStamp        int64                     `json:"timestamp"`
 }
 
 type RESTExposedEndpoint struct {

--- a/controller/api/apis.yaml
+++ b/controller/api/apis.yaml
@@ -14180,9 +14180,6 @@ definitions:
         $ref: '#/definitions/RESTRiskScoreMetricsGroup'
       cves:
         $ref: '#/definitions/RESTRiskScoreMetricsCVE'
-      timestamp:
-        type: integer
-        format: int64
   RESTExposedEndpoint:
     type: object
     properties:
@@ -14245,6 +14242,9 @@ definitions:
         type: string
       fqdn:
         type: string
+      last_seen_at:
+        type: integer
+        format: int64
   RESTSecurityScores:
     type: object
     properties:

--- a/controller/cache/compliance.go
+++ b/controller/cache/compliance.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -209,7 +208,6 @@ func (m CacheMethod) GetRiskScoreMetrics(acc, accCaller *access.AccessControl) *
 
 	s.Platform, s.K8sVersion, s.OCVersion = m.GetPlatform()
 	s.NewServiceMode, s.NewProfileMode = getNewServicePolicyMode()
-	s.TimeStamp = time.Now().UTC().Unix()
 
 	// Check if count system container/group
 	var disableSystem bool

--- a/controller/cache/connect.go
+++ b/controller/cache/connect.go
@@ -1724,6 +1724,7 @@ func graphAttr2REST(attr *graphAttr) *api.RESTConversationReport {
 			CIP:          utils.Int2IPv4(key.cip).String(),
 			SIP:          utils.Int2IPv4(key.sip).String(),
 			FQDN:         ge.fqdn,
+			LastSeenAt:   int64(ge.last),
 		}
 		protos.Add(key.ipproto)
 		if key.application == 0 || key.application == C.DPI_APP_NOT_CHECKED {


### PR DESCRIPTION
1. Add LastSeenAt timestamp in RESTConversationReportEntry from connection report
2. Remove the timestamp in RESTRiskScoreMetrics as customer doesn't need it for snapshot