### PR TITLE
NVSHAS-9847: fix broken dockerhub urls

### DIFF
--- a/controller/scan/dockerhub.go
+++ b/controller/scan/dockerhub.go
@@ -46,10 +46,11 @@ func (r dockerhub) GetRepoList(org, name string, limit int) ([]*share.CLUSImage,
 		}
 	}
 
-	u, err := r.url("v2/repositories/%s/?page_size=%d", org, limit)
+	u, err := r.url("v2/repositories/%s/", org)
 	if err != nil {
 		return nil, err
 	}
+	u = fmt.Sprintf("%s?page_size=%d", u, limit)
 
 	resp, err := r.rc.Client.Get(u)
 	if err != nil {


### PR DESCRIPTION
A previous change to use `url.JoinPath` was causing the query parameters to get escaped, meaning they would be interpreted as the repo part of the request path instead of actual query parameters.

This change reverts the previous behavior, where the query parameters are literally appended to the url, instead of escaped during `JoinPath`. Ideally this would be changed in a more _semantic_ way but this is the simplest way to fix this without affecting other parts of the codebase.