### PR TITLE
NVSHAS-9817: Creating NvClusterSecurityRule CRD shows successful crea…

### DIFF
--- a/controller/rest/crdsecurityrule.go
+++ b/controller/rest/crdsecurityrule.go
@@ -2310,10 +2310,7 @@ func (h *nvCrdHandler) validateCrdProcessRules(rules []*api.RESTProcessProfileEn
 		}
 
 		key := fmt.Sprintf("%s:%s:%s", r.Name, r.Path, r.Action)
-		if ruleSet.Contains(key) {
-			buffer.WriteString(fmt.Sprintf(" Duplicated process rule entry: : %s \n", msg))
-			errCnt++
-		} else {
+		if !ruleSet.Contains(key) {
 			ruleSet.Add(key)
 		}
 


### PR DESCRIPTION
…tion, but it was not actually created due to duplicated process rule entries

When configuring process rules thru REST API, the API handler does merge the rules so that duplicate rules are not treated as error.
CRD should have the same behavior.