### PR TITLE
NV9966: process rules of the custom group can not apply well

### DIFF
--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -3283,26 +3283,21 @@ func (p *Probe) IsAllowedShieldProcess(id, mode, svcGroup string, proc *procInte
 			}
 		}
 	} else {
-		switch ppe.Action {
-		case share.PolicyActionLearn, share.PolicyActionOpen:
-			ppe.Action = share.PolicyActionViolate
+		if ppe.Action == share.PolicyActionDeny {
 			ppe.Uuid = share.CLUSReservedUuidShieldMode
-		case share.PolicyActionAllow:
-			bPass = true
-			if ppe.CfgType == share.Learned { // user needs to allow the process manually
-				// TODO: how about the learned rule's translation from GroundCfg-CRD?
-				bPass = false
-				ppe.Action = negativeResByMode(mode)
+		} else { // other actions
+			if bFromPmon && ppe.CfgType <= share.Learned {
+				ppe.Action = share.PolicyActionViolate
 				ppe.Uuid = share.CLUSReservedUuidShieldMode
-			} else if !ppe.AllowFileUpdate && !bNotImageButNewlyAdded {
-				if bModified {
-					bPass = false
-					ppe.Action = negativeResByMode(mode)
+			} else { // a defined rule from custom/crd groups
+				if bModified && !ppe.AllowFileUpdate {
+					ppe.Action = share.PolicyActionViolate
 					ppe.Uuid = share.CLUSReservedUuidAnchorMode
+				} else {
+					bPass = true
+					ppe.Action = share.PolicyActionAllow // allowed
 				}
 			}
-		case share.PolicyActionDeny:
-			ppe.Uuid = share.CLUSReservedUuidShieldMode
 		}
 	}
 	mLog.WithFields(log.Fields{"bModified": bModified, "bImageFile": bImageFile, "bNotImageButNewlyAdded": bNotImageButNewlyAdded}).Debug("SHD:")

--- a/share/container/crio.go
+++ b/share/container/crio.go
@@ -605,7 +605,11 @@ func (d *crioDriver) IsDaemonProcess(proc string, cmds []string) bool {
 }
 
 func (d *crioDriver) IsRuntimeProcess(proc string, cmds []string) bool {
-	return proc == "runc" || proc == "crio" || proc == "conmon" || proc == "crio-conmon" // an OCI container runtime monitor
+	switch proc {
+	case "runc", "crio", "conmon", "crio-conmon", "crun": // an OCI container runtime monitor
+		return true
+	}
+	return false
 }
 
 func (d *crioDriver) GetParent(info *ContainerMetaExtra, pidMap map[int]string) (bool, string) {


### PR DESCRIPTION
NV9966:  Security Event is triggered whenever a new "Process Profile Rule" is added or changed in a group

(1) Fix the custom group rule's application during the Discover mode. 
(2) Fix the deny operation because the false-detection of system service. 
(3) Add a new CRIO runtime process name.

Tested by QA.