### PR TITLE
NVSHAS-9960: Scanner not working.

### DIFF
--- a/controller/cache/object.go
+++ b/controller/cache/object.go
@@ -1560,6 +1560,7 @@ func workloadUpdate(nType cluster.ClusterNotifyType, key string, value []byte) {
 		cacheMutexLock()
 
 		if wlCache, ok = wlCacheMap[id]; ok {
+			scanMapDelete(id) // Remove workload from scanMap
 			delete(wlCacheMap, id)
 
 			// Update parent's children list.


### PR DESCRIPTION
### Root cause
- wlCacheMap not sync with scanMap
- if enforcer is down, the scanMap will delete the item created by the agent, but wlCacheMap doesn't, and it lead to the in-consistent and unable to scan workload properly.

### Solution
Sync both map in deletion.
- When the [agent is removed](https://github.com/neuvector/neuvector/blob/7f856d6e0935bb9d62bf167cd9e2aa4228fefb74/controller/cache/scan.go#L808), remove related item in both scanMap and wlCacheMap.
- When delete the [wlCacheMap](https://github.com/neuvector/neuvector/blob/7f856d6e0935bb9d62bf167cd9e2aa4228fefb74/controller/cache/object.go#L1563), remove the related scanMap item as well
- Add `scanWorkloadAdd(id, cache)` to ensure the item in scanMap exist, because these two map should sync.