### PR TITLE
docs: fix api docs for the admission control rules test endpoint

### DIFF
--- a/controller/api/apis.yaml
+++ b/controller/api/apis.yaml
@@ -298,19 +298,42 @@ paths:
     post:
       tags:
         - Admission
+      description: Testing admission control rules. The payload body is the content of a resource yaml file.
       summary: Test admission control rules
       security:
         - ApiKeyAuth: []
         - TokenAuth: []
       consumes:
-        - application/json
+        - 'text/plain; charset=utf-8'
       parameters:
         - in: body
           name: body
-          description: Admission rule data
+          description: Resource yaml file
           required: true
           schema:
-            $ref: '#/definitions/RESTAdmissionRuleConfigData'
+            type: string
+            example: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: nginx-deployment
+                labels:
+                  app: nginx
+              spec:
+                replicas: 3
+                selector:
+                  matchLabels:
+                    app: nginx
+                template:
+                  metadata:
+                    labels:
+                      app: nginx
+                  spec:
+                    containers:
+                      - name: nginx
+                        image: nginx:latest
+                        ports:
+                          - containerPort: 80
       responses:
         '200':
           description: Success


### PR DESCRIPTION
The API documentation for the endpoint `/v1/assess/admission/rule` seems to be outdated/incorrect: the documentation claims this endpoint consumes an `application/json` body using the `RESTAdmissionRuleConfigData` schema, but actually expects a yaml string containing a kubernetes resource.

I have changed the required type to a UTF8-encoded plain text string (like the `/v1/file/compliance/profile/config` endpoint), and added a description and example.