### PR TITLE
NVSHAS-9824: reduce error messages when the file monitor exited

### DIFF
--- a/share/fsmon/fanotify_linux.go
+++ b/share/fsmon/fanotify_linux.go
@@ -104,7 +104,7 @@ func (fn *FaNotify) checkConfigPerm() bool {
 	}
 
 	err = fn.fa.Mark(faMarkDelFlags, mask, 0, tmpDir)
-	if err != nil && !os.IsNotExist(errors.Unwrap(err)) {
+	if err != nil && !bIgnoredErrors(err) {
 		log.WithFields(log.Fields{"err": err}).Error("delete mark fail")
 	}
 	return true
@@ -163,7 +163,7 @@ func (fn *FaNotify) RemoveMonitorFile(path string) {
 		if ifd, exist := r.paths[rPath]; exist {
 			// if the file removed, the mark will be removed automaticly
 			err := fn.fa.Mark(faMarkDelFlags, ifd.mask, unix.AT_FDCWD, path)
-			if err != nil && !os.IsNotExist(errors.Unwrap(err)) {
+			if err != nil && !bIgnoredErrors(err) {
 				log.WithFields(log.Fields{"path": ifd.path, "err": err}).Error("file")
 			}
 			delete(r.paths, rPath)
@@ -172,7 +172,7 @@ func (fn *FaNotify) RemoveMonitorFile(path string) {
 
 		if ifd, exist := r.dirs[rPath]; exist {
 			err := fn.fa.Mark(faMarkDelFlags, ifd.mask, unix.AT_FDCWD, path)
-			if err != nil && !os.IsNotExist(errors.Unwrap(err)) {
+			if err != nil && !bIgnoredErrors(err) {
 				log.WithFields(log.Fields{"path": ifd.path, "err": err}).Error("dir")
 			}
 			delete(r.dirs, rPath)
@@ -200,7 +200,7 @@ func (fn *FaNotify) removeMarks(r *rootFd) {
 	ppath := fmt.Sprintf(procRootMountPoint, r.pid)
 	for dir, mask := range r.dirMonitorMap {
 		path := ppath + dir
-		if err := fn.fa.Mark(unix.FAN_MARK_REMOVE, mask, unix.AT_FDCWD, path); err != nil && !os.IsNotExist(errors.Unwrap(err)) {
+		if err := fn.fa.Mark(unix.FAN_MARK_REMOVE, mask, unix.AT_FDCWD, path); err != nil && !bIgnoredErrors(err) {
 			log.WithFields(log.Fields{"err": err, "dir": path}).Error()
 		}
 	}
@@ -210,7 +210,7 @@ func (fn *FaNotify) removeMarks(r *rootFd) {
 		if ifile, ok := r.paths[file]; ok {
 			path := ppath + file
 			mask := ifile.mask
-			if err := fn.fa.Mark(unix.FAN_MARK_REMOVE, mask, unix.AT_FDCWD, path); err != nil && !os.IsNotExist(errors.Unwrap(err)) {
+			if err := fn.fa.Mark(unix.FAN_MARK_REMOVE, mask, unix.AT_FDCWD, path); err != nil && !bIgnoredErrors(err) {
 				log.WithFields(log.Fields{"err": err, "path": path}).Error()
 			}
 		}
@@ -374,7 +374,7 @@ func (fn *FaNotify) addSingleFile(r *rootFd, path string, mask uint64) bool {
 		return false
 	}
 
-	if err := fn.fa.Mark(faMarkAddFlags, mask, unix.AT_FDCWD, path); err != nil && !os.IsNotExist(errors.Unwrap(err)) {
+	if err := fn.fa.Mark(faMarkAddFlags, mask, unix.AT_FDCWD, path); err != nil && !bIgnoredErrors(err) {
 		log.WithFields(log.Fields{"path": path, "error": err}).Error("FMON:")
 		return false
 	}
@@ -425,7 +425,7 @@ func (fn *FaNotify) StartMonitor(rootPid int) bool {
 	ppath := fmt.Sprintf(procRootMountPoint, rootPid)
 	for dir, mask := range r.dirMonitorMap {
 		path := ppath + dir
-		if err := fn.fa.Mark(faMarkAddFlags, mask, unix.AT_FDCWD, path); err != nil && !os.IsNotExist(errors.Unwrap(err)) {
+		if err := fn.fa.Mark(faMarkAddFlags, mask, unix.AT_FDCWD, path); err != nil && !bIgnoredErrors(err) {
 			log.WithFields(log.Fields{"path": path, "error": err}).Error("FMON:")
 		} else {
 			mLog.WithFields(log.Fields{"path": path, "mask": fmt.Sprintf("0x%08x", mask)}).Debug("FMON:")

--- a/share/fsmon/inotify_linux.go
+++ b/share/fsmon/inotify_linux.go
@@ -91,14 +91,14 @@ func (n *Inotify) RemoveMonitorFile(path string) {
 	n.mux.Lock()
 	defer n.mux.Unlock()
 	if ifl, ok := n.paths[path]; ok {
-		if _, err := syscall.InotifyRmWatch(n.fd, uint32(ifl.wd)); err != nil && !errors.Is(err, syscall.EINVAL) {
+		if _, err := syscall.InotifyRmWatch(n.fd, uint32(ifl.wd)); err != nil && !bIgnoredErrors(err) {
 			log.WithFields(log.Fields{"err": err, "path": path}).Error()
 		}
 		delete(n.wds, ifl.wd)
 		delete(n.paths, path)
 	}
 	if ifl, ok := n.dirs[path]; ok {
-		if _, err := syscall.InotifyRmWatch(n.fd, uint32(ifl.wd)); err != nil && !errors.Is(err, syscall.EINVAL) {
+		if _, err := syscall.InotifyRmWatch(n.fd, uint32(ifl.wd)); err != nil && !bIgnoredErrors(err) {
 			log.WithFields(log.Fields{"err": err, "dir": path}).Error()
 		}
 		delete(n.wds, ifl.wd)
@@ -145,7 +145,7 @@ func (n *Inotify) ContainerCleanup(rootPid int) {
 	defer n.mux.Unlock()
 	for path, ifl := range n.paths {
 		if strings.Contains(path, fmt.Sprintf("/proc/%d/root/", rootPid)) {
-			if _, err := syscall.InotifyRmWatch(n.fd, uint32(ifl.wd)); err != nil && !errors.Is(err, syscall.EINVAL) {
+			if _, err := syscall.InotifyRmWatch(n.fd, uint32(ifl.wd)); err != nil && !bIgnoredErrors(err) {
 				log.WithFields(log.Fields{"err": err, "path": path}).Error()
 			}
 			delete(n.wds, ifl.wd)
@@ -155,7 +155,7 @@ func (n *Inotify) ContainerCleanup(rootPid int) {
 	}
 	for path, ifl := range n.dirs {
 		if strings.Contains(path, fmt.Sprintf("/proc/%d/root/", rootPid)) {
-			if _, err := syscall.InotifyRmWatch(n.fd, uint32(ifl.wd)); err != nil && !errors.Is(err, syscall.EINVAL) {
+			if _, err := syscall.InotifyRmWatch(n.fd, uint32(ifl.wd)); err != nil && !bIgnoredErrors(err) {
 				log.WithFields(log.Fields{"err": err, "dir": path}).Error()
 			}
 			delete(n.wds, ifl.wd)
@@ -295,7 +295,7 @@ func (n *Inotify) MonitorFileEvents() {
 					} else { // a watched file
 						if (event.Mask & imonitorRemoveMask) > 0 {
 							log.WithFields(log.Fields{"path": ifile.path}).Debug("file: remove")
-							if _, err := syscall.InotifyRmWatch(n.fd, uint32(event.Wd)); err != nil && !errors.Is(err, syscall.EINVAL) {
+							if _, err := syscall.InotifyRmWatch(n.fd, uint32(event.Wd)); err != nil && !bIgnoredErrors(err) {
 								log.WithFields(log.Fields{"err": err, "path": ifile.path}).Error()
 							}
 							cbFile = ifile

--- a/share/fsmon/monitor.go
+++ b/share/fsmon/monitor.go
@@ -3,6 +3,7 @@ package fsmon
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -262,6 +263,11 @@ func NewFileWatcher(config *FileMonitorConfig, logLevel string) (*FileWatch, err
 
 	go fw.loop()
 	return fw, nil
+}
+
+func bIgnoredErrors(err error) bool {
+	err = errors.Unwrap(err)
+	return os.IsNotExist(err) || errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.EBADF)
 }
 
 func (w *FileWatch) sendMsg(cid string, path string, event uint32, pInfo []*ProcInfo, mode string) {


### PR DESCRIPTION
It ignores the errors when the target files were removed.