### PR TITLE
NVSHAS-9876: Enforcer crashed on rke2 v1.32

### DIFF
--- a/share/container/types.go
+++ b/share/container/types.go
@@ -391,6 +391,10 @@ func isKubeletLikely(cmds []string) bool {
 			matchedCnt++
 		}
 
+		if strings.HasPrefix(cmd, "--containerd=") {
+			matchedCnt++
+		}
+
 		if matchedCnt >= 2 {
 			log.WithFields(log.Fields{"cmds": cmds}).Debug()
 			return true
@@ -461,6 +465,10 @@ func obtainRtEndpointFromKubelet(sys *system.SystemTools) (string, string, bool)
 							if strings.HasPrefix(cmd, "--container-runtime-endpoint=") {
 								// log.WithFields(log.Fields{"cmd": cmd}).Debug("found")
 								cmd = strings.TrimPrefix(cmd, "--container-runtime-endpoint=")
+								cmd = strings.TrimPrefix(cmd, "unix://") // remove "unix://" if exist
+								endpoint = cmd
+							} else if strings.HasPrefix(cmd, "--containerd=") {
+								cmd = strings.TrimPrefix(cmd, "--containerd=")
 								cmd = strings.TrimPrefix(cmd, "unix://") // remove "unix://" if exist
 								endpoint = cmd
 							}


### PR DESCRIPTION
The latest rke2 replaces its "kubelet" running parameters which cause the mismatched case with "docker" runtime together on the same node. 

Other work-arounds:
(1) User can use HELM's "k3s" flag to override the runtime driver 
(2) Remove the docker runtime from the nodes.