### PR TITLE
NVSHAS-9911: remove mis-leading info

### DIFF
--- a/controller/rest/repository.go
+++ b/controller/rest/repository.go
@@ -266,6 +266,7 @@ func handlerScanRepositoryReq(w http.ResponseWriter, r *http.Request, ps httprou
 		} else {
 			restRespError(w, http.StatusInternalServerError, scanErr.Code)
 		}
+		return
 	}
 
 	if result == nil {


### PR DESCRIPTION
### Summary
- forget to early return when scan error, add it to avoid misleading error.