### PR TITLE
NVSHAS-9756: File Monitor Performance Optimization

### DIFF
--- a/agent/probe/fsn.go
+++ b/agent/probe/fsn.go
@@ -295,7 +295,9 @@ func (fsn *FileNotificationCtr) updateFileInfo(index string, file, path string) 
 
 	// reporting events
 	// log.WithFields(log.Fields{"id": root.id, "file": file, "finfo": finfo}).Debug("FSN:")
-	go fsn.prober.ProcessFsnEvent(root.id, []string{file}, *finfo)
+	if bExec || bJavaPkg {
+		go fsn.prober.ProcessFsnEvent(root.id, []string{file}, *finfo)
+	}
 }
 
 // already locked
@@ -461,7 +463,7 @@ func (fsn *FileNotificationCtr) skipPathByRole(role, path string) bool {
 			return true
 		}
 		fallthrough
-	case "enforcer", "scanner":
+	case "enforcer", "scanner", "controller", "manager":
 		if strings.HasPrefix(path+"/", "/tmp/") {
 			return true
 		}

--- a/agent/workerlet/pathWalker/pathWalker.go
+++ b/agent/workerlet/pathWalker/pathWalker.go
@@ -179,7 +179,7 @@ func (tm *taskMain) WalkPathTask(req workerlet.WalkPathRequest) {
 		Files: make([]*workerlet.FileData, 0),
 	}
 
-	log.WithFields(log.Fields{"req": req}).Debug()
+	//log.WithFields(log.Fields{"req": req}).Debug()
 	rootPath := filepath.Join(fmt.Sprintf(procRootMountPoint, req.Pid), req.Path)
 	rootPathLen := len(rootPath)
 	rootPath += "/"
@@ -220,6 +220,18 @@ func (tm *taskMain) WalkPathTask(req workerlet.WalkPathRequest) {
 			if path != rootPath {
 				if utils.IsMountPoint(path) {
 					log.WithFields(log.Fields{"path": path}).Debug("skip dir")
+					return filepath.SkipDir
+				}
+
+				bSkip := true
+				ldir := path[rootPathLen:]
+				for _, rdir := range req.Dirs {
+					if strings.HasPrefix(ldir, rdir) {
+						bSkip = false
+						break
+					}
+				}
+				if bSkip {
 					return filepath.SkipDir
 				}
 			}

--- a/agent/workerlet/types.go
+++ b/agent/workerlet/types.go
@@ -18,6 +18,7 @@ type WalkPathRequest struct {
 	Path     string        `json:"path"`
 	ExecOnly bool          `json:"ExecOnly"`
 	Timeout  time.Duration `json:"Timeout"`
+	Dirs     []string      `json:"Directories"`
 }
 
 type WalkGetPackageRequest struct {

--- a/share/fsmon/monitor_test.go
+++ b/share/fsmon/monitor_test.go
@@ -1,0 +1,13 @@
+package fsmon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/neuvector/neuvector/share"
+)
+
+func TestGetBaseDirPrefix(t *testing.T) {
+	assert.Equal(t, "/lib64", getBaseDirPrefix(share.CLUSFileMonitorFilter{Behavior: share.FileAccessBehaviorMonitor, Path: "/lib64", Regex: "ld-linux.*", Recursive: true}))
+}

--- a/share/osutil/file_linux.go
+++ b/share/osutil/file_linux.go
@@ -196,15 +196,6 @@ func IsPackageLib(path string) bool {
 	return packageFiles.Contains(path)
 }
 
-func GetFileInfoExtFromPid(root, pid int) []*FileInfoExt {
-	if path, err := GetExePathFromLink(pid); err == nil {
-		filePath := global.SYS.ContainerFilePath(root, path)
-		return GetFileInfoExtFromPath(root, filePath, "", false, true) // TODO: user-added?
-	} else {
-		return nil
-	}
-}
-
 // get the file information, if the file is a symlink, return both the symlink and the real file
 func GetFileInfoExtFromPath(root int, path string, flt interface{}, protect, userAdded bool) []*FileInfoExt {
 	files := make([]*FileInfoExt, 0)


### PR DESCRIPTION
This change aims to improve the performance of the file monitor by reducing its CPU and I/O overhead

(1) Initial Flat Scan: Will perform a one-time "flat scan" to identify all relevant files within the workload's scope. This eliminates the need for constant directory traversal, significantly reducing I/O operations.

(2) Limited the number of concurrent "worklets" used by the file monitor will be limited to two. This controlled concurrency prevents excessive resource consumption and potential performance bottlenecks.

(3) Optimized "worklet" Scope:  Worklet efficiency will be improved by defining specific folders for each worklet to monitor.