### PR TITLE
fix: staticcheck and gosimple findings

### DIFF
--- a/agent/dp/ctrl.go
+++ b/agent/dp/ctrl.go
@@ -273,7 +273,7 @@ func DPCtrlAddMAC(iface string, mac, ucmac, bcmac, oldmac, pmac net.HardwareAddr
 			PIPS:   tpips,
 		},
 	}
-	if pips == nil || len(pips) <= 0 {
+	if len(pips) <= 0 {
 		data.AddMAC.PIPS = nil
 	}
 	msg, _ := json.Marshal(data)
@@ -1037,6 +1037,7 @@ func dpKeepAlive() {
 }
 
 func monitorDP() {
+	//nolint:staticcheck // SA1015
 	dpTicker := time.Tick(dpKeepAliveInterval)
 	dpConnJamRetry := 0
 

--- a/agent/pipe/port.go
+++ b/agent/pipe/port.go
@@ -1392,7 +1392,7 @@ func createIptablesNvQuarRules() {
 
 func insertIptablesNvRules(intf string, isloopback bool, qno int, appMap map[share.CLUSProtoPort]*share.CLUSApp) {
 	var cmd string
-	if appMap == nil || len(appMap) <= 0 {
+	if len(appMap) <= 0 {
 		cmd = fmt.Sprintf("iptables -I %v -t filter -i %v -j NFQUEUE --queue-num %d --queue-bypass", nvInputChain, intf, qno)
 		if _, dbgError := shellCombined(cmd); dbgError != nil {
 			log.WithFields(log.Fields{"dbgError": dbgError}).Debug()
@@ -1447,7 +1447,7 @@ func insertIptablesNvRules(intf string, isloopback bool, qno int, appMap map[sha
 
 func checkInsertIptablesNvRules(intf string, isloopback bool, qno int, appMap map[share.CLUSProtoPort]*share.CLUSApp) {
 	var cmd string
-	if appMap == nil || len(appMap) <= 0 {
+	if len(appMap) <= 0 {
 		cmd = fmt.Sprintf("iptables -C %v -t filter -i %v -j NFQUEUE --queue-num %d --queue-bypass", nvInputChain, intf, qno)
 		if _, err := shellCombined(cmd); err != nil {
 			cmd = fmt.Sprintf("iptables -I %v -t filter -i %v -j NFQUEUE --queue-num %d --queue-bypass", nvInputChain, intf, qno)

--- a/agent/policy/network.go
+++ b/agent/policy/network.go
@@ -768,7 +768,7 @@ func getWorkload(addrs []*share.CLUSWorkloadAddr,
 				(polAppDir&C.DP_POLICY_APPLY_INGRESS > 0 && !isto) {
 				for id, wl := range wlMap {
 					if strings.Contains(addr.PolicyMode, wl.PolicyMode) {
-						if addr.NatPortApp == nil || len(addr.NatPortApp) <= 0 { //PAI
+						if len(addr.NatPortApp) <= 0 { //PAI
 							wlList = append(wlList, &share.CLUSWorkloadAddr{WlID: id,
 								LocalPortApp: addr.LocalPortApp, NatPortApp: addr.NatPortApp})
 						} else {

--- a/agent/probe/probe.go
+++ b/agent/probe/probe.go
@@ -226,8 +226,11 @@ func (p *Probe) monitorProcessChanges() {
 }
 
 func (p *Probe) loop() {
+	//nolint:staticcheck // SA1015
 	scanTicker := time.Tick(time.Second * 1)
+	//nolint:staticcheck // SA1015
 	purgeHistoryTicker := time.Tick(time.Second * 60)
+	//nolint:staticcheck // SA1015
 	aggregateReportTicker := time.Tick(time.Second * 5)
 	var scan bool
 	var pidSetNew utils.Set

--- a/agent/probe/process_linux.go
+++ b/agent/probe/process_linux.go
@@ -281,6 +281,7 @@ func (p *Probe) netlinkProcMonitor() {
 	var rebuildCounter int64 = -1
 	const ticker_unit_in_seconds = 2
 	const cleanupCounter = 10 * 60 / ticker_unit_in_seconds // 10 minutes
+	//nolint:staticcheck // SA1015
 	ticker := time.Tick(time.Second * ticker_unit_in_seconds)
 	log.Info("PROC: Start real-time process listener")
 	for {

--- a/controller/cache/admission.go
+++ b/controller/cache/admission.go
@@ -1998,6 +1998,7 @@ func (m CacheMethod) SyncAdmCtrlStateToK8s(svcName, nvAdmName string, updateDete
 }
 
 func (m CacheMethod) WaitUntilApiPathReady() bool {
+	//nolint:staticcheck // SA1015
 	ticker := time.Tick(time.Second)
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)

--- a/controller/cache/learn.go
+++ b/controller/cache/learn.go
@@ -1231,6 +1231,7 @@ func startPolicyThread() {
 	vulProfUpdateTimer = time.NewTimer(vulProfUpdateDelayIdle)
 	vulProfUpdateTimer.Stop()
 
+	//nolint:staticcheck // SA1015
 	syncCheckTicker := time.Tick(time.Second * time.Duration(120))
 
 	// In case there are already learned rule in cluster, fetch the rules.

--- a/controller/nvk8sapi/nvvalidatewebhookcfg/nvvalidatewebhookcfg.go
+++ b/controller/nvk8sapi/nvvalidatewebhookcfg/nvvalidatewebhookcfg.go
@@ -781,11 +781,11 @@ func TestAdmWebhookConnection(svcname string) (int, error) {
 			} else {
 				c_sig := make(chan os.Signal, 1)
 				signal.Notify(c_sig, os.Interrupt, syscall.SIGTERM)
-				//nolint:staticcheck // SA1015
-				ticker := time.Tick(time.Second)
+				ticker := time.NewTicker(time.Second)
+				defer ticker.Stop()
 				for i := 0; i < 10; i++ {
 					select {
-					case <-ticker:
+					case <-ticker.C:
 						if err, svcInfo := GetValidateWebhookSvcInfo(svcname); err == nil {
 							if svcInfo.LabelTag == tag && svcInfo.LabelEcho == tag {
 								// one nv controller processed our UPDATE svc request
@@ -871,11 +871,11 @@ func EchoAdmWebhookConnection(tagExpected, svcname string) {
 	}
 	c_sig := make(chan os.Signal, 1)
 	signal.Notify(c_sig, os.Interrupt, syscall.SIGTERM)
-	//nolint:staticcheck // SA1015
-	ticker := time.Tick(time.Second)
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
 	for i := 0; i < 4; i++ {
 		select {
-		case <-ticker:
+		case <-ticker.C:
 			obj, err := global.ORCH.GetResource(resource.RscTypeService, resource.NvAdmSvcNamespace, svcname)
 			if err != nil {
 				log.WithFields(log.Fields{"namespace": resource.NvAdmSvcNamespace, "service": svcname, "err": err}).Error("resource no found")

--- a/controller/nvk8sapi/nvvalidatewebhookcfg/nvvalidatewebhookcfg.go
+++ b/controller/nvk8sapi/nvvalidatewebhookcfg/nvvalidatewebhookcfg.go
@@ -781,6 +781,7 @@ func TestAdmWebhookConnection(svcname string) (int, error) {
 			} else {
 				c_sig := make(chan os.Signal, 1)
 				signal.Notify(c_sig, os.Interrupt, syscall.SIGTERM)
+				//nolint:staticcheck // SA1015
 				ticker := time.Tick(time.Second)
 				for i := 0; i < 10; i++ {
 					select {
@@ -870,6 +871,7 @@ func EchoAdmWebhookConnection(tagExpected, svcname string) {
 	}
 	c_sig := make(chan os.Signal, 1)
 	signal.Notify(c_sig, os.Interrupt, syscall.SIGTERM)
+	//nolint:staticcheck // SA1015
 	ticker := time.Tick(time.Second)
 	for i := 0; i < 4; i++ {
 		select {

--- a/controller/rest/admwebhook.go
+++ b/controller/rest/admwebhook.go
@@ -153,6 +153,7 @@ func checkAggrLogsCache(alwaysFlush bool) {
 func CleanupSessCfgCache() {
 	cSig := make(chan os.Signal, 1)
 	signal.Notify(cSig, os.Interrupt, syscall.SIGTERM)
+	//nolint:staticcheck // SA1015
 	ticker := time.Tick(time.Minute)
 Loop:
 	for {

--- a/controller/scan/registry.go
+++ b/controller/scan/registry.go
@@ -1846,6 +1846,7 @@ func (rs *Registry) polling(ctx context.Context) {
 		smd.scanLog.WithFields(log.Fields{"PollPeriod": rs.config.PollPeriod}).Error("Polling interval out of range")
 		return
 	}
+	//nolint:staticcheck // SA1015
 	ticker := time.Tick(time.Second * time.Duration(rs.config.PollPeriod))
 	for {
 		select {

--- a/share/cluster/grpc.go
+++ b/share/cluster/grpc.go
@@ -96,8 +96,7 @@ func NewGRPCServerTCP(endpoint string) (*GRPCServer, error) {
 		return nil, fmt.Errorf("failed to create new server credentials: %w", err)
 	}
 
-	//TODO: addressing go-linter "SA1019: grpc.NewGZIPDecompressor is deprecated: use package encoding/gzip. (staticcheck)"
-	//nolint:staticcheck
+	//nolint:staticcheck // SA1019
 	opts := []grpc.ServerOption{
 		grpc.Creds(ct),
 		grpc.UnaryInterceptor(middlefunc),
@@ -168,8 +167,7 @@ func ReloadInternalCert() error {
 }
 
 func NewGRPCServerUnix(socket string) (*GRPCServer, error) {
-	//TODO: addressing go-linter "SA1019: grpc.NewGZIPDecompressor is deprecated: use package encoding/gzip. (staticcheck)"
-	//nolint:staticcheck
+	//nolint:staticcheck // SA1019
 	opts := []grpc.ServerOption{
 		grpc.RPCCompressor(grpc.NewGZIPCompressor()),
 		grpc.RPCDecompressor(grpc.NewGZIPDecompressor()),
@@ -318,8 +316,7 @@ func newGRPCClientTCP(ctx context.Context, key, endpoint string, cb GRPCCallback
 	// This is to be compatible with pre-3.2 grpc server that doesn't install decompressor.
 	var opts []grpc.DialOption
 	if compress {
-		//TODO: addressing go-linter "SA1019: grpc.NewGZIPDecompressor is deprecated: use package encoding/gzip. (staticcheck)"
-		//nolint:staticcheck
+		//nolint:staticcheck // SA1019
 		opts = []grpc.DialOption{
 			grpc.WithTransportCredentials(ct),
 			grpc.WithDecompressor(grpc.NewGZIPDecompressor()),
@@ -330,8 +327,7 @@ func newGRPCClientTCP(ctx context.Context, key, endpoint string, cb GRPCCallback
 				grpc.MaxCallSendMsgSize(GRPCMaxMsgSize)),
 		}
 	} else {
-		//TODO: addressing go-linter "SA1019: grpc.NewGZIPDecompressor is deprecated: use package encoding/gzip. (staticcheck)"
-		//nolint:staticcheck
+		//nolint:staticcheck // SA1019
 		opts = []grpc.DialOption{
 			grpc.WithTransportCredentials(ct),
 			grpc.WithDecompressor(grpc.NewGZIPDecompressor()),
@@ -342,6 +338,7 @@ func newGRPCClientTCP(ctx context.Context, key, endpoint string, cb GRPCCallback
 		}
 	}
 
+	//nolint:staticcheck // SA1019
 	conn, err := grpc.DialContext(ctx, endpoint, opts...)
 	if err != nil {
 		return nil, err
@@ -357,8 +354,7 @@ func newGRPCClientTCP(ctx context.Context, key, endpoint string, cb GRPCCallback
 func newGRPCClientUnix(ctx context.Context, key, socket string, cb GRPCCallback, compress bool) (*GRPCClient, error) {
 	var opts []grpc.DialOption
 	if compress {
-		//TODO: addressing go-linter "SA1019: grpc.NewGZIPDecompressor is deprecated: use package encoding/gzip. (staticcheck)"
-		//nolint:staticcheck
+		//nolint:staticcheck // SA1019
 		opts = []grpc.DialOption{
 			grpc.WithInsecure(),
 			grpc.WithDecompressor(grpc.NewGZIPDecompressor()),
@@ -372,8 +368,7 @@ func newGRPCClientUnix(ctx context.Context, key, socket string, cb GRPCCallback,
 			}),
 		}
 	} else {
-		//TODO: addressing go-linter "SA1019: grpc.NewGZIPDecompressor is deprecated: use package encoding/gzip. (staticcheck)"
-		//nolint:staticcheck
+		//nolint:staticcheck // SA1019
 		opts = []grpc.DialOption{
 			grpc.WithInsecure(),
 			grpc.WithDecompressor(grpc.NewGZIPDecompressor()),
@@ -387,6 +382,7 @@ func newGRPCClientUnix(ctx context.Context, key, socket string, cb GRPCCallback,
 		}
 	}
 
+	//nolint:staticcheck // SA1019
 	conn, err := grpc.DialContext(ctx, socket, opts...)
 	if err != nil {
 		return nil, err

--- a/share/cluster/intfs.go
+++ b/share/cluster/intfs.go
@@ -360,6 +360,7 @@ func RegisterLeadChangeWatcher(fn LeadChangeCallback, lead string) {
 	})
 
 	go func() {
+		//nolint:staticcheck // SA1015
 		leadMonitorTicker := time.Tick(time.Second * 5)
 		for {
 			select {

--- a/share/container/cri_client.go
+++ b/share/container/cri_client.go
@@ -87,6 +87,7 @@ func newCriClient(sock string, ctx context.Context) (*grpc.ClientConn, *criRT.Ve
 	}
 
 	log.WithFields(log.Fields{"addr": addr}).Debug()
+	//nolint:staticcheck // SA1019
 	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(4*time.Second), grpc.WithDialer(dialer))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to connect, make sure you are running as root and the runtime has been started: %v", err)

--- a/share/fsmon/monitor.go
+++ b/share/fsmon/monitor.go
@@ -329,8 +329,10 @@ func (w *FileWatch) sendMsg(cid string, path string, event uint32, pInfo []*Proc
 }
 
 func (w *FileWatch) loop() {
+	//nolint:staticcheck // SA1015
 	msgTicker := time.Tick(time.Second * 4)
 	// every 10s send learning rules to controller
+	//nolint:staticcheck // SA1015
 	learnTicker := time.Tick(time.Second * 10)
 
 	for {

--- a/share/osutil/process_linux.go
+++ b/share/osutil/process_linux.go
@@ -230,7 +230,7 @@ func getCGroupSocketTable(rootPid int, tbl map[uint32]SocketInfo, file string, t
 			}
 		}
 
-		if tokens == nil || len(tokens) < 9 {
+		if len(tokens) < 9 {
 			continue
 		}
 
@@ -290,7 +290,7 @@ func getConnectionByFile(fileName string, inodes utils.Set, tcp bool, sport uint
 			}
 		}
 
-		if tokens == nil || len(tokens) < 9 {
+		if len(tokens) < 9 {
 			continue
 		}
 


### PR DESCRIPTION
So far we've fixed most of issues reported by golangci-lint.  These are the remaining ones.  

```
S1009: should omit nil check; len() for nil slices is defined as zero (gosimple)
SA1015: using time.Tick leaks the underlying ticker, consider using it only in endless functions, tests and the main package, and use time.NewTicker here (staticcheck)
SA1019: grpc.DialContext is deprecated: use NewClient instead.  Will be supported throughout 1.x. (staticcheck)
```

For SA1015, our usage is reviewed to make sure our usage is alright - no ticker leak.
For SA1019, because gRPC won't deprecate those APIs until its next major version, these findings are marked as nolint. 

After this PR, we don't have to run golangci-lint against only diff anymore.  This will help us to discover more issues using golangci-lint. 