### PR TITLE
NV9905: k8s workload scan returns image metadata

### DIFF
--- a/agent/workerlet/pathWalker/pathWalker.go
+++ b/agent/workerlet/pathWalker/pathWalker.go
@@ -300,7 +300,7 @@ func (tm *taskMain) WalkPathTask(req workerlet.WalkPathRequest) {
 func (tm *taskMain) WalkPackageTask(req workerlet.WalkGetPackageRequest) {
 	var data share.ScanData
 	scanUtil := scan.NewScanUtil(tm.sys)
-	data.Buffer, data.Error = scanUtil.GetRunningPackages(req.Id, req.ObjType, req.Pid, req.Kernel, req.PidHost)
+	data.Buffer, data.Error = scanUtil.GetRunningPackages(req.Id, req.ObjType, req.Pid, req.Kernel, req.ImageRepo, req.PidHost)
 
 	// outputs:
 	output, err := json.Marshal(data)

--- a/agent/workerlet/types.go
+++ b/agent/workerlet/types.go
@@ -22,11 +22,12 @@ type WalkPathRequest struct {
 }
 
 type WalkGetPackageRequest struct {
-	Pid     int                  `json:"pid"`
-	Id      string               `json:"id"`
-	Kernel  string               `json:"kernel"`
-	ObjType share.ScanObjectType `json:"objType"`
-	PidHost bool                 `json:"pidHost"`
+	Pid       int                  `json:"pid"`
+	Id        string               `json:"id"`
+	Kernel    string               `json:"kernel"`
+	ObjType   share.ScanObjectType `json:"objType"`
+	PidHost   bool                 `json:"pidHost"`
+	ImageRepo string               `json:"k8sImage"`
 }
 
 type WalkSecretRequest struct {

--- a/share/scan/apps.go
+++ b/share/scan/apps.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	AppFileName = "apps_pkg"
+	Kubernetes  = "kubernetes"
 
 	nodeModules1 = "/usr/lib/node_modules"
 	nodeModules2 = "/usr/local/lib/node_modules"


### PR DESCRIPTION
K8s only: add returning image repo into the scan data. Later on, the scanner can utilize the information to match its cve database.

Add new module type and its associated structure:


```
Kubernetes = "kubernetes"

const (
	TypeK8sRepo = "k8sRepo"
)

type KubernetesResource struct {
	ResourceType string `json:"type"`
	Name         string `json:"name"`
}
```