### PR TITLE
fix: quay.io is unable to use wildcard properly

### DIFF
--- a/controller/scan/image.go
+++ b/controller/scan/image.go
@@ -256,7 +256,14 @@ func (r *base) GetRepoList(org, name string, limit int) ([]*share.CLUSImage, err
 		}
 	}
 
-	repos, err := r.rc.Repositories()
+	var repos []string
+	var err error
+	if strings.Contains(r.regURL, "quay.io") {
+		repos, err = r.rc.QuayRepositories(org)
+	} else {
+		repos, err = r.rc.Repositories()
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/share/scan/registry/repositories.go
+++ b/share/scan/registry/repositories.go
@@ -14,6 +14,52 @@ type repositoriesResponse struct {
 	Repositories []string `json:"repositories"`
 }
 
+type Repository struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	IsPublic  bool   `json:"is_public"`
+}
+type quayRepositoriesResponse struct {
+	Repositories []Repository `json:"repositories"`
+}
+
+func (r *Registry) parseQuayRepositories(response quayRepositoriesResponse) []string {
+	repos := make([]string, 0)
+	for _, repo := range response.Repositories {
+		repos = append(repos, fmt.Sprintf("%s/%s", repo.Namespace, repo.Name))
+	}
+	return repos
+}
+
+func (r *Registry) QuayRepositories(namespace string) ([]string, error) {
+	url := r.url("/api/v1/repository?namespace=%s&public=true", namespace)
+	repos := make([]string, 0)
+
+	var response quayRepositoriesResponse
+	var err error
+
+	r.Client.SetTimeout(longTimeout)
+	for {
+		log.WithFields(log.Fields{"url": url}).Debug()
+		if !strings.HasPrefix(url, r.URL) {
+			url = r.URL + url
+		}
+
+		url, err = r.getPaginatedJson(url, &response)
+		switch err {
+		case ErrNoMorePages:
+			repos = append(repos, r.parseQuayRepositories(response)...)
+			return repos, nil
+		case nil:
+			repos = append(repos, r.parseQuayRepositories(response)...)
+			continue
+		default:
+			log.WithFields(log.Fields{"error": err}).Debug() // Debug level, as we are trying different URLs
+			return nil, err
+		}
+	}
+}
+
 func (r *Registry) Repositories() ([]string, error) {
 	url := r.url("/v2/_catalog")
 	repos := make([]string, 0)


### PR DESCRIPTION
### Summary
- Wildcard not work properly in quay.io, because quay.io use other api to fetch the repo.
- Only consider the cases for explicitly write quay, since there may not much user using this, plus it requires extra UI change if we make this as a new type.