### PR TITLE
NV9894: false-positive incidents on k8s's controller

### DIFF
--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -2979,9 +2979,10 @@ func (p *Probe) isNVChildProcess(c *procContainer, proc *procInternal) bool {
 		return path == ppath /// only for cli case
 	}
 
+	bK8sProbeSituation := p.bKubePlatform && isControllerType(nvRole) && ppath == "" // a quick probe process
 	// backup lookup if we did not catch its parents
 	for i := 0; i < 8; i++ { // lookup for 8 callers
-		if global.RT.IsRuntimeProcess(filepath.Base(ppath), nil) || bRuncInit {
+		if global.RT.IsRuntimeProcess(filepath.Base(ppath), nil) || bRuncInit || bK8sProbeSituation {
 			mLog.WithFields(log.Fields{"path": path, "ppath": ppath, "nvRole": nvRole, "k8s": p.bKubePlatform, "bRuncInit": bRuncInit}).Debug()
 			switch path {
 			case "/usr/bin/cat": // k8s readiness probe


### PR DESCRIPTION
On k8s, controllers have setup k8s PROBE actions. They are allowed but we failed to identify it on a very short-lived action.