### PR TITLE
NVSHAS-9791: read runtime dependency not dev dependency

### DIFF
--- a/share/scan/apps.go
+++ b/share/scan/apps.go
@@ -557,7 +557,7 @@ func isRuby(filename string) bool {
 }
 
 func isDotNet(filename string) bool {
-	return strings.HasSuffix(filename, ".deps.json")
+	return strings.HasSuffix(filename, ".App.deps.json")
 }
 
 func isWordpress(filename string) bool {

--- a/share/scan/apps.go
+++ b/share/scan/apps.go
@@ -739,7 +739,8 @@ func parseDotNetJsonData(filename string, fullpath string, dotnet dotnetPackage)
 	if targets, ok := dotnet.Targets[dotnet.Runtime.Name]; ok {
 		for target, dep := range targets {
 			// Skip if the target has no runtime; it means the dependency is not actually installed.
-			if dep.Runtime == nil && os.Getenv("SCAN_DOTNET_RUNTIME") == "true" {
+			// if SCAN_DOTNET_RUNTIME is not set, we don't need to skip
+			if dep.Runtime == nil && os.Getenv("SCAN_DOTNET_RUNTIME") != "" {
 				continue
 			}
 			//Get dependencies of individual targets


### PR DESCRIPTION
### Summary
- In .NET applications, multiple *.deps.json files may exist, but only the runtime dependencies are relevant for identifying actual vulnerabilities — not the development-time dependencies.
  - Currently, NV including all dependencies by default, regardless of whether they’re actually used at runtime.
  - Incorporating the `runtime` section into our logic would make this more accurate.
- add `os.Getenv("SCAN_DOTNET_RUNTIME")` to ensure backward compatible
Here are some `.deps.json` snippets for context:

```json
"Microsoft.AspNetCore.Authentication.OpenIdConnect/7.0.0": {
  "dependencies": {
    "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.15.1"
  },
  "runtime": {
    "lib/net7.0/Microsoft.AspNetCore.Authentication.OpenIdConnect.dll": {
      "assemblyVersion": "7.0.0.0",
      "fileVersion": "7.0.22.51819"
    }
  }
},
"Microsoft.AspNetCore.Http/2.2.2": {
  "dependencies": {
    "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
    "Microsoft.AspNetCore.WebUtilities": "2.2.0",
    "Microsoft.Extensions.ObjectPool": "2.2.0",
    "Microsoft.Extensions.Options": "8.0.2",
    "Microsoft.Net.Http.Headers": "2.2.0"
  }
},
"Microsoft.AspNetCore.Http.Abstractions/2.2.0": {
  "dependencies": {
    "Microsoft.AspNetCore.Http.Features": "2.2.0",
    "System.Text.Encodings.Web": "4.5.0"
  }
}
```