### PR TITLE
NSHAS-9875: add default commit comment for azure devops export

### DIFF
--- a/controller/remote_repository/azure_devops.go
+++ b/controller/remote_repository/azure_devops.go
@@ -133,6 +133,10 @@ func (exp *azureDevopsExport) getRef() (AzureDevopsApi_Ref, error) {
 }
 
 func (exp *azureDevopsExport) pushFileToRepo(ref AzureDevopsApi_Ref, pushOperation string) error {
+	commitComment := exp.exportOptions.Comment
+	if commitComment == "" {
+		commitComment = fmt.Sprintf("import %s", exp.exportOptions.FilePath)
+	}
 	requestBody := AzureDevopsApi_RepoPushRequest{
 		RefUpdates: []RefUpdates{
 			{
@@ -142,7 +146,7 @@ func (exp *azureDevopsExport) pushFileToRepo(ref AzureDevopsApi_Ref, pushOperati
 		},
 		Commits: []Commits{
 			{
-				Comment: exp.exportOptions.Comment,
+				Comment: commitComment,
 				Changes: []Changes{
 					{
 						ChangeType: pushOperation,


### PR DESCRIPTION
It is possible that user does not enter a commit comment, however an empty `comment` results in a `400` from the Azure Devops repo API. A default comment is necessary.