### PR TITLE
fix(controller): make admission control rules test endpoint accessible with read permission

### DIFF
--- a/controller/rest/assessment.go
+++ b/controller/rest/assessment.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"github.com/neuvector/neuvector/controller/access"
 	"io"
 	"net/http"
 	"strings"
@@ -27,7 +28,7 @@ func handlerAssessAdmCtrlRules(w http.ResponseWriter, r *http.Request, ps httpro
 	log.WithFields(log.Fields{"URL": r.URL.String()}).Debug()
 	defer r.Body.Close()
 
-	acc, login := getAccessControl(w, r, "")
+	acc, login := getAccessControl(w, r, access.AccessOPRead)
 	if acc == nil {
 		return
 	} else if !licenseAllowEnforce() {


### PR DESCRIPTION
See #1969

The current implementation does not explicitly specify whether this endpoint performs a read or write operation. Because of this the access operation is determined by checking the default for the used request method, which results in write since this is a `POST` endpoint. Because of this, you need an API key for a role with `Admission Control (M)` permission to call this endpoint.

By specifying the access operation as `access.AccessOPRead`, an API key using a role with the `Admission Control (V)` permission can be used to test admission control rules.