### PR TITLE
chore: update CODEOWNERS to skip files under root

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,6 @@
 * @holyspectral @BinX-Suse @yasker 
+/*
+/vendor/
 /CODEOWNERS @holyspectral @BinX-Suse @yasker
 /.github/ @neuvector/build @yasker  
 /build/ @neuvector/build @yasker 


### PR DESCRIPTION
Update CODEOWNERS, so no owners are assigned to the files under root, e.g., `/go.mod` and `vendor/`.  Updating these files still require a PR approval.  