### PR TITLE
chore: pin golang version used in lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: '1.23'
       - name: Install dependencies
         run: |
           sudo apt update && sudo apt install -y libpcre3-dev


### PR DESCRIPTION
1.24 is causing issues in lint.  This is a temporary fix to re-enable golangci-lint.