### PR TITLE
[NVSHAS-9826] Support auto scan with fine-grained leverl control.

### DIFF
--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -2244,14 +2244,26 @@ type RESTServiceBatchConfigData struct {
 }
 
 type RESTScanConfig struct {
-	AutoScan bool `json:"auto_scan"`
+	AutoScan bool `json:"auto_scan"` // Deprecated, keeps for backward compatibility
+	// New fields for auto scan, to separate from the old unified auto scan
+	EnableAutoScanWorkload bool `json:"enable_auto_scan_workload"`
+	EnableAutoScanHost     bool `json:"enable_auto_scan_host"`
+	EnableAutoScanPlatform bool `json:"enable_auto_scan_platform"`
 }
 
 type RESTScanConfigConfig struct {
-	AutoScan *bool `json:"auto_scan"`
+	AutoScan *bool `json:"auto_scan"` // Deprecated, keeps for backward compatibility
+	// New fields for auto scan, to separate from the old unified auto scan
+	EnableAutoScanWorkload *bool `json:"enable_auto_scan_workload"`
+	EnableAutoScanHost     *bool `json:"enable_auto_scan_host"`
+	EnableAutoScanPlatform *bool `json:"enable_auto_scan_platform"`
 }
 
 type RESTScanConfigData struct {
+	Config *RESTScanConfigConfig `json:"config"`
+}
+
+type RESTScanConfigResp struct {
 	Config *RESTScanConfig `json:"config"`
 }
 

--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -2248,7 +2248,6 @@ type RESTScanConfig struct {
 	// New fields for auto scan, to separate from the old unified auto scan
 	EnableAutoScanWorkload bool `json:"enable_auto_scan_workload"`
 	EnableAutoScanHost     bool `json:"enable_auto_scan_host"`
-	EnableAutoScanPlatform bool `json:"enable_auto_scan_platform"`
 }
 
 type RESTScanConfigConfig struct {
@@ -2256,7 +2255,6 @@ type RESTScanConfigConfig struct {
 	// New fields for auto scan, to separate from the old unified auto scan
 	EnableAutoScanWorkload *bool `json:"enable_auto_scan_workload"`
 	EnableAutoScanHost     *bool `json:"enable_auto_scan_host"`
-	EnableAutoScanPlatform *bool `json:"enable_auto_scan_platform"`
 }
 
 type RESTScanConfigData struct {

--- a/controller/api/apis.yaml
+++ b/controller/api/apis.yaml
@@ -9147,11 +9147,7 @@ definitions:
         example: false
   RESTScanConfigConfig:
     type: object
-    required:
-      - auto_scan
-      - enable_auto_scan_workload
-      - enable_auto_scan_host
-      - enable_auto_scan_platform
+    minProperties: 1
     properties:
       auto_scan:
         description: set to true to enable all kind of auto-scan
@@ -9168,7 +9164,7 @@ definitions:
       enable_auto_scan_platform:
         description: set to true to enable auto-scan for platform
         type: boolean
-        example: false        
+        example: false
   RESTScanConfigData:
     type: object
     required:

--- a/controller/api/apis.yaml
+++ b/controller/api/apis.yaml
@@ -2367,7 +2367,7 @@ paths:
     patch:
       tags:
         - Scan
-      summary: Update scan configure, Auto-scan can be configured globally or with fine-grained control for workloads, hosts, or platforms. However, if any of the detailed control fields (enable_auto_scan_workload, enable_auto_scan_host, or enable_auto_scan_platform) is set to false, auto-scan will be disabled overall, because these flags collectively represent a "scan all" setting.
+      summary: Update scan configure, Auto-scan can be configured globally or with fine-grained control for workloads, hosts, or platforms. However, if any of the detailed control fields (enable_auto_scan_workload, enable_auto_scan_host) is set to false, auto-scan will be disabled overall, because these flags collectively represent a "scan all" setting.
       security:
         - ApiKeyAuth: []
         - TokenAuth: []
@@ -9127,7 +9127,6 @@ definitions:
       - auto_scan
       - enable_auto_scan_workload
       - enable_auto_scan_host
-      - enable_auto_scan_platform
     properties:
       auto_scan:
         description: set to true to enable all kind of auto-scan
@@ -9139,10 +9138,6 @@ definitions:
         example: false
       enable_auto_scan_host:
         description: set to true to enable auto-scan for host
-        type: boolean
-        example: false
-      enable_auto_scan_platform:
-        description: set to true to enable auto-scan for platform
         type: boolean
         example: false
   RESTScanConfigConfig:
@@ -9159,10 +9154,6 @@ definitions:
         example: false
       enable_auto_scan_host:
         description: set to true to enable auto-scan for host
-        type: boolean
-        example: false
-      enable_auto_scan_platform:
-        description: set to true to enable auto-scan for platform
         type: boolean
         example: false
   RESTScanConfigData:

--- a/controller/api/apis.yaml
+++ b/controller/api/apis.yaml
@@ -5,7 +5,7 @@ swagger: '2.0'
 ################################################################################
 info:
   description: Secure Docker and Kubernetes based container deployments with the NeuVector run-time security solution.
-  version: '5.4.2'
+  version: '5.4.3'
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/controller/api/apis.yaml
+++ b/controller/api/apis.yaml
@@ -2363,11 +2363,11 @@ paths:
         '200':
           description: Success
           schema:
-            $ref: '#/definitions/RESTScanConfigData'
+            $ref: '#/definitions/RESTScanConfigResp'
     patch:
       tags:
         - Scan
-      summary: Update scan configure
+      summary: Update scan configure, Auto-scan can be configured globally or with fine-grained control for workloads, hosts, or platforms. However, if any of the detailed control fields (enable_auto_scan_workload, enable_auto_scan_host, or enable_auto_scan_platform) is set to false, auto-scan will be disabled overall, because these flags collectively represent a "scan all" setting.
       security:
         - ApiKeyAuth: []
         - TokenAuth: []
@@ -9125,17 +9125,64 @@ definitions:
     type: object
     required:
       - auto_scan
+      - enable_auto_scan_workload
+      - enable_auto_scan_host
+      - enable_auto_scan_platform
     properties:
       auto_scan:
+        description: set to true to enable all kind of auto-scan
         type: boolean
         example: false
+      enable_auto_scan_workload:
+        description: set to true to enable auto-scan for workload
+        type: boolean
+        example: false
+      enable_auto_scan_host:
+        description: set to true to enable auto-scan for host
+        type: boolean
+        example: false
+      enable_auto_scan_platform:
+        description: set to true to enable auto-scan for platform
+        type: boolean
+        example: false
+  RESTScanConfigConfig:
+    type: object
+    required:
+      - auto_scan
+      - enable_auto_scan_workload
+      - enable_auto_scan_host
+      - enable_auto_scan_platform
+    properties:
+      auto_scan:
+        description: set to true to enable all kind of auto-scan
+        type: boolean
+        example: false
+      enable_auto_scan_workload:
+        description: set to true to enable auto-scan for workload
+        type: boolean
+        example: false
+      enable_auto_scan_host:
+        description: set to true to enable auto-scan for host
+        type: boolean
+        example: false
+      enable_auto_scan_platform:
+        description: set to true to enable auto-scan for platform
+        type: boolean
+        example: false        
   RESTScanConfigData:
     type: object
     required:
       - config
     properties:
       config:
-        $ref: '#/definitions/RESTScanConfig'
+        $ref: '#/definitions/RESTScanConfigConfig'
+  RESTScanConfigResp:
+    type: object
+    required:
+      - config
+    properties:
+      config:
+        $ref: '#/definitions/RESTScanConfig'        
   RESTScanImageSummaryData:
     type: object
     required:

--- a/controller/api/apis.yaml
+++ b/controller/api/apis.yaml
@@ -2367,7 +2367,7 @@ paths:
     patch:
       tags:
         - Scan
-      summary: Update scan configure, Auto-scan can be configured globally or with fine-grained control for workloads, hosts, or platforms. However, if any of the detailed control fields (enable_auto_scan_workload, enable_auto_scan_host) is set to false, auto-scan will be disabled overall, because these flags collectively represent a "scan all" setting.
+      summary: Update scan configure, Auto-scan can be configured globally or with fine-grained control for workloads, hosts. However, if any of the detailed control fields (enable_auto_scan_workload, enable_auto_scan_host) is set to false, auto-scan will be disabled overall, because these flags collectively represent a "scan all" setting.
       security:
         - ApiKeyAuth: []
         - TokenAuth: []

--- a/controller/cache/log.go
+++ b/controller/cache/log.go
@@ -986,10 +986,13 @@ func incidentLogUpdate(nType cluster.ClusterNotifyType, key string, value []byte
 					_ = cctx.StartStopFedPingPollFunc(share.PostToIBMSA, 0, param)
 				}
 
-				if isLeader() && scanCfg.AutoScan {
-					if incd.ID == share.CLUSIncidHostPackageUpdated {
+				if isLeader() {
+					enableAutoScanHost := (scanCfg.EnableAutoScanHost || scanCfg.AutoScan)
+					if enableAutoScanHost && incd.ID == share.CLUSIncidHostPackageUpdated {
 						_ = cacher.ScanHost(incd.HostID, access.NewReaderAccessControl())
-					} else if incd.ID == share.CLUSIncidContainerPackageUpdated {
+					}
+					enableAutoScanWorkload := (scanCfg.EnableAutoScanWorkload || scanCfg.AutoScan)
+					if enableAutoScanWorkload && incd.ID == share.CLUSIncidContainerPackageUpdated {
 						_ = cacher.ScanWorkload(incd.WorkloadID, access.NewReaderAccessControl())
 					}
 				}

--- a/controller/cache/object.go
+++ b/controller/cache/object.go
@@ -1662,7 +1662,7 @@ func configUpdate(nType cluster.ClusterNotifyType, key string, value []byte, mod
 	case share.CFGEndpointPolicy:
 		policyConfigUpdate(nType, key, value)
 	case share.CFGEndpointScan:
-		scanConfigUpdate(nType, key, value)
+		scanConfigUpdate(nType, value)
 	case share.CFGEndpointLicense:
 		licenseConfigUpdate(nType, key, value)
 	case share.CFGEndpointResponseRule:

--- a/controller/cache/scan.go
+++ b/controller/cache/scan.go
@@ -134,7 +134,7 @@ func isInfoAutoScanEnabled(info *scanInfo, cfg *share.CLUSScanConfig) bool {
 	case share.ScanObjectType_HOST:
 		enableAutoScanBool = enableAutoScanBool || cfg.EnableAutoScanHost
 	case share.ScanObjectType_PLATFORM:
-		enableAutoScanBool = enableAutoScanBool || cfg.EnableAutoScanPlatform
+		enableAutoScanBool = false // platform is not supported for auto scan
 	}
 	return enableAutoScanBool
 }
@@ -629,7 +629,6 @@ func scannerDBChange(newVer string) {
 	// Skip if no auto-scan options are enabled
 	if !scanCfg.EnableAutoScanWorkload &&
 		!scanCfg.EnableAutoScanHost &&
-		!scanCfg.EnableAutoScanPlatform &&
 		!scanCfg.AutoScan {
 		return
 	}
@@ -809,7 +808,6 @@ func CompareScanConfig(src, target *share.CLUSScanConfig) (shouldEnable, shouldD
 	}{
 		{src.EnableAutoScanWorkload, target.EnableAutoScanWorkload},
 		{src.EnableAutoScanHost, target.EnableAutoScanHost},
-		{src.EnableAutoScanPlatform, target.EnableAutoScanPlatform},
 		{src.AutoScan, target.AutoScan},
 	}
 
@@ -1375,7 +1373,6 @@ func (m CacheMethod) GetScanConfig(acc *access.AccessControl) (*api.RESTScanConf
 		AutoScan:               scanCfg.AutoScan,
 		EnableAutoScanWorkload: scanCfg.EnableAutoScanWorkload,
 		EnableAutoScanHost:     scanCfg.EnableAutoScanHost,
-		EnableAutoScanPlatform: scanCfg.EnableAutoScanPlatform,
 	}, nil
 }
 

--- a/controller/rest/configmap.go
+++ b/controller/rest/configmap.go
@@ -316,8 +316,7 @@ func handlesystemcfg(yaml_data []byte, load bool, skip *bool, context *configMap
 	if err == nil && rc.ScanConfig != nil &&
 		(rc.ScanConfig.AutoScan != nil ||
 			rc.ScanConfig.EnableAutoScanWorkload != nil ||
-			rc.ScanConfig.EnableAutoScanHost != nil ||
-			rc.ScanConfig.EnableAutoScanPlatform != nil) {
+			rc.ScanConfig.EnableAutoScanHost != nil) {
 
 		cconf, err := applyScanConfigUpdates(rc.ScanConfig)
 		if err != nil {

--- a/controller/rest/configmap.go
+++ b/controller/rest/configmap.go
@@ -319,8 +319,7 @@ func handlesystemcfg(yaml_data []byte, load bool, skip *bool, context *configMap
 			rc.ScanConfig.EnableAutoScanHost != nil ||
 			rc.ScanConfig.EnableAutoScanPlatform != nil) {
 
-		cconf := &share.CLUSScanConfig{}
-		err = applyScanConfigUpdates(rc.ScanConfig, cconf)
+		cconf, err := applyScanConfigUpdates(rc.ScanConfig)
 		if err != nil {
 			log.WithFields(log.Fields{"err": err}).Error("applyScanConfigUpdates error")
 			return err

--- a/controller/rest/scanner.go
+++ b/controller/rest/scanner.go
@@ -37,69 +37,52 @@ func handlerScannerList(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 	restRespSuccess(w, r, &resp, acc, login, nil, "Get scanner list")
 }
 
-func applyScanConfigUpdates(sconf *api.RESTScanConfigConfig, cconf *share.CLUSScanConfig) error {
-	// fromNewClient is true if the request is from a 5.4.3+ http client
-	fromNewClient := false
-	if sconf.AutoScan != nil {
-		cconf.AutoScan = *sconf.AutoScan
-	}
-
-	updateAutoScanWorkload := false
-	updateAutoScanHost := false
-	updateAutoScanPlatform := false
-	// update from the 5.4.3+ http client => use the pointer to update the config
-	if sconf.EnableAutoScanWorkload != nil {
-		fromNewClient = true
-		cconf.EnableAutoScanWorkload = *sconf.EnableAutoScanWorkload
-		updateAutoScanWorkload = true
-	}
-	if sconf.EnableAutoScanHost != nil {
-		fromNewClient = true
-		cconf.EnableAutoScanHost = *sconf.EnableAutoScanHost
-		updateAutoScanHost = true
-	}
-	if sconf.EnableAutoScanPlatform != nil {
-		fromNewClient = true
-		cconf.EnableAutoScanPlatform = *sconf.EnableAutoScanPlatform
-		updateAutoScanPlatform = true
-	}
-
+func applyScanConfigUpdates(sconf *api.RESTScanConfigConfig) (*share.CLUSScanConfig, error) {
 	// Retrieve existing scan configuration from the cluster before applying updates.
 	// This ensures NeuVector doesn't accidentally override existing settings that should be preserved.
 	// For example, if only some auto-scan flags are being updated, we want to keep the
 	// previous values for any flags that aren't being modified in this request.
+	var cconf *share.CLUSScanConfig
 	oldCfg, _ := cluster.Get(share.CLUSConfigScanKey)
 	if oldCfg != nil {
 		var oldCLUSScanConfig share.CLUSScanConfig
 		err := json.Unmarshal(oldCfg, &oldCLUSScanConfig)
 		if err != nil {
 			log.WithFields(log.Fields{"error": err}).Error("Failed to unmarshal old scan config")
-			return err
+			return nil, err
 		}
+		cconf = &oldCLUSScanConfig
+	} else {
+		cconf = &share.CLUSScanConfig{}
+	}
 
-		// make sure the new config is not overriding the old config
-		if !updateAutoScanPlatform {
-			cconf.EnableAutoScanPlatform = cconf.EnableAutoScanPlatform || oldCLUSScanConfig.EnableAutoScanPlatform
-		}
-		if !updateAutoScanWorkload {
-			cconf.EnableAutoScanWorkload = cconf.EnableAutoScanWorkload || oldCLUSScanConfig.EnableAutoScanWorkload
-		}
-		if !updateAutoScanHost {
-			cconf.EnableAutoScanHost = cconf.EnableAutoScanHost || oldCLUSScanConfig.EnableAutoScanHost
-		}
+	// fromNewClient is true if the request is from a 5.4.3+ http client
+	fromNewClient := false
+	if sconf.AutoScan != nil {
+		cconf.AutoScan = *sconf.AutoScan
+	}
+
+	// update from the 5.4.3+ http client => use the pointer to update the config
+	if sconf.EnableAutoScanWorkload != nil {
+		fromNewClient = true
+		cconf.EnableAutoScanWorkload = *sconf.EnableAutoScanWorkload
+	}
+	if sconf.EnableAutoScanHost != nil {
+		fromNewClient = true
+		cconf.EnableAutoScanHost = *sconf.EnableAutoScanHost
 	}
 
 	// if one of the fields is not set, we need to set the auto scan to false
 	// this is to ensure that the old config is not overridden by the new config
 	if fromNewClient {
-		if cconf.EnableAutoScanPlatform && cconf.EnableAutoScanWorkload && cconf.EnableAutoScanHost {
+		if cconf.EnableAutoScanWorkload && cconf.EnableAutoScanHost {
 			cconf.AutoScan = true
 		} else {
 			cconf.AutoScan = false
 		}
 	}
 
-	return nil
+	return cconf, nil
 }
 
 func handlerScanConfig(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
@@ -126,15 +109,15 @@ func handlerScanConfig(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 		return
 	}
 
-	cconf := &share.CLUSScanConfig{}
-	if !acc.Authorize(cconf, nil) {
-		restRespAccessDenied(w, login)
+	cconf, err := applyScanConfigUpdates(sconf.Config)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err}).Error("applyScanConfigUpdates error")
+		restRespError(w, http.StatusInternalServerError, api.RESTErrFailReadCluster)
 		return
 	}
 
-	if err := applyScanConfigUpdates(sconf.Config, cconf); err != nil {
-		log.WithFields(log.Fields{"err": err}).Error("applyScanConfigUpdates error")
-		restRespError(w, http.StatusInternalServerError, api.RESTErrFailReadCluster)
+	if !acc.Authorize(cconf, nil) {
+		restRespAccessDenied(w, login)
 		return
 	}
 

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -698,7 +698,10 @@ type CLUSScanState struct {
 }
 
 type CLUSScanConfig struct {
-	AutoScan bool `json:"auto_scan"`
+	AutoScan               bool `json:"auto_scan"`
+	EnableAutoScanWorkload bool `json:"enable_auto_scan_workload"`
+	EnableAutoScanHost     bool `json:"enable_auto_scan_host"`
+	EnableAutoScanPlatform bool `json:"enable_auto_scan_platform"`
 }
 
 type CLUSCtrlVersion struct {

--- a/share/clus_apis.go
+++ b/share/clus_apis.go
@@ -701,7 +701,6 @@ type CLUSScanConfig struct {
 	AutoScan               bool `json:"auto_scan"`
 	EnableAutoScanWorkload bool `json:"enable_auto_scan_workload"`
 	EnableAutoScanHost     bool `json:"enable_auto_scan_host"`
-	EnableAutoScanPlatform bool `json:"enable_auto_scan_platform"`
 }
 
 type CLUSCtrlVersion struct {


### PR DESCRIPTION
### Summary
- Support auto scan with fine-grained level control.
- Auto-scan can be configured globally or with fine-grained control for workloads, hosts, or platforms. However, if any of the detailed control fields (enable_auto_scan_workload, enable_auto_scan_host, or enable_auto_scan_platform) is set to false, auto-scan will be disabled overall, because these flags collectively represent a "scan all" setting.

### Test Perform
- set auto-scan through patch /v1/scan/config, will not affect enable_auto_scan_workload, enable_auto_scan_host, or enable_auto_scan_platform
- if set any of enable_auto_scan_workload, enable_auto_scan_host, or enable_auto_scan_platform, it will follow the following _**if enable_auto_scan_workload, enable_auto_scan_host, or enable_auto_scan_platform is set to false, auto-scan will be disabled overall, because these flags collectively represent a "scan all" setting.**_