### PR TITLE
fix: incorrect version format

### DIFF
--- a/package/Dockerfile.controller
+++ b/package/Dockerfile.controller
@@ -25,7 +25,7 @@ COPY upgrader/ /src/upgrader
 COPY vendor /src/vendor
 COPY go.mod go.sum base.h defs.h genlic.sh /src/
 WORKDIR /src
-RUN sed -i -e 's/interim.*xxxx/'"${VERSION:1}"'/g' ./controller/version.go
+RUN sed -i -e 's#interim.*xxxx#'"${VERSION}"'#g' ./controller/version.go
 RUN bash package/build_controller.sh
 
 #

--- a/package/Dockerfile.enforcer
+++ b/package/Dockerfile.enforcer
@@ -27,7 +27,7 @@ ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 
 COPY . /src
 WORKDIR /src
-RUN sed -i -e 's/interim.*xxxx/'"${VERSION:1}"'/g' ./agent/version.go
+RUN sed -i -e 's#interim.*xxxx#'"${VERSION}"'#g' ./agent/version.go
 RUN bash package/build_enforcer.sh
 
 #


### PR DESCRIPTION
In 5.4.2, the version format in golang space missed a v prefix.  This commit fixed the issue.  