### PR TITLE
fix: cis-benchmark file detection, replace with -e, fix cis-rke2-1.8

### DIFF
--- a/agent/nvbench/kubernetes-cis-benchmark/aks-1.4.0/worker/3_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/aks-1.4.0/worker/3_worker_nodes.yaml
@@ -22,7 +22,7 @@ groups:
           check="$id  - $description"
           file="/var/lib/kubelet/kubeconfig"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
               pass "      * read check_argument for $file"
@@ -50,7 +50,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -80,7 +80,7 @@ groups:
           file=""
           file="/etc/kubernetes/kubelet/kubelet-config.json"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
               pass "      * read check_argument for $file"
@@ -91,7 +91,7 @@ groups:
           else
             warn "$check"
             warn "      * kubelet configuration file, $file not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chmod chmod 644 /proc/1/root/etc/kubernetes/kubelet/kubelet-config.json
       - id: K.3.1.4
@@ -107,8 +107,8 @@ groups:
           PCI: []
           GDPR: []
         audit: |
-          check="$id  - $description"           
-          if [ -f "$file" ]; then
+          check="$id  - $description"
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -118,7 +118,7 @@ groups:
           else
             warn "$check"
             warn "      * kubelet configuration file, $file not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chown root:root /proc/1/root/etc/kubernetes/kubelet/kubelet-config.json
   - id: 3.2
@@ -157,10 +157,10 @@ groups:
           export NODE_NAME=ip-192.168.31.226.aks.internal (example node name from
           "kubectl get nodes")
           curl -sSL "http://${HOSTNAME_PORT}/api/v1/nodes/${NODE_NAME}/proxy/configz"
-          Based on your system, restart the kubelet service. For example:   
+          Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-          systemctl status kubelet -l                
+          systemctl status kubelet -l
       - id: K.3.2.2
         description: Ensure that the --authorization-mode argument is not set to AlwaysAllow
           (Automated)
@@ -182,10 +182,10 @@ groups:
           fi
         remediation: |
           If using a Kubelet config file, edit the file to set authorization: mode to Webhook.
-          If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.        
+          If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
           --authorization-mode=Webhook
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.3.2.3
         description: Ensure that the --client-ca-file argument is set as appropriate
@@ -208,7 +208,7 @@ groups:
               pass "      * client-ca-file: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to set authentication: x509: clientCAFile to the location of the client CA file.
           If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
@@ -239,7 +239,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to set readOnlyPort to 0.
           If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
@@ -264,13 +264,13 @@ groups:
               warn "      * streaming-connection-idle-timeout: $timeout"
           else
               pass "$check"
-          fi        
+          fi
         remediation: |
-          If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a value other than 0. 
+          If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a value other than 0.
           If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
           --streaming-connection-idle-timeout=5m
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.3.2.6
         description: Ensure that the --make-iptables-util-chains argument is set to
@@ -287,12 +287,12 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
-          If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true. 
-          If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and remove the --mak-iptables-util-chains argument from the KUBELET_SYSTEM_PODS_ARGS variable. 
-          Based on your system, restart the kubelet service. For example:        
-          systemctl daemon-reload 
+          If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true.
+          If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and remove the --mak-iptables-util-chains argument from the KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.3.2.7
         description: Ensure that the --hostname-override argument is not set (Manual)
@@ -308,7 +308,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: 'Edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
           on each worker node and remove the --hostname-override argument from the
           KUBELET_SYSTEM_PODS_ARGS variable. Based on your system, restart the kubelet
@@ -335,7 +335,7 @@ groups:
           else
               warn "$check"
               warn "      * --event-qps is not set"
-          fi  
+          fi
         remediation: |
           Remediation Method 1:
           If modifying the Kubelet config file, edit the kubelet-config.json file /etc/kubernetes/kubelet/kubelet-config.json and set the below parameter to 5 or a value greater or equal to 0
@@ -380,13 +380,13 @@ groups:
             warn "$check"
           else
             pass "$check"
-          fi   
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to add the line rotateCertificates: true or remove it altogether to use the default value.
           If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS variable.
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service 
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.3.2.10
         description: Ensure that the RotateKubeletServerCertificate argument is set
           to true (Automated)
@@ -406,7 +406,7 @@ groups:
               file=$(get_argument_value "$CIS_KUBELET_CMD" '--config'|cut -d " " -f 1)
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             found=$(sed -rn '/--feature-gates=RotateKubeletServerCertificate=true/p' $file)
             if [ -z "$found" ]; then
                 warn "$check"

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/master/1_control_plane_components.yaml
@@ -49,7 +49,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -77,7 +77,7 @@ groups:
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -104,7 +104,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -132,7 +132,7 @@ groups:
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -159,7 +159,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -187,7 +187,7 @@ groups:
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -214,7 +214,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -291,7 +291,7 @@ groups:
             count_files=$((count_files + 1))
             permissions=$(stat -c %u%g $file)
 
-            # Check if the ownership is set to root:root 
+            # Check if the ownership is set to root:root
             if [ "$permissions" != "00" ]; then
               non_compliant_files="$non_compliant_files$file ($permissions), "
             fi
@@ -332,7 +332,7 @@ groups:
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 700 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -361,7 +361,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %U:%G $file)" = "etcd:etcd" ]; then
               pass "$check"
             else
@@ -392,7 +392,7 @@ groups:
           file="/etc/kubernetes/admin.conf"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -419,7 +419,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -448,7 +448,7 @@ groups:
           file="/etc/kubernetes/scheduler.conf"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -475,7 +475,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -504,7 +504,7 @@ groups:
           file="/etc/kubernetes/controller-manager.conf"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -514,7 +514,7 @@ groups:
           else
             info "$check"
             info "      * File not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chmod 600 /etc/kubernetes/controller-manager.conf
       - id: K.1.1.18
@@ -531,7 +531,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -540,7 +540,7 @@ groups:
             fi
           else
             info "$check"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chown root:root /etc/kubernetes/controller-manager.conf
       - id: K.1.1.19
@@ -602,7 +602,7 @@ groups:
             pass "$check"
           else
             warn "$check"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chmod -R 600 /etc/kubernetes/pki/*.crt
       - id: K.1.1.21
@@ -655,7 +655,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the below parameter. --anonymous-auth=false
       - id: K.1.2.2
@@ -725,7 +725,7 @@ groups:
               fi
           else
               warn "$check"
-          fi  
+          fi
         remediation: Follow the Kubernetes documentation and set up the TLS connection
           between the apiserver and kubelets. Then, edit API server pod specification
           file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and
@@ -749,7 +749,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and setup the TLS connection
           between the apiserver and kubelets. Then, edit the API server pod specification
           file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and
@@ -773,7 +773,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --authorization-mode parameter to values
           other than AlwaysAllow . One such example could be as below. --authorization-mode=RBAC
@@ -794,7 +794,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --authorization-mode parameter to a value
           that includes Node . --authorization-mode=Node,RBAC
@@ -836,7 +836,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and set the desired limits
           in a configuration file. Then, edit the API server pod specification file
           /etc/kubernetes/manifests/kube-apiserver.yaml and set the below parameters.  --enable-admission-plugins=...,EventRateLimit,...
@@ -858,7 +858,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and either remove the --enable-admission-plugins parameter,
           or set it to a value that does not include AlwaysAdmit.
@@ -879,7 +879,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --enable-admission-plugins parameter to include
           AlwaysPullImages.  --enable-admission-plugins=...,AlwaysPullImages,...
@@ -904,7 +904,7 @@ groups:
             else
               warn "$check"
             fi
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --enable-admission-plugins parameter to include
           SecurityContextDeny, unless PodSecurityPolicy is already in place.  --enable-admission-plugins=...,SecurityContextDeny,...
@@ -925,7 +925,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: Follow the documentation and create ServiceAccount objects as
           per your environment. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and ensure that the --disable-admission-plugins parameter
@@ -996,7 +996,7 @@ groups:
               fi
           else
               pass "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and either remove the --secure-port parameter or set
           it to a different (non-zero) desired port.
@@ -1014,7 +1014,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the below parameter. --profiling=false
       - id: K.1.2.18
@@ -1033,7 +1033,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: 'Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --audit-log-path parameter to a suitable
           path and file where you would like audit logs to be written, for example:
@@ -1062,7 +1062,7 @@ groups:
               fi
           else
               warn "$check"
-          fi 
+          fi
         remediation: 'Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --audit-log-maxage parameter to 30 or as
           an appropriate number of days: --audit-log-maxage=30'
@@ -1139,7 +1139,7 @@ groups:
               pass "      * request-timeout: $requestTimeout"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           and set the below parameter as appropriate and if needed. For example, --request-timeout=300s
       - id: K.1.2.23
@@ -1160,7 +1160,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the below parameter. --service-account-lookup=true
       - id: K.1.2.24
@@ -1184,7 +1184,7 @@ groups:
               pass "      * service-account-key-file: $file"
           else
               warn "$check"
-          fi        
+          fi
         remediation: 'Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --service-account-key-file parameter to the
           public key file for service accounts: --service-account-key-file=<filename>'
@@ -1250,7 +1250,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and set up the TLS connection
           on the apiserver. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the TLS certificate and private key file parameters.
@@ -1301,7 +1301,7 @@ groups:
               pass "      * etcd-cafile: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and set up the TLS connection
           between the apiserver and etcd. Then, edit the API server pod specification
           file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and
@@ -1324,7 +1324,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi     
+          fi
         remediation: 'Follow the Kubernetes documentation and configure a EncryptionConfig
           file. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --encryption-provider-config parameter to
@@ -1356,7 +1356,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and configure a EncryptionConfig
           file. In this file, choose aescbc, kms or secretbox as the encryption provider.
       - id: K.1.2.31
@@ -1383,7 +1383,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and set the below parameter.
           --tls-cipher-suites=TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384,
@@ -1421,7 +1421,7 @@ groups:
               pass "      * terminated-pod-gc-threshold: $threshold"
           else
               warn "$check"
-          fi        
+          fi
         remediation: 'Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the --terminated-pod-gc-threshold to an appropriate
           threshold, for example: --terminated-pod-gc-threshold=10'
@@ -1439,7 +1439,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the below parameter. --profiling=false
       - id: K.1.3.3
@@ -1460,7 +1460,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node to set the below parameter. --use-service-account-credentials=true
       - id: K.1.3.4
@@ -1484,7 +1484,7 @@ groups:
               pass "      * service-account-private-key-file: $keyfile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the --service-account-private-key-file parameter
           to the private key file for service accounts. --service-account-private-key-file=<filename>
@@ -1509,7 +1509,7 @@ groups:
               pass "      * root-ca-file: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the --root-ca-file parameter to the certificate
           bundle file`. --root-ca-file=<path/to/file>
@@ -1537,7 +1537,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
           --feature-gates=RotateKubeletServerCertificate=true
@@ -1555,7 +1555,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and ensure the correct value for the --bind-address parameter.
   - id: 1.4
@@ -1575,7 +1575,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Scheduler pod specification file /etc/kubernetes/manifests/kube-scheduler.yaml
           file on the master node and set the below parameter. --profiling=false
       - id: K.1.4.2
@@ -1592,6 +1592,6 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Scheduler pod specification file /etc/kubernetes/manifests/kube-scheduler.yaml
           on the master node and ensure the correct value for the --bind-address parameter

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.23/worker/4_worker_nodes.yaml
@@ -29,7 +29,7 @@ groups:
               file=$kubeadm10
           fi
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -56,7 +56,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -87,7 +87,7 @@ groups:
               file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -97,7 +97,7 @@ groups:
           else
             info "$check"
             info "      * kubeconfig file not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chmod 644 <proxy kubeconfig file>
       - id: K.4.1.4
@@ -113,8 +113,8 @@ groups:
           PCI: []
           GDPR: []
         audit: |
-          check="$id  - $description"           
-          if [ -f "$file" ]; then
+          check="$id  - $description"
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -124,7 +124,7 @@ groups:
           else
             info "$check"
             info "      * kubeconfig file not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chown root:root <proxy kubeconfig
           file>
@@ -148,7 +148,7 @@ groups:
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -158,7 +158,7 @@ groups:
           else
             warn "$check"
             warn "      * File not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chmod 600 /etc/kubernetes/kubelet.conf
       - id: K.4.1.6
@@ -175,7 +175,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -244,7 +244,7 @@ groups:
           else
             info "$check"
             info "      * --client-ca-file not set"
-          fi 
+          fi
         remediation: Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>
       - id: K.4.1.9
@@ -330,11 +330,11 @@ groups:
           fi
         remediation: |
           If using a Kubelet config file, edit the file to set authentication: anonymous: enabled to false.
-          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.        
+          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
           --anonymous-auth=false
-          Based on your system, restart the kubelet service. For example:   
-          systemctl daemon-reload 
-          systemctl restart kubelet.service                   
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.4.2.2
         description: Ensure that the --authorization-mode argument is not set to AlwaysAllow
           (Automated)
@@ -356,10 +356,10 @@ groups:
           fi
         remediation: |
           If using a Kubelet config file, edit the file to set authorization: mode to Webhook.
-          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.        
+          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
           --authorization-mode=Webhook
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.4.2.3
         description: Ensure that the --client-ca-file argument is set as appropriate
@@ -382,7 +382,7 @@ groups:
               pass "      * client-ca-file: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to set authentication: x509: clientCAFile to the location of the client CA file.
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
@@ -413,7 +413,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to set readOnlyPort to 0.
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
@@ -438,13 +438,13 @@ groups:
               warn "      * streaming-connection-idle-timeout: $timeout"
           else
               pass "$check"
-          fi        
+          fi
         remediation: |
-          If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a value other than 0. 
+          If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a value other than 0.
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
           --streaming-connection-idle-timeout=5m
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.4.2.6
         description: Ensure that the --protect-kernel-defaults argument is set to
@@ -470,7 +470,7 @@ groups:
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
           --protect-kernel-defaults=true
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.4.2.7
         description: Ensure that the --make-iptables-util-chains argument is set to
@@ -487,12 +487,12 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
-          If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true. 
-          If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and remove the --make-iptables-util-chains argument from the KUBELET_SYSTEM_PODS_ARGS variable. 
-          Based on your system, restart the kubelet service. For example:        
-          systemctl daemon-reload 
+          If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true.
+          If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and remove the --make-iptables-util-chains argument from the KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.4.2.8
         description: Ensure that the --hostname-override argument is not set (Manual)
@@ -508,7 +508,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: 'Edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
           on each worker node and remove the --hostname-override argument from the
           KUBELET_SYSTEM_PODS_ARGS variable. Based on your system, restart the kubelet
@@ -535,7 +535,7 @@ groups:
           else
               warn "$check"
               warn "      * --event-qps is not set"
-          fi     
+          fi
         remediation: 'If using a Kubelet config file, edit the file to set eventRecordQPS:
           to an appropriate level. If using command line arguments, edit the kubelet
           service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each
@@ -570,14 +570,14 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
-          If using a Kubelet config file, edit the file to set tlsCertFile to the location of the certificate file to use to identify this Kubelet, and tlsPrivateKeyFile to the location of the corresponding private key file. 
-          If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameters in KUBELET_CERTIFICATE_ARGS variable.  
-          --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key-file=<path/to/tls-key-file> 
+          If using a Kubelet config file, edit the file to set tlsCertFile to the location of the certificate file to use to identify this Kubelet, and tlsPrivateKeyFile to the location of the corresponding private key file.
+          If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
+          --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key-file=<path/to/tls-key-file>
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service                    
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.4.2.11
         description: Ensure that the --rotate-certificates argument is not set to
           false (Automated)
@@ -596,13 +596,13 @@ groups:
             warn "$check"
           else
             pass "$check"
-          fi         
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to add the line rotateCertificates: true or remove it altogether to use the default value.
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS variable.
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service 
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.4.2.12
         description: Verify that the RotateKubeletServerCertificate argument is set
           to true (Manual)
@@ -677,9 +677,9 @@ groups:
           fi
         remediation: |-
           If using a Kubelet config file, edit the file to set TLSCipherSuites: to TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-          ,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256 or to a subset of these values.   
-          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the --tls-cipher-suites parameter as follows, or to a subset of these values.                 
+          ,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256 or to a subset of these values.
+          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the --tls-cipher-suites parameter as follows, or to a subset of these values.
           --tls-ciphe-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
+          systemctl daemon-reload
           systemctl restart kubelet.service

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/master/1_control_plane_components.yaml
@@ -49,7 +49,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -77,7 +77,7 @@ groups:
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -104,7 +104,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -132,7 +132,7 @@ groups:
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -159,7 +159,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -187,7 +187,7 @@ groups:
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -214,7 +214,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -291,7 +291,7 @@ groups:
             count_files=$((count_files + 1))
             permissions=$(stat -c %u%g $file)
 
-            # Check if the ownership is set to root:root 
+            # Check if the ownership is set to root:root
             if [ "$permissions" != "00" ]; then
               non_compliant_files="$non_compliant_files$file ($permissions), "
             fi
@@ -332,7 +332,7 @@ groups:
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 700 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -361,7 +361,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %U:%G $file)" = "etcd:etcd" ]; then
               pass "$check"
             else
@@ -392,7 +392,7 @@ groups:
           file="/etc/kubernetes/admin.conf"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -419,7 +419,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -448,7 +448,7 @@ groups:
           file="/etc/kubernetes/scheduler.conf"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -475,7 +475,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -504,7 +504,7 @@ groups:
           file="/etc/kubernetes/controller-manager.conf"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -514,7 +514,7 @@ groups:
           else
             info "$check"
             info "      * File not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chmod 600 /etc/kubernetes/controller-manager.conf
       - id: K.1.1.18
@@ -531,7 +531,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -540,7 +540,7 @@ groups:
             fi
           else
             info "$check"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chown root:root /etc/kubernetes/controller-manager.conf
       - id: K.1.1.19
@@ -602,7 +602,7 @@ groups:
             pass "$check"
           else
             warn "$check"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chmod -R 600 /etc/kubernetes/pki/*.crt
       - id: K.1.1.21
@@ -655,7 +655,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the below parameter. --anonymous-auth=false
       - id: K.1.2.2
@@ -725,7 +725,7 @@ groups:
               fi
           else
               warn "$check"
-          fi  
+          fi
         remediation: Follow the Kubernetes documentation and set up the TLS connection
           between the apiserver and kubelets. Then, edit API server pod specification
           file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and
@@ -749,7 +749,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and setup the TLS connection
           between the apiserver and kubelets. Then, edit the API server pod specification
           file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and
@@ -773,7 +773,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --authorization-mode parameter to values
           other than AlwaysAllow . One such example could be as below. --authorization-mode=RBAC
@@ -794,7 +794,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --authorization-mode parameter to a value
           that includes Node . --authorization-mode=Node,RBAC
@@ -836,7 +836,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and set the desired limits
           in a configuration file. Then, edit the API server pod specification file
           /etc/kubernetes/manifests/kube-apiserver.yaml and set the below parameters.  --enable-admission-plugins=...,EventRateLimit,...
@@ -858,7 +858,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and either remove the --enable-admission-plugins parameter,
           or set it to a value that does not include AlwaysAdmit.
@@ -879,7 +879,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --enable-admission-plugins parameter to include
           AlwaysPullImages.  --enable-admission-plugins=...,AlwaysPullImages,...
@@ -904,7 +904,7 @@ groups:
             else
               warn "$check"
             fi
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --enable-admission-plugins parameter to include
           SecurityContextDeny, unless PodSecurityPolicy is already in place.  --enable-admission-plugins=...,SecurityContextDeny,...
@@ -925,7 +925,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: Follow the documentation and create ServiceAccount objects as
           per your environment. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and ensure that the --disable-admission-plugins parameter
@@ -996,7 +996,7 @@ groups:
               fi
           else
               pass "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and either remove the --secure-port parameter or set
           it to a different (non-zero) desired port.
@@ -1014,7 +1014,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the below parameter. --profiling=false
       - id: K.1.2.18
@@ -1033,7 +1033,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: 'Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --audit-log-path parameter to a suitable
           path and file where you would like audit logs to be written, for example:
@@ -1062,7 +1062,7 @@ groups:
               fi
           else
               warn "$check"
-          fi 
+          fi
         remediation: 'Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --audit-log-maxage parameter to 30 or as
           an appropriate number of days: --audit-log-maxage=30'
@@ -1139,7 +1139,7 @@ groups:
               pass "      * request-timeout: $requestTimeout"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           and set the below parameter as appropriate and if needed. For example, --request-timeout=300s
       - id: K.1.2.23
@@ -1160,7 +1160,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the below parameter. --service-account-lookup=true
       - id: K.1.2.24
@@ -1184,7 +1184,7 @@ groups:
               pass "      * service-account-key-file: $file"
           else
               warn "$check"
-          fi        
+          fi
         remediation: 'Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --service-account-key-file parameter to the
           public key file for service accounts: --service-account-key-file=<filename>'
@@ -1250,7 +1250,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and set up the TLS connection
           on the apiserver. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the TLS certificate and private key file parameters.
@@ -1301,7 +1301,7 @@ groups:
               pass "      * etcd-cafile: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and set up the TLS connection
           between the apiserver and etcd. Then, edit the API server pod specification
           file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and
@@ -1324,7 +1324,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi     
+          fi
         remediation: 'Follow the Kubernetes documentation and configure a EncryptionConfig
           file. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --encryption-provider-config parameter to
@@ -1356,7 +1356,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and configure a EncryptionConfig
           file. In this file, choose aescbc, kms or secretbox as the encryption provider.
       - id: K.1.2.31
@@ -1383,7 +1383,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and set the below parameter.
           --tls-cipher-suites=TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384,
@@ -1421,7 +1421,7 @@ groups:
               pass "      * terminated-pod-gc-threshold: $threshold"
           else
               warn "$check"
-          fi        
+          fi
         remediation: 'Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the --terminated-pod-gc-threshold to an appropriate
           threshold, for example: --terminated-pod-gc-threshold=10'
@@ -1439,7 +1439,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the below parameter. --profiling=false
       - id: K.1.3.3
@@ -1460,7 +1460,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node to set the below parameter. --use-service-account-credentials=true
       - id: K.1.3.4
@@ -1484,7 +1484,7 @@ groups:
               pass "      * service-account-private-key-file: $keyfile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the --service-account-private-key-file parameter
           to the private key file for service accounts. --service-account-private-key-file=<filename>
@@ -1509,7 +1509,7 @@ groups:
               pass "      * root-ca-file: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the --root-ca-file parameter to the certificate
           bundle file`. --root-ca-file=<path/to/file>
@@ -1537,7 +1537,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
           --feature-gates=RotateKubeletServerCertificate=true
@@ -1555,7 +1555,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and ensure the correct value for the --bind-address parameter.
   - id: 1.4
@@ -1575,7 +1575,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Scheduler pod specification file /etc/kubernetes/manifests/kube-scheduler.yaml
           file on the master node and set the below parameter. --profiling=false
       - id: K.1.4.2
@@ -1592,6 +1592,6 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Scheduler pod specification file /etc/kubernetes/manifests/kube-scheduler.yaml
           on the master node and ensure the correct value for the --bind-address parameter

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.24/worker/4_worker_nodes.yaml
@@ -29,7 +29,7 @@ groups:
               file=$kubeadm10
           fi
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -56,7 +56,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -87,7 +87,7 @@ groups:
               file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -97,7 +97,7 @@ groups:
           else
             info "$check"
             info "      * kubeconfig file not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chmod 600 <proxy kubeconfig file>
       - id: K.4.1.4
@@ -113,8 +113,8 @@ groups:
           PCI: []
           GDPR: []
         audit: |
-          check="$id  - $description"           
-          if [ -f "$file" ]; then
+          check="$id  - $description"
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -124,7 +124,7 @@ groups:
           else
             info "$check"
             info "      * kubeconfig file not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chown root:root <proxy kubeconfig
           file>
@@ -148,7 +148,7 @@ groups:
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -158,7 +158,7 @@ groups:
           else
             warn "$check"
             warn "      * File not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chmod 600 /etc/kubernetes/kubelet.conf
       - id: K.4.1.6
@@ -175,7 +175,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -244,7 +244,7 @@ groups:
           else
             info "$check"
             info "      * --client-ca-file not set"
-          fi 
+          fi
         remediation: Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>
       - id: K.4.1.9
@@ -330,11 +330,11 @@ groups:
           fi
         remediation: |
           If using a Kubelet config file, edit the file to set authentication: anonymous: enabled to false.
-          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.        
+          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
           --anonymous-auth=false
-          Based on your system, restart the kubelet service. For example:   
-          systemctl daemon-reload 
-          systemctl restart kubelet.service                   
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.4.2.2
         description: Ensure that the --authorization-mode argument is not set to AlwaysAllow
           (Automated)
@@ -356,10 +356,10 @@ groups:
           fi
         remediation: |
           If using a Kubelet config file, edit the file to set authorization: mode to Webhook.
-          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.        
+          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
           --authorization-mode=Webhook
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.4.2.3
         description: Ensure that the --client-ca-file argument is set as appropriate
@@ -382,7 +382,7 @@ groups:
               pass "      * client-ca-file: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to set authentication: x509: clientCAFile to the location of the client CA file.
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
@@ -413,7 +413,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to set readOnlyPort to 0.
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
@@ -438,13 +438,13 @@ groups:
               warn "      * streaming-connection-idle-timeout: $timeout"
           else
               pass "$check"
-          fi        
+          fi
         remediation: |
-          If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a value other than 0. 
+          If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a value other than 0.
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
           --streaming-connection-idle-timeout=5m
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.4.2.6
         description: Ensure that the --protect-kernel-defaults argument is set to
@@ -470,7 +470,7 @@ groups:
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
           --protect-kernel-defaults=true
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.4.2.7
         description: Ensure that the --make-iptables-util-chains argument is set to
@@ -487,12 +487,12 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
-          If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true. 
-          If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and remove the --make-iptables-util-chains argument from the KUBELET_SYSTEM_PODS_ARGS variable. 
-          Based on your system, restart the kubelet service. For example:        
-          systemctl daemon-reload 
+          If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true.
+          If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and remove the --make-iptables-util-chains argument from the KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.4.2.8
         description: Ensure that the --hostname-override argument is not set (Manual)
@@ -508,7 +508,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: 'Edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
           on each worker node and remove the --hostname-override argument from the
           KUBELET_SYSTEM_PODS_ARGS variable. Based on your system, restart the kubelet
@@ -535,7 +535,7 @@ groups:
           else
               warn "$check"
               warn "      * --event-qps is not set"
-          fi     
+          fi
         remediation: 'If using a Kubelet config file, edit the file to set eventRecordQPS:
           to an appropriate level. If using command line arguments, edit the kubelet
           service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each
@@ -570,14 +570,14 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
-          If using a Kubelet config file, edit the file to set tlsCertFile to the location of the certificate file to use to identify this Kubelet, and tlsPrivateKeyFile to the location of the corresponding private key file. 
-          If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameters in KUBELET_CERTIFICATE_ARGS variable.  
-          --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key-file=<path/to/tls-key-file> 
+          If using a Kubelet config file, edit the file to set tlsCertFile to the location of the certificate file to use to identify this Kubelet, and tlsPrivateKeyFile to the location of the corresponding private key file.
+          If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
+          --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key-file=<path/to/tls-key-file>
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service                    
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.4.2.11
         description: Ensure that the --rotate-certificates argument is not set to
           false (Automated)
@@ -596,13 +596,13 @@ groups:
             warn "$check"
           else
             pass "$check"
-          fi         
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to add the line rotateCertificates: true or remove it altogether to use the default value.
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS variable.
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service 
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.4.2.12
         description: Verify that the RotateKubeletServerCertificate argument is set
           to true (Manual)
@@ -677,9 +677,9 @@ groups:
           fi
         remediation: |-
           If using a Kubelet config file, edit the file to set TLSCipherSuites: to TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-          ,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256 or to a subset of these values.   
-          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the --tls-cipher-suites parameter as follows, or to a subset of these values.                 
+          ,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256 or to a subset of these values.
+          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the --tls-cipher-suites parameter as follows, or to a subset of these values.
           --tls-ciphe-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service 
+          systemctl daemon-reload
+          systemctl restart kubelet.service

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/master/1_control_plane_components.yaml
@@ -56,7 +56,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -91,7 +91,7 @@ groups:
               file=$config_yaml
           fi
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -117,8 +117,8 @@ groups:
           PCI: []
           GDPR: []
         audit: |
-          check="$id  - $description"    
-          if [ -f "$file" ]; then
+          check="$id  - $description"
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -153,7 +153,7 @@ groups:
               file=$config_manifest
           fi
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -180,7 +180,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -215,7 +215,7 @@ groups:
               file=$config_manifest
           fi
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -242,7 +242,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -319,7 +319,7 @@ groups:
             count_files=$((count_files + 1))
             permissions=$(stat -c %u%g $file)
 
-            # Check if the ownership is set to root:root 
+            # Check if the ownership is set to root:root
             if [ "$permissions" != "00" ]; then
               non_compliant_files="$non_compliant_files$file ($permissions), "
             fi
@@ -360,7 +360,7 @@ groups:
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 700 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -389,7 +389,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %U:%G $file)" = "etcd:etcd" ]; then
               pass "$check"
             else
@@ -421,7 +421,7 @@ groups:
           file="/etc/kubernetes/admin.conf"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -448,7 +448,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -477,7 +477,7 @@ groups:
           file="/etc/kubernetes/scheduler.conf"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -504,7 +504,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -533,7 +533,7 @@ groups:
           file="/etc/kubernetes/controller-manager.conf"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -543,7 +543,7 @@ groups:
           else
             info "$check"
             info "      * File not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chmod 644 /etc/kubernetes/controller-manager.conf
       - id: K.1.1.18
@@ -560,7 +560,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -569,7 +569,7 @@ groups:
             fi
           else
             info "$check"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chown root:root /etc/kubernetes/controller-manager.conf
       - id: K.1.1.19
@@ -631,7 +631,7 @@ groups:
             pass "$check"
           else
             warn "$check"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chmod -R 644 /etc/kubernetes/pki/*.crt
       - id: K.1.1.21
@@ -684,7 +684,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the below parameter. --anonymous-auth=false
       - id: K.1.2.2
@@ -746,7 +746,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and remove the --kubelet-https parameter.
       - id: K.1.2.5
@@ -775,7 +775,7 @@ groups:
               fi
           else
               warn "$check"
-          fi  
+          fi
         remediation: Follow the Kubernetes documentation and set up the TLS connection
           between the apiserver and kubelets. Then, edit API server pod specification
           file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and
@@ -799,7 +799,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and setup the TLS connection
           between the apiserver and kubelets. Then, edit the API server pod specification
           file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and
@@ -823,7 +823,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --authorization-mode parameter to values
           other than AlwaysAllow . One such example could be as below. --authorization-mode=RBAC
@@ -844,7 +844,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --authorization-mode parameter to a value
           that includes Node . --authorization-mode=Node,RBAC
@@ -886,7 +886,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and set the desired limits
           in a configuration file. Then, edit the API server pod specification file
           /etc/kubernetes/manifests/kube-apiserver.yaml and set the below parameters.  --enable-admission-plugins=...,EventRateLimit,...
@@ -908,7 +908,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and either remove the --enable-admission-plugins parameter,
           or set it to a value that does not include AlwaysAdmit.
@@ -929,7 +929,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --enable-admission-plugins parameter to include
           AlwaysPullImages.  --enable-admission-plugins=...,AlwaysPullImages,...
@@ -954,7 +954,7 @@ groups:
             else
               warn "$check"
             fi
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --enable-admission-plugins parameter to include
           SecurityContextDeny, unless PodSecurityPolicy is already in place.  --enable-admission-plugins=...,SecurityContextDeny,...
@@ -975,7 +975,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: Follow the documentation and create ServiceAccount objects as
           per your environment. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and ensure that the --disable-admission-plugins parameter
@@ -1018,7 +1018,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: 'Follow the documentation and create Pod Security Policy objects
           as per your environment. Then, edit the API server pod specification file
           /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and set
@@ -1064,7 +1064,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and remove the --insecure-bind-address parameter.
       - id: K.1.2.19
@@ -1090,7 +1090,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the below parameter. --insecure-port=0
       - id: K.1.2.20
@@ -1116,7 +1116,7 @@ groups:
               fi
           else
               pass "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and either remove the --secure-port parameter or set
           it to a different (non-zero) desired port.
@@ -1134,7 +1134,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the below parameter. --profiling=false
       - id: K.1.2.22
@@ -1153,7 +1153,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: 'Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --audit-log-path parameter to a suitable
           path and file where you would like audit logs to be written, for example:
@@ -1182,7 +1182,7 @@ groups:
               fi
           else
               warn "$check"
-          fi 
+          fi
         remediation: 'Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --audit-log-maxage parameter to 30 or as
           an appropriate number of days: --audit-log-maxage=30'
@@ -1259,7 +1259,7 @@ groups:
               pass "      * request-timeout: $requestTimeout"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           and set the below parameter as appropriate and if needed. For example, --request-timeout=300s
       - id: K.1.2.27
@@ -1280,7 +1280,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the below parameter. --service-account-lookup=true
       - id: K.1.2.28
@@ -1304,7 +1304,7 @@ groups:
               pass "      * service-account-key-file: $file"
           else
               warn "$check"
-          fi        
+          fi
         remediation: 'Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --service-account-key-file parameter to the
           public key file for service accounts: --service-account-key-file=<filename>'
@@ -1370,7 +1370,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and set up the TLS connection
           on the apiserver. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the TLS certificate and private key file parameters.
@@ -1421,7 +1421,7 @@ groups:
               pass "      * etcd-cafile: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and set up the TLS connection
           between the apiserver and etcd. Then, edit the API server pod specification
           file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and
@@ -1444,7 +1444,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi     
+          fi
         remediation: 'Follow the Kubernetes documentation and configure a EncryptionConfig
           file. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --encryption-provider-config parameter to
@@ -1476,7 +1476,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and configure a EncryptionConfig
           file. In this file, choose aescbc, kms or secretbox as the encryption provider.
       - id: K.1.2.35
@@ -1503,10 +1503,10 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the below parameter as follows, or to a subset
-          of these values. 
+          of these values.
           --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
   - id: 1.3
     title: 1.3 - Controller Manager
@@ -1530,7 +1530,7 @@ groups:
               pass "      * terminated-pod-gc-threshold: $threshold"
           else
               warn "$check"
-          fi        
+          fi
         remediation: 'Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the --terminated-pod-gc-threshold to an appropriate
           threshold, for example: --terminated-pod-gc-threshold=10'
@@ -1548,7 +1548,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the below parameter. --profiling=false
       - id: K.1.3.3
@@ -1569,7 +1569,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node to set the below parameter. --use-service-account-credentials=true
       - id: K.1.3.4
@@ -1593,7 +1593,7 @@ groups:
               pass "      * service-account-private-key-file: $keyfile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the --service-account-privae-key-file parameter
           to the private key file for service accounts. --service-account-private-key-file=<filename>
@@ -1618,7 +1618,7 @@ groups:
               pass "      * root-ca-file: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the --root-ca-file parameter to the certificate
           bundle file`. --root-ca-file=<path/to/file>
@@ -1646,7 +1646,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
           --feature-gates=RotateKubeletServerCertificate=true
@@ -1664,7 +1664,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and ensure the correct value for the --bind-address parameter.
   - id: 1.4
@@ -1684,7 +1684,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Scheduler pod specification file /etc/kubernetes/manifests/kube-scheduler.yaml
           file on the master node and set the below parameter. --profiling=false
       - id: K.1.4.2
@@ -1701,6 +1701,6 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Scheduler pod specification file /etc/kubernetes/manifests/kube-scheduler.yaml
           on the master node and ensure the correct value for the --bind-address parameter

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/worker/4_worker_nodes.yaml
@@ -23,7 +23,7 @@ groups:
           file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -52,7 +52,7 @@ groups:
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -83,7 +83,7 @@ groups:
               file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -93,7 +93,7 @@ groups:
           else
             info "$check"
             info "      * kubeconfig file not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chmod 600 <proxy kubeconfig file
       - id: K.4.1.4
@@ -114,8 +114,8 @@ groups:
           if check_argument "$CIS_PROXY_CMD" '--kubeconfig' >/dev/null 2>&1; then
               file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
           fi
-          file=$(append_prefix "$CONFIG_PREFIX" "$file")              
-          if [ -f "$file" ]; then
+          file=$(append_prefix "$CONFIG_PREFIX" "$file")
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -125,7 +125,7 @@ groups:
           else
             info "$check"
             info "      * kubeconfig file not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chown root:root <proxy kubeconfig
           file>
@@ -149,7 +149,7 @@ groups:
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -159,7 +159,7 @@ groups:
           else
             info "$check"
             info "      * File not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chmod 644 /etc/kubernetes/kubelet.conf
       - id: K.4.1.6
@@ -181,8 +181,8 @@ groups:
               file=$(get_argument_value "$CIS_KUBELET_CMD" '--kubeconfig'|cut -d " " -f 1)
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-                     
-          if [ -f "$file" ]; then
+
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -251,7 +251,7 @@ groups:
           else
             info "$check"
             info "      * --client-ca-file not set"
-          fi 
+          fi
         remediation: Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>
       - id: K.4.1.9
@@ -387,7 +387,7 @@ groups:
               pass "      * client-ca-file: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: 'If using a Kubelet config file, edit the file to set authentication:
           x509: clientCAFile to the location of the client CA file. If using command
           line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
@@ -418,7 +418,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: 'If using a Kubelet config file, edit the file to set readOnlyPort
           to 0. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
           on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS
@@ -441,7 +441,7 @@ groups:
               warn "      * streaming-connection-idle-timeout: $timeout"
           else
               pass "$check"
-          fi        
+          fi
         remediation: 'If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout
           to a value other than 0. If using command line arguments, edit the kubelet
           service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each
@@ -489,7 +489,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: 'If using a Kubelet config file, edit the file to set makeIPTablesUtilChains:
           true. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
           on each worker node and remove the --make-iptables-util-chains argument
@@ -510,7 +510,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: 'Edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
           on each worker node and remove the --hostname-override argument from the
           KUBELET_SYSTEM_PODS_ARGS variable. Based on your system, restart the kubelet
@@ -537,7 +537,7 @@ groups:
           else
               warn "$check"
               warn "      * --event-qps is not set"
-          fi      
+          fi
         remediation: 'If using a Kubelet config file, edit the file to set eventRecordQPS:
           to an appropriate level. If using command line arguments, edit the kubelet
           service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each
@@ -572,7 +572,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: 'If using a Kubelet config file, edit the file to set tlsCertFile
           to the location of the certificate file to use to identify this Kubelet,
           and tlsPrivateKeyFile to the location of the corresponding private key file.
@@ -599,7 +599,7 @@ groups:
             warn "$check"
           else
             pass "$check"
-          fi        
+          fi
         remediation: 'If using a Kubelet config file, edit the file to add the line
           rotateCertificates: true or remove it altogether to use the default value.
           If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
@@ -682,9 +682,9 @@ groups:
           fi
         remediation: |-
           If using a Kubelet config file, edit the file to set TLSCipherSuites: to TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-          ,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256 or to a subset of these values.   
-          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the --tls-cipher-suites parameter as follows, or to a subset of these values.                 
+          ,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256 or to a subset of these values.
+          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the --tls-cipher-suites parameter as follows, or to a subset of these values.
           --tls-ciphe-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service     
+          systemctl daemon-reload
+          systemctl restart kubelet.service

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/master/1_control_plane_components.yaml
@@ -50,7 +50,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" = "00" ]; then
               pass "$check"
@@ -80,7 +80,7 @@ groups:
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -le 600 ]; then
               pass "$check"
@@ -108,7 +108,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" = "00" ]; then
               pass "$check"
@@ -138,7 +138,7 @@ groups:
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -le 600 ]; then
               pass "$check"
@@ -166,7 +166,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" = "00" ]; then
               pass "$check"
@@ -196,7 +196,7 @@ groups:
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -le 600 ]; then
               pass "$check"
@@ -224,7 +224,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" = "00" ]; then
               pass "$check"
@@ -303,7 +303,7 @@ groups:
             count_files=$((count_files + 1))
             permissions=$(stat -c %u%g $file)
 
-            # Check if the ownership is set to root:root 
+            # Check if the ownership is set to root:root
             if [ "$permissions" != "00" ]; then
               non_compliant_files="$non_compliant_files$file ($permissions), "
             fi
@@ -344,7 +344,7 @@ groups:
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -le 700 ]; then
               pass "$check"
@@ -374,7 +374,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %U:%G $file)
             if [ "$ownership" = "etcd:etcd" ]; then
               pass "$check"
@@ -406,7 +406,7 @@ groups:
           file="/etc/kubernetes/admin.conf"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -le 600 ]; then
               pass "$check"
@@ -434,7 +434,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" = "00" ]; then
               pass "$check"
@@ -465,7 +465,7 @@ groups:
           file="/etc/kubernetes/scheduler.conf"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -le 600 ]; then
               pass "$check"
@@ -493,7 +493,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" = "00" ]; then
               pass "$check"
@@ -524,7 +524,7 @@ groups:
           file="/etc/kubernetes/controller-manager.conf"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -le 600 ]; then
               pass "$check"
@@ -535,7 +535,7 @@ groups:
           else
             warn "$check"
             warn "      * File not found, $file"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chmod 600 /etc/kubernetes/controller-manager.conf
       - id: K.1.1.18
@@ -552,7 +552,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" = "00" ]; then
               pass "$check"
@@ -563,7 +563,7 @@ groups:
           else
             warn "$check"
             warn "      * File not found, $file"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chown root:root /etc/kubernetes/controller-manager.conf
       - id: K.1.1.19
@@ -638,7 +638,7 @@ groups:
           else
               warn "$check"
               warn "      * Wrong permissions for $failed_file, expected 600 or less, but is $failed_perm"
-          fi       
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chmod -R 600 /etc/kubernetes/pki/*.crt
       - id: K.1.1.21
@@ -698,7 +698,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the below parameter. --anonymous-auth=false
       - id: K.1.2.2
@@ -768,7 +768,7 @@ groups:
               fi
           else
               warn "$check"
-          fi  
+          fi
         remediation: Follow the Kubernetes documentation and set up the TLS connection
           between the apiserver and kubelets. Then, edit API server pod specification
           file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and
@@ -792,7 +792,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and setup the TLS connection
           between the apiserver and kubelets. Then, edit the API server pod specification
           file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and
@@ -816,7 +816,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --authorization-mode parameter to values
           other than AlwaysAllow . One such example could be as below. --authorization-mode=RBAC
@@ -837,7 +837,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --authorization-mode parameter to a value
           that includes Node . --authorization-mode=Node,RBAC
@@ -879,7 +879,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and set the desired limits
           in a configuration file. Then, edit the API server pod specification file
           /etc/kubernetes/manifests/kube-apiserver.yaml and set the below parameters.  --enable-admission-plugins=...,EventRateLimit,...
@@ -901,7 +901,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and either remove the --enable-admission-plugins parameter,
           or set it to a value that does not include AlwaysAdmit.
@@ -922,7 +922,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --enable-admission-plugins parameter to include
           AlwaysPullImages.  --enable-admission-plugins=...,AlwaysPullImages,...
@@ -947,7 +947,7 @@ groups:
             else
               warn "$check"
             fi
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --enable-admission-plugins parameter to include
           SecurityContextDeny, unless PodSecurityPolicy is already in place.  --enable-admission-plugins=...,SecurityContextDeny,...
@@ -968,7 +968,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: Follow the documentation and create ServiceAccount objects as
           per your environment. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and ensure that the --disable-admission-plugins parameter
@@ -1030,7 +1030,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the below parameter. --profiling=false
       - id: K.1.2.17
@@ -1049,7 +1049,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: 'Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --audit-log-path parameter to a suitable
           path and file where you would like audit logs to be written, for example:
@@ -1078,7 +1078,7 @@ groups:
               fi
           else
               warn "$check"
-          fi 
+          fi
         remediation: 'Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --audit-log-maxage parameter to 30 or as
           an appropriate number of days: --audit-log-maxage=30'
@@ -1155,7 +1155,7 @@ groups:
               pass "      * request-timeout: $requestTimeout"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           and set the below parameter as appropriate and if needed. For example, --request-timeout=300s
       - id: K.1.2.22
@@ -1176,7 +1176,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the below parameter. --service-account-lookup=true
       - id: K.1.2.23
@@ -1200,7 +1200,7 @@ groups:
               pass "      * service-account-key-file: $file"
           else
               warn "$check"
-          fi        
+          fi
         remediation: 'Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --service-account-key-file parameter to the
           public key file for service accounts: --service-account-key-file=<filename>'
@@ -1266,7 +1266,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and set up the TLS connection
           on the apiserver. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the TLS certificate and private key file parameters.
@@ -1317,7 +1317,7 @@ groups:
               pass "      * etcd-cafile: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and set up the TLS connection
           between the apiserver and etcd. Then, edit the API server pod specification
           file /etc/kubernetes/manifests/kube-apiserver.yaml on the master node and
@@ -1340,7 +1340,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi     
+          fi
         remediation: 'Follow the Kubernetes documentation and configure a EncryptionConfig
           file. Then, edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
           on the master node and set the --encryption-provider-config parameter to
@@ -1372,7 +1372,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: Follow the Kubernetes documentation and configure a EncryptionConfig
           file. In this file, choose aescbc, kms or secretbox as the encryption provider.
       - id: K.1.2.30
@@ -1399,7 +1399,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml on the Control Plane node and set the below parameter.
           --tls-cipher-suites=TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384,
@@ -1437,7 +1437,7 @@ groups:
               pass "      * terminated-pod-gc-threshold: $threshold"
           else
               warn "$check"
-          fi        
+          fi
         remediation: 'Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the --terminated-pod-gc-threshold to an appropriate
           threshold, for example: --terminated-pod-gc-threshold=10'
@@ -1455,7 +1455,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the below parameter. --profiling=false
       - id: K.1.3.3
@@ -1476,7 +1476,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node to set the below parameter. --use-service-account-credentials=true
       - id: K.1.3.4
@@ -1500,7 +1500,7 @@ groups:
               pass "      * service-account-private-key-file: $keyfile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the --service-account-privat-key-file parameter
           to the private key file for service accounts. --service-account-private-key-file=<filename>
@@ -1525,7 +1525,7 @@ groups:
               pass "      * root-ca-file: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the --root-ca-file parameter to the certificate
           bundle file`. --root-ca-file=<path/to/file>
@@ -1553,7 +1553,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
           --feature-gates=RotateKubeletServerCertificate=true
@@ -1571,7 +1571,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Controller Manager pod specification file /etc/kubernetes/manifests/kube-controller-manager.yaml
           on the master node and ensure the correct value for the --bind-address parameter.
   - id: 1.4
@@ -1591,7 +1591,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Scheduler pod specification file /etc/kubernetes/manifests/kube-scheduler.yaml
           file on the master node and set the below parameter. --profiling=false
       - id: K.1.4.2
@@ -1608,6 +1608,6 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: Edit the Scheduler pod specification file /etc/kubernetes/manifests/kube-scheduler.yaml
           on the master node and ensure the correct value for the --bind-address parameter

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/worker/4_worker_nodes.yaml
@@ -29,7 +29,7 @@ groups:
               file=$kubeadm10
           fi
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -eq 600 -o "$permissions" -eq 400 ]; then
               pass "$check"
@@ -57,7 +57,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" = "00" ]; then
               pass "$check"
@@ -90,7 +90,7 @@ groups:
               file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -eq 600 -o "$permissions" -eq 400 ]; then
               pass "$check"
@@ -101,7 +101,7 @@ groups:
           else
             warn "$check"
             warn "      * The kubeconfig file not found, $file"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chmod 600 <proxy kubeconfig file>
       - id: K.4.1.4
@@ -117,8 +117,8 @@ groups:
           PCI: []
           GDPR: []
         audit: |
-          check="$id  - $description"           
-          if [ -f "$file" ]; then
+          check="$id  - $description"
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" = "00" ]; then
               pass "$check"
@@ -129,7 +129,7 @@ groups:
           else
             warn "$check"
             warn "      * The kubeconfig file not found, $file"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chown root:root <proxy kubeconfig
           file>
@@ -153,7 +153,7 @@ groups:
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -eq 600 -o "$permissions" -eq 400 ]; then
               pass "$check"
@@ -164,7 +164,7 @@ groups:
           else
             warn "$check"
             warn "      * The kubeconfig file not found, $file"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chmod 600 /etc/kubernetes/kubelet.conf
       - id: K.4.1.6
@@ -181,7 +181,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" = "00" ]; then
               pass "$check"
@@ -212,7 +212,7 @@ groups:
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
             file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
             file=$(append_prefix "$CONFIG_PREFIX" "$file")
-            if [ -f "$file" ]; then
+            if [ -e "$file" ]; then
               permissions=$(stat -c %a $file)
               if [ "$permissions" -le 600 ]; then
                 pass "$check"
@@ -248,7 +248,7 @@ groups:
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
             file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
             file=$(append_prefix "$CONFIG_PREFIX" "$file")
-            if [ -f "$file" ]; then
+            if [ -e "$file" ]; then
               ownership=$(stat -c %u%g $file)
               if [ "$ownership" = "00" ]; then
                 pass "$check"
@@ -264,7 +264,7 @@ groups:
           else
             warn "$check"
             warn "      * --client-ca-file not set"
-          fi 
+          fi
         remediation: Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>
       - id: K.4.1.9
@@ -284,7 +284,7 @@ groups:
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
             file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
             file=$(append_prefix "$CONFIG_PREFIX" "$file")
-            if [ -f "$file" ]; then
+            if [ -e "$file" ]; then
               permissions=$(stat -c %a $file)
               if [ "$permissions" -le 600 ]; then
                 pass "$check"
@@ -320,7 +320,7 @@ groups:
           if check_argument "$CIS_KUBELET_CMD" '--config' >/dev/null 2>&1; then
             file=$(get_argument_value "$CIS_KUBELET_CMD" '--config')
             file=$(append_prefix "$CONFIG_PREFIX" "$file")
-            if [ -f "$file" ]; then
+            if [ -e "$file" ]; then
               ownership=$(stat -c %u%g $file)
               if [ "$ownership" = "00" ]; then
                 pass "$check"
@@ -362,11 +362,11 @@ groups:
           fi
         remediation: |
           If using a Kubelet config file, edit the file to set authentication: anonymous: enabled to false.
-          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.        
+          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
           --anonymous-auth=false
-          Based on your system, restart the kubelet service. For example:   
-          systemctl daemon-reload 
-          systemctl restart kubelet.service                   
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.4.2.2
         description: Ensure that the --authorization-mode argument is not set to AlwaysAllow
           (Automated)
@@ -388,10 +388,10 @@ groups:
           fi
         remediation: |
           If using a Kubelet config file, edit the file to set authorization: mode to Webhook.
-          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.        
+          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
           --authorization-mode=Webhook
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.4.2.3
         description: Ensure that the --client-ca-file argument is set as appropriate
@@ -414,7 +414,7 @@ groups:
               pass "      * client-ca-file: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to set authentication: x509: clientCAFile to the location of the client CA file.
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
@@ -445,7 +445,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to set readOnlyPort to 0.
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
@@ -470,13 +470,13 @@ groups:
               warn "      * streaming-connection-idle-timeout: $timeout"
           else
               pass "$check"
-          fi        
+          fi
         remediation: |
-          If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a value other than 0. 
+          If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a value other than 0.
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
           --streaming-connection-idle-timeout=5m
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.4.2.6
         description: Ensure that the --make-iptables-util-chains argument is set to
@@ -493,12 +493,12 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
-          If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true. 
-          If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and remove the --mak-iptables-util-chains argument from the KUBELET_SYSTEM_PODS_ARGS variable. 
-          Based on your system, restart the kubelet service. For example:        
-          systemctl daemon-reload 
+          If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true.
+          If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and remove the --mak-iptables-util-chains argument from the KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.4.2.7
         description: Ensure that the --hostname-override argument is not set (Manual)
@@ -514,7 +514,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: 'Edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
           on each worker node and remove the --hostname-override argument from the
           KUBELET_SYSTEM_PODS_ARGS variable. Based on your system, restart the kubelet
@@ -541,7 +541,7 @@ groups:
           else
               warn "$check"
               warn "      * --event-qps is not set"
-          fi        
+          fi
         remediation: 'If using a Kubelet config file, edit the file to set eventRecordQPS:
           to an appropriate level. If using command line arguments, edit the kubelet
           service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each
@@ -576,14 +576,14 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
-          If using a Kubelet config file, edit the file to set tlsCertFile to the location of the certificate file to use to identify this Kubelet, and tlsPrivateKeyFile to the location of the corresponding private key file. 
-          If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameters in KUBELET_CERTIFICATE_ARGS variable.  
-          --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key-file=<path/to/tls-key-file> 
+          If using a Kubelet config file, edit the file to set tlsCertFile to the location of the certificate file to use to identify this Kubelet, and tlsPrivateKeyFile to the location of the corresponding private key file.
+          If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
+          --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key-file=<path/to/tls-key-file>
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service                    
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.4.2.10
         description: Ensure that the --rotate-certificates argument is not set to
           false (Automated)
@@ -602,13 +602,13 @@ groups:
             warn "$check"
           else
             pass "$check"
-          fi        
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to add the line rotateCertificates: true or remove it altogether to use the default value.
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and remove --rotat-certificates=false argument from the KUBELET_CERTIFICATE_ARGS variable.
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service 
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.4.2.11
         description: Verify that the RotateKubeletServerCertificate argument is set
           to true (Manual)
@@ -683,12 +683,12 @@ groups:
           fi
         remediation: |
           If using a Kubelet config file, edit the file to set TLSCipherSuites: to TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-          ,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256 or to a subset of these values.   
-          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the --tls-cipher-suites parameter as follows, or to a subset of these values.                 
+          ,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256 or to a subset of these values.
+          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the --tls-cipher-suites parameter as follows, or to a subset of these values.
           --tls-ciphe-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service     
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.4.2.13
         description: Ensure that a limit is set on pod PIDs (Manual)
         type: worker
@@ -700,7 +700,7 @@ groups:
         audit: |
           check="$id  - $description"
           manual "$check"
-          manual "      * Review the Kubelet's start-up parameters for the value of --pod-max-pids, and check the Kubelet configuration file for the PodPidsLimit . If neither of these values is set, then there is no limit in place."   
+          manual "      * Review the Kubelet's start-up parameters for the value of --pod-max-pids, and check the Kubelet configuration file for the PodPidsLimit . If neither of these values is set, then there is no limit in place."
         remediation: Decide on an appropriate level for this parameter and set it,
           either via the --pod-max-pids command line parameter or the PodPidsLimit
           configuration file setting.

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/master/1_control_plane_components.yaml
@@ -67,8 +67,8 @@ groups:
           PCI: []
           GDPR: []
         audit: |
-          check="$id  - $description"  
-          pass "$check"      
+          check="$id  - $description"
+          pass "$check"
         remediation: By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
       - id: K.1.1.5
         description: Ensure that the scheduler pod specification file permissions
@@ -154,7 +154,7 @@ groups:
 
           if [ -d "$dir" ]; then
             files=$(find "$dir" -type f ! -name lock 2>/dev/null)
-            
+
             if [ -z "$files" ]; then
               warn "$check"
               warn "      * No files found in $dir."
@@ -201,7 +201,7 @@ groups:
 
           if [ -d "$dir" ]; then
             files=$(find "$dir" -type f ! -name lock 2>/dev/null)
-            
+
             if [ -z "$files" ]; then
               warn "$check"
               warn "      * No files found in $dir."
@@ -265,7 +265,7 @@ groups:
       - id: K.1.1.12
         description: Ensure that the etcd data directory ownership is set to etcd:etcd
           (Automated)
-        type: master 
+        type: master
         category: kubernetes
         scored: true
         profile: Level 1
@@ -294,7 +294,7 @@ groups:
           file="/var/lib/rancher/k3s/server/cred/admin.kubeconfig"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -321,7 +321,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -351,7 +351,7 @@ groups:
           file="/var/lib/rancher/k3s/server/cred/scheduler.kubeconfig"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -378,7 +378,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -408,7 +408,7 @@ groups:
           file="/var/lib/rancher/k3s/server/cred/controller.kubeconfig"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -418,7 +418,7 @@ groups:
           else
             warn "$check"
             warn "      * File: $file not found"
-          fi     
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chmod 600 /var/lib/rancher/k3s/server/cred/controller.kubeconfig
       - id: K.1.1.18
@@ -435,7 +435,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -445,7 +445,7 @@ groups:
           else
             warn "$check"
             warn "      * File: $file not found"
-          fi   
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chown root:root /var/lib/rancher/k3s/server/cred/controller.kubeconfig
       - id: K.1.1.19
@@ -513,7 +513,7 @@ groups:
           else
             warn "$check"
             warn "      * Wrong permissions for the following files: $incorrect_files"
-          fi              
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the master node. For example, chmod -R 600 /var/lib/rancher/k3s/server/tls/*.crt
       - id: K.1.1.21
@@ -569,8 +569,8 @@ groups:
               pass "$check"
           else
               warn "$check"
-              warn "      * found: $(check_argument_from_journal "$KUBE_APISERVER_CMD" '--anonymous-auth=false')" 
-          fi              
+              warn "      * found: $(check_argument_from_journal "$KUBE_APISERVER_CMD" '--anonymous-auth=false')"
+          fi
         remediation: |
           By default, K3s sets the --anonymous-auth argument to false. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
             kube-apiserver-arg:
@@ -590,10 +590,10 @@ groups:
           check="$id  - $description"
           if check_argument_from_journal "$KUBE_APISERVER_CMD" '--token-auth-file' >/dev/null 2>&1; then
               warn "$check"
-              warn "      * found: $(check_argument_from_journal "$KUBE_APISERVER_CMD" '--token-auth-file')" 
+              warn "      * found: $(check_argument_from_journal "$KUBE_APISERVER_CMD" '--token-auth-file')"
           else
               pass "$check"
-          fi             
+          fi
         remediation: |
           Follow the documentation and configure alternate mechanisms for authentication. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
           kube-apiserver-arg:
@@ -648,7 +648,7 @@ groups:
               fi
           else
               warn "$check"
-          fi  
+          fi
         remediation: |
           By default, K3s automatically provides the kubelet client certificate and key. They are generated and located at /var/lib/rancher/k3s/server/tls/client-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/client-kube-apiserver.key If for some reason you need to provide your own certificate and key, you can set the below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
           kube-apiserver-arg:
@@ -672,7 +672,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s automatically provides the kubelet CA cert file, at /var/lib/rancher/k3s/server/tls/server-ca.crt. If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-apiserver-arg:
@@ -695,7 +695,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s does not set the --authorization-mode to AlwaysAllow. If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
           kube-apiserver-arg:
@@ -717,7 +717,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: By default, K3s sets the --authorization-mode to Node and RBAC. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, ensure that you are not overriding authorization-mode.
       - id: K.1.2.8
         description: Ensure that the --authorization-mode argument includes RBAC (Automated)
@@ -755,7 +755,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           Follow the Kubernetes documentation and set the desired limits in a configuration file. Then, edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameters.
           kube-apiserver-arg:
@@ -778,11 +778,11 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s does not set the --enable-admission-plugins to AlwaysAdmit. If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
           kube-apiserver-arg:
-            - "enable-admission-plugins=AlwaysAdmit"        
+            - "enable-admission-plugins=AlwaysAdmit"
       - id: K.1.2.11
         description: Ensure that the admission control plugin AlwaysPullImages is
           set (Manual)
@@ -800,7 +800,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           Permissive, per CIS guidelines, "This setting could impact offline or isolated clusters, which have images pre-loaded and do not have access to a registry to pull in-use images. This setting is not appropriate for clusters which use this configuration." Edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameter.
           kube-apiserver-arg:
@@ -818,7 +818,7 @@ groups:
           PCI: []
         audit: |
           check="$id  - $description"
-          pass "$check"     
+          pass "$check"
         remediation: Enabling Pod Security Policy is no longer supported on K3s v1.25+ and will cause applications to unexpectedly fail.
       - id: K.1.2.13
         description: Ensure that the admission control plugin ServiceAccount is set
@@ -837,9 +837,9 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: |
-          By default, K3s does not set the --disable-admission-plugins to anything. Follow the documentation and create ServiceAccount objects as per your environment. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.        
+          By default, K3s does not set the --disable-admission-plugins to anything. Follow the documentation and create ServiceAccount objects as per your environment. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-apiserver-arg:
             - "disable-admission-plugins=ServiceAccount"
       - id: K.1.2.14
@@ -863,7 +863,7 @@ groups:
         remediation: |
           By default, K3s does not set the --disable-admission-plugins to anything. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-apiserver-arg:
-            - "disable-admission-plugins=...,NamespaceLifecycle,..."        
+            - "disable-admission-plugins=...,NamespaceLifecycle,..."
       - id: K.1.2.15
         description: Ensure that the admission control plugin NodeRestriction is set
           (Automated)
@@ -885,7 +885,7 @@ groups:
         remediation: |
           By default, K3s sets the --enable-admission-plugins to NodeRestriction. If using the K3s config file /etc/rancher/k3s/config.yaml, check that you are not overriding the admission plugins. If you are, include NodeRestriction in the list.
           kube-apiserver-arg:
-            - "enable-admission-plugins=...,NodeRestriction,..." 
+            - "enable-admission-plugins=...,NodeRestriction,..."
       - id: K.1.2.16
         description: Ensure that the --profiling argument is set to false (Automated)
         type: master
@@ -900,11 +900,11 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s sets the --profiling argument to false. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-apiserver-arg:
-            - "profiling=true"        
+            - "profiling=true"
       - id: K.1.2.17
         description: Ensure that the --audit-log-path argument is set (Automated)
         type: master
@@ -921,7 +921,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           Edit the K3s config file /etc/rancher/k3s/config.yaml and set the audit-log-path parameter to a suitable path and file where you would like audit logs to be written, for example,
           kube-apiserver-arg:
@@ -950,7 +950,7 @@ groups:
               fi
           else
               warn "$check"
-          fi 
+          fi
         remediation: |
           Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the audit-log-maxage parameter to 30 or as an appropriate number of days, for example,
           kube-apiserver-arg:
@@ -983,7 +983,7 @@ groups:
         remediation: |
           Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
           kube-apiserver-arg:
-            - "audit-log-maxbackup=10"     
+            - "audit-log-maxbackup=10"
       - id: K.1.2.20
         description: Ensure that the --audit-log-maxsize argument is set to 100 or
           as appropriate (Automated)
@@ -1012,7 +1012,7 @@ groups:
         remediation: |
           Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the audit-log-maxsize parameter to an appropriate size in MB. For example,
           kube-apiserver-arg:
-            - "audit-log-maxsize=100"        
+            - "audit-log-maxsize=100"
       - id: K.1.2.21
         description: Ensure that the --request-timeout argument is set as appropriate
           (Manual)
@@ -1024,7 +1024,7 @@ groups:
         tags: {}
         audit: |
           check="$id  - $description"
-          pass "$check"     
+          pass "$check"
         remediation: |
           Permissive, per CIS guidelines, "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed". Edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameter if needed. For example,
           kube-apiserver-arg:
@@ -1047,12 +1047,12 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s does not set the --service-account-lookup argument. Edit the K3s config file /etc/rancher/k3s/config.yaml and set the service-account-lookup. For example,
           kube-apiserver-arg:
             - "service-account-lookup=true"
-          Alternatively, you can delete the service-account-lookup parameter from this file so that the default takes effect.        
+          Alternatively, you can delete the service-account-lookup parameter from this file so that the default takes effect.
       - id: K.1.2.23
         description: Ensure that the --service-account-key-file argument is set as
           appropriate (Automated)
@@ -1074,11 +1074,11 @@ groups:
               pass "      * service-account-key-file: $file"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           K3s automatically generates and sets the service account key file. It is located at /var/lib/rancher/k3s/server/tls/service.key. If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-apiserver-arg:
-            - "service-account-key-file=<path>"       
+            - "service-account-key-file=<path>"
       - id: K.1.2.24
         description: Ensure that the --etcd-certfile and --etcd-keyfile arguments
           are set as appropriate (Automated)
@@ -1112,7 +1112,7 @@ groups:
           K3s automatically generates and sets the etcd certificate and key files. They are located at /var/lib/rancher/k3s/server/tls/etcd/client.crt and /var/lib/rancher/k3s/server/tls/etcd/client.key. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-apiserver-arg:
             - "etcd-certfile=<path>"
-            - "etcd-keyfile=<path>"        
+            - "etcd-keyfile=<path>"
       - id: K.1.2.25
         description: Ensure that the --tls-cert-file and --tls-private-key-file arguments
           are set as appropriate (Automated)
@@ -1141,12 +1141,12 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s automatically generates and provides the TLS certificate and private key for the apiserver. They are generated and located at /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.key If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-apiserver-arg:
             - "tls-cert-file=<path>"
-            - "tls-private-key-file=<path>"        
+            - "tls-private-key-file=<path>"
       - id: K.1.2.26
         description: Ensure that the --client-ca-file argument is set as appropriate
           (Automated)
@@ -1194,11 +1194,11 @@ groups:
               pass "      * etcd-cafile: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
-          By default, K3s automatically provides the etcd certificate authority file. It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt. If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below. 
+          By default, K3s automatically provides the etcd certificate authority file. It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt. If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-apiserver-arg:
-            - "etcd-cafile=<path>"       
+            - "etcd-cafile=<path>"
       - id: K.1.2.28
         description: Ensure that the --encryption-provider-config argument is set
           as appropriate (Manual)
@@ -1217,7 +1217,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi     
+          fi
         remediation: |
           K3s can be configured to use encryption providers to encrypt secrets at rest. Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter. secrets-encryption: true Secrets encryption can then be managed with the k3s secrets-encrypt command line tool. If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json.
       - id: K.1.2.29
@@ -1247,7 +1247,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           K3s can be configured to use encryption providers to encrypt secrets at rest. K3s will utilize the aescbc provider. Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter. secrets-encryption: true Secrets encryption can then be managed with the k3s secrets-encrypt command line tool. If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json
       - id: K.1.2.30
@@ -1274,7 +1274,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, the K3s kube-apiserver complies with this test. Changes to these values may cause regression, therefore ensure that all apiserver clients support the new TLS configuration before applying it in production deployments. If a custom TLS configuration is required, consider also creating a custom version of this rule that aligns with your requirements. If this check fails, remove any custom configuration around tls-cipher-suites or update the /etc/rancher/k3s/config.yaml file to match the default by adding the following:
           kube-apiserver-arg:
@@ -1301,7 +1301,7 @@ groups:
               pass "      * terminated-pod-gc-threshold: $threshold"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
           kube-controller-manager-arg:
@@ -1320,11 +1320,11 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s sets the --profiling argument to false. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-controller-manager-arg:
-            - "profiling=true"   
+            - "profiling=true"
       - id: K.1.3.3
         description: Ensure that the --use-service-account-credentials argument is
           set to true (Automated)
@@ -1343,11 +1343,11 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s sets the --use-service-account-credentials argument to true. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-controller-manager-arg:
-            - "use-service-account-credentials=false"     
+            - "use-service-account-credentials=false"
       - id: K.1.3.4
         description: Ensure that the --service-account-private-key-file argument is
           set as appropriate (Automated)
@@ -1369,11 +1369,11 @@ groups:
               pass "      * service-account-private-key-file: $keyfile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s automatically provides the service account private key file. It is generated and located at /var/lib/rancher/k3s/server/tls/service.current.key. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-controller-manager-arg:
-            - "service-account-private-key-file=<path>"        
+            - "service-account-private-key-file=<path>"
       - id: K.1.3.5
         description: Ensure that the --root-ca-file argument is set as appropriate
           (Automated)
@@ -1395,7 +1395,7 @@ groups:
               pass "      * root-ca-file: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s automatically provides the root CA file. It is generated and located at /var/lib/rancher/k3s/server/tls/server-ca.crt. If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-controller-manager-arg:
@@ -1424,11 +1424,11 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s does not set the RotateKubeletServerCertificate feature gate. If you have enabled this feature gate, you should remove it. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
           kube-controller-manager-arg:
-            - "feature-gate=RotateKubeletServerCertificate" 
+            - "feature-gate=RotateKubeletServerCertificate"
       - id: K.1.3.7
         description: Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)
         type: master
@@ -1443,7 +1443,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s sets the --bind-address argument to 127.0.0.1 If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-controller-manager-arg:
@@ -1465,7 +1465,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s sets the --profiling argument to false. If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-scheduler-arg:
@@ -1484,7 +1484,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s sets the --bind-address argument to 127.0.0.1 If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-scheduler-arg:

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-k3s-1.8.0/worker/4_worker_nodes.yaml
@@ -53,7 +53,7 @@ groups:
         audit: |
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/var/lib/rancher/k3s/agent/kubeproxy.kubeconfig")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -63,7 +63,7 @@ groups:
           else
             warn "$check"
             warn "      * kubeconfig file: $file not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chmod 600 /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
       - id: K.4.1.4
@@ -79,8 +79,8 @@ groups:
           PCI: []
           GDPR: []
         audit: |
-          check="$id  - $description"           
-          if [ -f "$file" ]; then
+          check="$id  - $description"
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -90,7 +90,7 @@ groups:
           else
             warn "$check"
             warn "      * kubeconfig file: $file not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chown root:root /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
           file>
@@ -110,7 +110,7 @@ groups:
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/var/lib/rancher/k3s/agent/kubelet.kubeconfig")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -120,7 +120,7 @@ groups:
           else
             warn "$check"
             warn "      * File: $file not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chmod 600 /var/lib/rancher/k3s/agent/kubelet.kubeconfig
       - id: K.4.1.6
@@ -137,7 +137,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -176,7 +176,7 @@ groups:
             warn "      * File: $file not found"
           fi
         remediation: |
-          Run the following command to modify the file permissions of the --client-ca-file chmod 600 /var/lib/rancher/k3s/agent/client-ca.crt        
+          Run the following command to modify the file permissions of the --client-ca-file chmod 600 /var/lib/rancher/k3s/agent/client-ca.crt
       - id: K.4.1.8
         description: Ensure that the client certificate authorities file ownership
           is set to root:root (Manual)
@@ -262,7 +262,7 @@ groups:
           By default, K3s sets the --anonymous-auth to false. If you have set this to a different value, you should set it back to false. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
           kubelet-arg:
             - "anonymous-auth=true"
-          If using the command line, edit the K3s service file and remove the below argument. --kubelet-arg="anonymous-auth=true" Based on your system, restart the k3s service. For example, systemctl daemon-reload systemctl restart k3s.service               
+          If using the command line, edit the K3s service file and remove the below argument. --kubelet-arg="anonymous-auth=true" Based on your system, restart the k3s service. For example, systemctl daemon-reload systemctl restart k3s.service
       - id: K.4.2.2
         description: Ensure that the --authorization-mode argument is not set to AlwaysAllow
           (Automated)
@@ -308,7 +308,7 @@ groups:
               pass "      * client-ca-file: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s automatically provides the client ca certificate for the Kubelet. It is generated and located at /var/lib/rancher/k3s/agent/client-ca.crt
       - id: K.4.2.4
@@ -334,7 +334,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s sets the --read-only-port to 0. If you have set this to a different value, you should set it back to 0. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
           kubelet-arg:
@@ -357,7 +357,7 @@ groups:
               warn "      * streaming-connection-idle-timeout: $timeout"
           else
               pass "$check"
-          fi        
+          fi
         remediation: |
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
           kubelet-arg:
@@ -378,7 +378,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
           kubelet-arg:
@@ -394,9 +394,9 @@ groups:
         tags: {}
         audit: |
           check="$id  - $description"
-          pass "$check"     
+          pass "$check"
         remediation: |
-          By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply with cloud providers that require this flag to ensure that hostname matches node names.      
+          By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply with cloud providers that require this flag to ensure that hostname matches node names.
       - id: K.4.2.8
         description: Ensure that the eventRecordQPS argument is set to a level which
           ensures appropriate event capture (Manual)
@@ -419,12 +419,12 @@ groups:
           else
               warn "$check"
               warn "      * --event-qps is not set"
-          fi        
+          fi
         remediation: |
           By default, K3s sets the event-qps to 0. Should you wish to change this, If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
           kubelet-arg:
             - "event-qps=<value>"
-          If using the command line, run K3s with --kubelet-arg="event-qps=<value>". Based on your system, restart the k3s service. For example, systemctl restart k3s.service             
+          If using the command line, run K3s with --kubelet-arg="event-qps=<value>". Based on your system, restart the k3s service. For example, systemctl restart k3s.service
       - id: K.4.2.9
         description: Ensure that the --tls-cert-file and --tls-private-key-file arguments
           are set as appropriate (Manual)
@@ -453,12 +453,12 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s automatically provides the TLS certificate and private key for the Kubelet. They are generated and located at /var/lib/rancher/k3s/agent/serving-kubelet.crt and /var/lib/rancher/k3s/agent/serving-kubelet.key If for some reason you need to provide your own certificate and key, you can set the below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
           kubelet-arg:
             - "tls-cert-file=<path/to/tls-cert-file>"
-            - "tls-private-key-file=<path/to/tls-private-key-file>"                
+            - "tls-private-key-file=<path/to/tls-private-key-file>"
       - id: K.4.2.10
         description: Ensure that the --rotate-certificates argument is not set to
           false (Automated)
@@ -477,7 +477,7 @@ groups:
             warn "$check"
           else
             pass "$check"
-          fi        
+          fi
         remediation: |
           By default, K3s does not set the --rotate-certificates argument. If you have set this flag with a value of false, you should either set it to true or completely remove the flag. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter. If using the command line, remove the K3s flag --kubelet-arg="rotate-certificates". Based on your system, restart the k3s service. For example, systemctl restart k3s.service
       - id: K.4.2.11
@@ -505,7 +505,7 @@ groups:
               fi
           else
               warn "$check"
-          fi   
+          fi
         remediation: |
           By default, K3s does not set the RotateKubeletServerCertificate feature gate. If you have enabled this feature gate, you should remove it. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter. If using the command line, remove the K3s flag --kubelet-arg="feature-gate=RotateKubeletServerCertificate". Based on your system, restart the k3s service. For example, systemctl restart k3s.service
       - id: K.4.2.12
@@ -556,7 +556,7 @@ groups:
           If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set TLSCipherSuites to
           kubelet-arg:
             - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
-          or to a subset of these values. If using the command line, add the K3s flag --kubelet-arg="tls-cipher-suites=<same values as above>" Based on your system, restart the k3s service. For example, systemctl restart k3s.service 
+          or to a subset of these values. If using the command line, add the K3s flag --kubelet-arg="tls-cipher-suites=<same values as above>" Based on your system, restart the k3s service. For example, systemctl restart k3s.service
       - id: K.4.2.13
         description: Ensure that a limit is set on pod PIDs (Manual)
         type: worker
@@ -568,8 +568,8 @@ groups:
         audit: |
           check="$id  - $description"
           manual "$check"
-          manual "      * Review the Kubelet's start-up parameters for the value of --pod-max-pids, and check the Kubelet configuration file for the PodPidsLimit . If neither of these values is set, then there is no limit in place."   
+          manual "      * Review the Kubelet's start-up parameters for the value of --pod-max-pids, and check the Kubelet configuration file for the PodPidsLimit . If neither of these values is set, then there is no limit in place."
         remediation: |
           Decide on an appropriate level for this parameter and set it, If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set podPidsLimit to
           kubelet-arg:
-            - "pod-max-pids=<value>"        
+            - "pod-max-pids=<value>"

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/master/1_control_plane_components.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/master/1_control_plane_components.yaml
@@ -50,7 +50,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" -eq 00 ]; then
               pass "$check"
@@ -80,7 +80,7 @@ groups:
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -le 600 ]; then
               pass "$check"
@@ -108,7 +108,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" -eq 00 ]; then
               pass "$check"
@@ -138,7 +138,7 @@ groups:
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/var/lib/rancher/rke2/agent/pod-manifests/kube-scheduler.yaml")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -le 600 ]; then
               pass "$check"
@@ -166,7 +166,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" -eq 00 ]; then
               pass "$check"
@@ -196,7 +196,7 @@ groups:
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -le 600 ]; then
               pass "$check"
@@ -224,7 +224,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" -eq 00 ]; then
               pass "$check"
@@ -303,7 +303,7 @@ groups:
             count_files=$((count_files + 1))
             permissions=$(stat -c %u%g $file)
 
-            # Check if the ownership is set to root:root 
+            # Check if the ownership is set to root:root
             if [ "$permissions" != "00" ]; then
               non_compliant_files="$non_compliant_files$file ($permissions), "
             fi
@@ -341,7 +341,7 @@ groups:
           file="/var/lib/rancher/rke2/server/db/etcd"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -le 700 ]; then
               pass "$check"
@@ -356,7 +356,7 @@ groups:
         remediation: 'On the etcd server node, get the etcd data directory, passed
           as an argument --data-dir, from the below command: ps -ef | grep etcd Run
           the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd'
+          chmod 700 /var/lib/rancher/rke2/server/db/etcd'
       - id: K.1.1.12
         description: Ensure that the etcd data directory ownership is set to etcd:etcd
           (Automated)
@@ -372,7 +372,7 @@ groups:
         audit: |
           check="$id  - $description"
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %U:%G $file)
             if [ "$ownership" = "etcd:etcd" ]; then
               pass "$check"
@@ -404,7 +404,7 @@ groups:
           file="/var/lib/rancher/rke2/server/cred/admin.kubeconfig"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -le 600 ]; then
               pass "$check"
@@ -433,7 +433,7 @@ groups:
         audit: |
           check="$id  - $description"
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" = "00" ]; then
               pass "$check"
@@ -464,7 +464,7 @@ groups:
           file="/var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -le 600 ]; then
               pass "$check"
@@ -492,7 +492,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" = "00" ]; then
               pass "$check"
@@ -523,7 +523,7 @@ groups:
           file="/var/lib/rancher/rke2/server/cred/controller.kubeconfig"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -le 600 ]; then
               pass "$check"
@@ -534,7 +534,7 @@ groups:
           else
             warn "$check"
             warn "      * File not found, $file"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the control plane node. For example, chmod 600 /var/lib/rancher/rke2/server/cred/controller.kubeconfig
       - id: K.1.1.18
@@ -551,7 +551,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" = "00" ]; then
               pass "$check"
@@ -562,7 +562,7 @@ groups:
           else
             warn "$check"
             warn "      * File not found, $file"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the control plane node. For example, chown root:root /var/lib/rancher/rke2/server/cred/controller.kubeconfig
       - id: K.1.1.19
@@ -579,30 +579,22 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          file="/var/lib/rancher/rke2/server/tls/"
+          file="/var/lib/rancher/rke2/server/tls"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          files=$(find $file)
-          pass=true
-          failed_ownership=""
-          failed_file=""
-          for f in ${files}; do
-            ownership=$(stat -c %u%g $f)
-            if [ "$ownership" != "00" ]; then
-              pass=false;
-              failed_ownership=$ownership
-              failed_file=$f
-              break;
+          if [ -e "$file" ]; then
+            ownership=$(stat -c %u%g $file)
+            if [ "$ownership" -eq 00 ]; then
+              pass "$check"
+            else
+              warn "$check"
+              warn "      * Wrong ownership for $file, expected 00, but is $ownership"
             fi
-          done
-
-          if [ "$pass" = "true" ]; then
-            pass "$check"
           else
             warn "$check"
-            warn "      * Wrong ownership for $failed_file, expected root:root, but is $failed_ownership"
+            warn "      * Directory not found, $file"
           fi
         remediation: Run the below command (based on the file location on your system)
-          on the control plane node. For example, chown -R root:root /var/lib/rancher/rke2/server/tls/
+          on the control plane node. For example, chown -R root:root /var/lib/rancher/rke2/server/tls
       - id: K.1.1.20
         description: Ensure that the Kubernetes PKI certificate file permissions are
           set to 600 or more restrictive (Manual)
@@ -636,9 +628,9 @@ groups:
           else
             warn "$check"
             warn "      * Wrong permissions for $failed_file, expected 600 or less, but is $failed_perm"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
-          on the control plane node. For example, chmod -R 600 /var/lib/rancher/rke2/server/tls/*.crt
+          on the control plane node. For example, chmod -R 600 /var/lib/rancher/rke2/server/tls/*.key
       - id: K.1.1.21
         description: Ensure that the Kubernetes PKI key file permissions are set to
           600 (Automated)
@@ -659,7 +651,7 @@ groups:
           failed_file=""
           for f in ${files}; do
             permissions=$(stat -c %a $f)
-            if ! [ "$permissions" -eq 600 ]; then
+            if ! [ "$permissions" -le 600 ]; then
               pass=false;
               failed_perm=$permissions
               failed_file=$f
@@ -695,7 +687,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 sets the --anonymous-auth argument to false.
           If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml and remove anything similar to below.
@@ -773,7 +765,7 @@ groups:
               fi
           else
               warn "$check"
-          fi  
+          fi
         remediation: |
           By default, RKE2 automatically provides the kubelet client certificate and key.
           They are generated and located at /var/lib/rancher/rke2/server/tls/client-kube-apiserver.crt and /var/lib/rancher/rke2/server/tls/client-kube-apiserver.key
@@ -800,7 +792,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 automatically provides the kubelet CA cert file, at /var/lib/rancher/rke2/server/tls/server-ca.crt.
           If for some reason you need to provide your own ca certificate, look at using the rke2 certificate command line tool.
@@ -825,7 +817,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 does not set the --authorization-mode to AlwaysAllow.
           If this check fails, edit RKE2 config file /etc/rancher/rke2/config.yaml, remove any lines like below.
@@ -848,7 +840,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 sets the --authorization-mode to Node and RBAC.
           If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml,
@@ -892,7 +884,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           Follow the Kubernetes documentation and set the desired limits in a configuration file.
           Then, edit the RKE2 config file /etc/rancher/rke2/config.yaml and set the below parameters.
@@ -916,7 +908,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 does not set the --enable-admission-plugins to AlwaysAdmit.
           If this check fails, edit RKE2 config file /etc/rancher/rke2/config.yaml, remove any lines like below.
@@ -939,7 +931,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           Permissive, per CIS guidelines,
           "This setting could impact offline or isolated clusters, which have images pre-loaded and
@@ -962,7 +954,7 @@ groups:
           PCI: []
         audit: |
           check="$id  - $description"
-          pass "$check"      
+          pass "$check"
         remediation: |
           Not Applicable.
           Enabling Pod Security Policy is no longer supported on RKE2 v1.25+ and will cause applications to unexpectedly fail.
@@ -983,7 +975,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 does not set the --disable-admission-plugins to anything.
           Follow the documentation and create ServiceAccount objects as per your environment.
@@ -1051,7 +1043,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 sets the --profiling argument to false.
           If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml and remove any lines like below.
@@ -1073,7 +1065,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 sets the --audit-log-path argument to /var/lib/rancher/rke2/server/logs/audit.log
           If you want to change this, edit the RKE2 config file /etc/rancher/rke2/config.yaml
@@ -1105,7 +1097,7 @@ groups:
               fi
           else
               warn "$check"
-          fi 
+          fi
         remediation: |
           By default, RKE2 sets the --audit-log-maxage argument to 30 days.
           If you want to change this, edit the RKE2 config file /etc/rancher/rke2/config.yaml
@@ -1193,7 +1185,7 @@ groups:
               pass "      * request-timeout: $requestTimeout"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           Permissive, per CIS guidelines,
           "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed".
@@ -1219,7 +1211,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 does not set the --service-account-lookup argument.
           Edit the RKE2 config file /etc/rancher/rke2/config.yaml and set the service-account-lookup. For example,
@@ -1248,7 +1240,7 @@ groups:
               pass "      * service-account-key-file: $file"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           RKE2 automatically generates and sets the service account key file.
           It is located at /var/lib/rancher/rke2/server/tls/service.key.
@@ -1319,7 +1311,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 automatically generates and provides the TLS certificate and private key for the apiserver.
           They are generated and located at /var/lib/rancher/rke2/server/tls/serving-kube-apiserver.crt and /var/lib/rancher/rke2/server/tls/serving-kube-apiserver.key
@@ -1377,7 +1369,7 @@ groups:
               pass "      * etcd-cafile: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 automatically provides the etcd certificate authority file.
           It is generated and located at /var/lib/rancher/rke2/server/tls/client-ca.crt.
@@ -1403,7 +1395,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi     
+          fi
         remediation: |
           RKE2 always is configured to encrypt secrets.
           Secrets encryption is managed with the rke2 secrets-encrypt command line tool.
@@ -1423,7 +1415,7 @@ groups:
         audit: |
           check="$id  - $description"
           if check_argument "$CIS_APISERVER_CMD" '--encryption-provider-config' >/dev/null 2>&1; then
-              encryptionConfig=$(get_argument_value "$CIS_APISERVER_CMD" '--encryption-provider-config') 
+              encryptionConfig=$(get_argument_value "$CIS_APISERVER_CMD" '--encryption-provider-config')
               encryptionConfig=$(append_prefix "$CONFIG_PREFIX" "$encryptionConfig")
 
               if [ -f "$encryptionConfig" ]; then
@@ -1440,7 +1432,7 @@ groups:
           else
               warn "$check"
               warn "      * encryption-provider-config: not found"
-          fi        
+          fi
         remediation: |
           RKE2 always is configured to use the aescbc encryption provider to encrypt secrets.
           Secrets encryption is managed with the rke2 secrets-encrypt command line tool.
@@ -1469,7 +1461,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, the RKE2 kube-apiserver complies with this test. Changes to these values may cause regression, therefore ensure that all apiserver clients support the new TLS configuration before applying it in production deployments.
           If a custom TLS configuration is required, consider also creating a custom version of this rule that aligns with your requirements.
@@ -1498,7 +1490,7 @@ groups:
               pass "      * terminated-pod-gc-threshold: $threshold"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 sets a terminated-pod-gc-threshold of 1000.
           If you need to change this value, edit the RKE2 config file /etc/rancher/rke2/config.yaml on the control plane node
@@ -1519,7 +1511,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 sets the --profiling argument to false.
           If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml and remove any lines like below.
@@ -1543,7 +1535,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 sets the --use-service-account-credentials argument to true.
           If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml and remove any lines like below.
@@ -1570,7 +1562,7 @@ groups:
               pass "      * service-account-private-key-file: $keyfile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 automatically provides the service account private key file.
           It is generated and located at /var/lib/rancher/rke2/server/tls/service.current.key.
@@ -1598,7 +1590,7 @@ groups:
               pass "      * root-ca-file: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 automatically provides the root CA file.
           It is generated and located at /var/lib/rancher/rke2/server/tls/server-ca.crt.
@@ -1630,7 +1622,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
@@ -1651,7 +1643,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 sets the --bind-address argument to 127.0.0.1
           If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml and remove any lines like below.
@@ -1674,7 +1666,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 sets the --profiling argument to false.
           If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml and remove any lines like below.
@@ -1694,7 +1686,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 sets the --bind-address argument to 127.0.0.1
           If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml and remove any lines like below.

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
@@ -58,7 +58,7 @@ groups:
           check="$id  - $description"
           file="/var/lib/rancher/rke2/agent/kubeproxy.kubeconfig"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -le 600 ]; then
               pass "$check"
@@ -69,7 +69,7 @@ groups:
           else
             warn "$check"
             warn "      * kubeconfig file not found, $file"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chmod 600 /var/lib/rancher/rke2/agent/kubeproxy.kubeconfig
       - id: K.4.1.4
@@ -85,8 +85,8 @@ groups:
           PCI: []
           GDPR: []
         audit: |
-          check="$id  - $description"           
-          if [ -f "$file" ]; then
+          check="$id  - $description"
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" = "00" ]; then
               pass "$check"
@@ -97,7 +97,7 @@ groups:
           else
             warn "$check"
             warn "      * kubeconfig file not found, $file"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chown root:root /var/lib/rancher/rke2/agent/kubeproxy.kubeconfig
       - id: K.4.1.5
@@ -117,7 +117,7 @@ groups:
           file="/var/lib/rancher/rke2/agent/kubelet.kubeconfig"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -le 600 ]; then
               pass "$check"
@@ -128,7 +128,7 @@ groups:
           else
             warn "$check"
             warn "      * File not found, $file"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chmod 600 /var/lib/rancher/rke2/agent/kubelet.kubeconfig
       - id: K.4.1.6
@@ -145,7 +145,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             ownership=$(stat -c %u%g $file)
             if [ "$ownership" = "00" ]; then
               pass "$check"
@@ -174,7 +174,8 @@ groups:
         audit: |
           check="$id  - $description"
           file="/var/lib/rancher/rke2/agent/client-ca.crt"
-          if [ -f "$file" ]; then
+          file=$(append_prefix "$CONFIG_PREFIX" "$file")
+          if [ -e "$file" ]; then
             permissions=$(stat -c %a $file)
             if [ "$permissions" -le 600 ]; then
               pass "$check"
@@ -206,7 +207,7 @@ groups:
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
             file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
             file=$(append_prefix "$CONFIG_PREFIX" "$file")
-            if [ -f "$file" ]; then
+            if [ -e "$file" ]; then
               ownership=$(stat -c %u%g $file)
               if [ "$ownership" = "00" ]; then
                 pass "$check"
@@ -222,7 +223,7 @@ groups:
           else
             warn "$check"
             warn "      * --client-ca-file not set"
-          fi 
+          fi
         remediation: Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>
       - id: K.4.1.9
@@ -240,7 +241,7 @@ groups:
         audit: |
           check="$id  - $description"
           pass "$check"
-        remediation: |          
+        remediation: |
           Not Applicable.
           The kubelet is managed by the RKE2 process. There is no kubelet config file, all configuration is passed in as arguments at runtime.
       - id: K.4.1.10
@@ -288,7 +289,7 @@ groups:
           kubelet-arg:
             - "anonymous-auth=true"
           Based on your system, restart the RKE2 service. For example,
-          systemctl restart rke2-server.service         
+          systemctl restart rke2-server.service
       - id: K.4.2.2
         description: Ensure that the --authorization-mode argument is not set to AlwaysAllow
           (Automated)
@@ -336,7 +337,7 @@ groups:
               pass "      * client-ca-file: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 automatically provides the client ca certificate for the Kubelet.
           It is generated and located at /var/lib/rancher/rke2/agent/client-ca.crt
@@ -363,7 +364,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 sets the --read-only-port to 0. If you have set this to a different value, you
           should set it back to 0. Edit the RKE2 config file /etc/rancher/rke2/config.yaml, remove any lines similar to below.
@@ -388,7 +389,7 @@ groups:
               warn "      * streaming-connection-idle-timeout: $timeout"
           else
               pass "$check"
-          fi        
+          fi
         remediation: |
           Edit the RKE2 config file /etc/rancher/rke2/config.yaml, set the following parameter to an appropriate value.
           kubelet-arg:
@@ -410,7 +411,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           Edit the RKE2 config file /etc/rancher/rke2/config.yaml, set the following parameter.
           kubelet-arg:
@@ -432,7 +433,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: |
           Not Applicable.
           By default, RKE2 does set the --hostname-override argument. Per CIS guidelines, this is to comply
@@ -459,7 +460,7 @@ groups:
           else
               warn "$check"
               warn "      * --event-qps is not set"
-          fi        
+          fi
         remediation: |
           Edit the RKE2 config file /etc/rancher/rke2/config.yaml, set the following parameter to an appropriate value.
           kubelet-arg:
@@ -494,14 +495,14 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 automatically provides the TLS certificate and private key for the Kubelet.
           They are generated and located at /var/lib/rancher/rke2/agent/serving-kubelet.crt and /var/lib/rancher/rke2/agent/serving-kubelet.key
           If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml and remove any lines similar to below.
           kubelet-arg:
             - "tls-cert-file=<path/to/tls-cert-file>"
-            - "tls-private-key-file=<path/to/tls-private-key-file>"            
+            - "tls-private-key-file=<path/to/tls-private-key-file>"
       - id: K.4.2.10
         description: Ensure that the --rotate-certificates argument is not set to
           false (Automated)
@@ -520,7 +521,7 @@ groups:
             warn "$check"
           else
             pass "$check"
-          fi        
+          fi
         remediation: |
           By default, RKE2 does not set the --rotate-certificates argument.
           If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml, remove any rotate-certificates parameter.
@@ -604,7 +605,7 @@ groups:
             - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
           or to a subset of these values.
           Based on your system, restart the RKE2 service. For example,
-          systemctl restart rke2-server.service     
+          systemctl restart rke2-server.service
       - id: K.4.2.13
         description: Ensure that a limit is set on pod PIDs (Manual)
         type: worker
@@ -616,7 +617,7 @@ groups:
         audit: |
           check="$id  - $description"
           manual "$check"
-          manual "      * Review the Kubelet's start-up parameters for the value of --pod-max-pids, and check the Kubelet configuration file for the PodPidsLimit . If neither of these values is set, then there is no limit in place."   
+          manual "      * Review the Kubelet's start-up parameters for the value of --pod-max-pids, and check the Kubelet configuration file for the PodPidsLimit . If neither of these values is set, then there is no limit in place."
         remediation: |
           Edit the RKE2 config file /etc/rancher/rke2/config.yaml, set the following parameter to an appropriate value.
           kubelet-arg:

--- a/agent/nvbench/kubernetes-cis-benchmark/eks-1.4.0/worker/3_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/eks-1.4.0/worker/3_worker_nodes.yaml
@@ -22,7 +22,7 @@ groups:
           check="$id  - $description"
           file="/var/lib/kubelet/kubeconfig"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
               pass "      * read check_argument for $file"
@@ -50,7 +50,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -80,7 +80,7 @@ groups:
           file=""
           file="/etc/kubernetes/kubelet/kubelet-config.json"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
               pass "      * read check_argument for $file"
@@ -91,7 +91,7 @@ groups:
           else
             warn "$check"
             warn "      * kubelet configuration file, $file not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chmod chmod 644 /proc/1/root/etc/kubernetes/kubelet/kubelet-config.json
       - id: K.3.1.4
@@ -107,8 +107,8 @@ groups:
           PCI: []
           GDPR: []
         audit: |
-          check="$id  - $description"           
-          if [ -f "$file" ]; then
+          check="$id  - $description"
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -118,7 +118,7 @@ groups:
           else
             warn "$check"
             warn "      * kubelet configuration file, $file not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chown root:root /proc/1/root/etc/kubernetes/kubelet/kubelet-config.json
   - id: 3.2
@@ -160,7 +160,7 @@ groups:
           The following example is for operating systems using systemd, such as the Amazon EKS Optimised Amazon Linux or Bottlerocket AMIs, and invokes the systemctl command. If systemctl is not available then you will need to look up documentation for your chosen operating system to determine which service manager is configured:
           systemctl daemon-reload
           systemctl restart kubelet.service
-          systemctl status kubelet -l                
+          systemctl status kubelet -l
       - id: K.3.2.2
         description: Ensure that the --authorization-mode argument is not set to AlwaysAllow
           (Automated)
@@ -221,7 +221,7 @@ groups:
               pass "      * client-ca-file: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           Remediation Method 1:
           If configuring via the Kubelet config file, you first need to locate the file.
@@ -261,7 +261,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           If modifying the Kubelet config file, edit the kubelet-config.json file /etc/kubernetes/kubelet/kubelet-config.json and set the below parameter to 0
           "readOnlyPort": 0
@@ -289,7 +289,7 @@ groups:
               warn "      * streaming-connection-idle-timeout: $timeout"
           else
               pass "$check"
-          fi        
+          fi
         remediation: |
           Remediation Method 1:
           If modifying the Kubelet config file, edit the kubelet-config.json file /etc/kubernetes/kubelet/kubelet-config.json and set the below parameter to a non- zero value in the format of #h#m#s
@@ -326,7 +326,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           Remediation Method 1:
           If modifying the Kubelet config file, edit the kubelet-config.json file /etc/kubernetes/kubelet/kubelet-config.json and set the below parameter to true
@@ -370,7 +370,7 @@ groups:
           else
               warn "$check"
               warn "      * --event-qps is not set"
-          fi     
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to set eventRecordQPS: to an appropriate level. If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
           Based on your system, restart the kubelet service. For example:
@@ -395,7 +395,7 @@ groups:
             warn "$check"
           else
             pass "$check"
-          fi   
+          fi
         remediation: |
           Remediation Method 1:
           If modifying the Kubelet config file, edit the kubelet-config.json file /etc/kubernetes/kubelet/kubelet-config.json and set the below parameter to true
@@ -423,7 +423,7 @@ groups:
               file=$(get_argument_value "$CIS_KUBELET_CMD" '--config'|cut -d " " -f 1)
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             found=$(sed -rn '/--feature-gates=RotateKubeletServerCertificate=true/p' $file)
             if [ -z "$found" ]; then
                 warn "$check"

--- a/agent/nvbench/kubernetes-cis-benchmark/gke-1.4.0/worker/3_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/gke-1.4.0/worker/3_worker_nodes.yaml
@@ -22,7 +22,7 @@ groups:
           check="$id  - $description"
           file="/var/lib/kube-proxy/kubeconfig"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
               pass "      * read check_argument for $file"
@@ -50,7 +50,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -80,7 +80,7 @@ groups:
           file=""
           file="/home/kubernetes/kubelet-config.yaml"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
               pass "      * read check_argument for $file"
@@ -91,7 +91,7 @@ groups:
           else
             warn "$check"
             warn "      * kubelet configuration file, $file not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chmod chmod 644 /proc/1/root/home/kubernetes/kubelet-config.yaml
       - id: K.3.1.4
@@ -107,8 +107,8 @@ groups:
           PCI: []
           GDPR: []
         audit: |
-          check="$id  - $description"           
-          if [ -f "$file" ]; then
+          check="$id  - $description"
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -118,7 +118,7 @@ groups:
           else
             warn "$check"
             warn "      * kubelet configuration file, $file not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chown root:root /proc/1/root/home/kubernetes/kubelet-config.yaml
   - id: 3.2
@@ -146,9 +146,9 @@ groups:
           If using a Kubelet config file, edit the file to set authentication: anonymous: enabled to false.
           If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
           --anonymous-auth=false
-          Based on your system, restart the kubelet service. For example:   
-          systemctl daemon-reload 
-          systemctl restart kubelet.service                   
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.3.2.2
         description: Ensure that the --authorization-mode argument is not set to AlwaysAllow
           (Automated)
@@ -170,10 +170,10 @@ groups:
           fi
         remediation: |
           If using a Kubelet config file, edit the file to set authorization: mode to Webhook.
-          If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.        
+          If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
           --authorization-mode=Webhook
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.3.2.3
         description: Ensure that the --client-ca-file argument is set as appropriate
@@ -196,7 +196,7 @@ groups:
               pass "      * client-ca-file: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to set authentication: x509: clientCAFile to the location of the client CA file.
           If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
@@ -227,7 +227,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to set readOnlyPort to 0.
           If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
@@ -252,13 +252,13 @@ groups:
               warn "      * streaming-connection-idle-timeout: $timeout"
           else
               pass "$check"
-          fi        
+          fi
         remediation: |
-          If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a value other than 0. 
+          If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a value other than 0.
           If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
           --streaming-connection-idle-timeout=5m
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.3.2.6
         description: Ensure that the --make-iptables-util-chains argument is set to
@@ -275,12 +275,12 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
-          If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true. 
-          If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and remove the --mak-iptables-util-chains argument from the KUBELET_SYSTEM_PODS_ARGS variable. 
-          Based on your system, restart the kubelet service. For example:        
-          systemctl daemon-reload 
+          If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true.
+          If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and remove the --mak-iptables-util-chains argument from the KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.3.2.7
         description: Ensure that the --hostname-override argument is not set (Manual)
@@ -296,7 +296,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: 'Edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
           on each worker node and remove the --hostname-override argument from the
           KUBELET_SYSTEM_PODS_ARGS variable. Based on your system, restart the kubelet
@@ -323,7 +323,7 @@ groups:
           else
               warn "$check"
               warn "      * --event-qps is not set"
-          fi    
+          fi
         remediation: 'If using a Kubelet config file, edit the file to set --event-qps:
           to an appropriate level. If using command line arguments, edit the kubelet
           service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each
@@ -358,14 +358,14 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
-          If using a Kubelet config file, edit the file to set tlsCertFile to the location of the certificate file to use to identify this Kubelet, and tlsPrivateKeyFile to the location of the corresponding private key file. 
-          If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameters in KUBELET_CERTIFICATE_ARGS variable.  
-          --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key-file=<path/to/tls-key-file> 
+          If using a Kubelet config file, edit the file to set tlsCertFile to the location of the certificate file to use to identify this Kubelet, and tlsPrivateKeyFile to the location of the corresponding private key file.
+          If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
+          --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key-file=<path/to/tls-key-file>
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service                    
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.3.2.10
         description: Ensure that the --rotate-certificates argument is not set to
           false (Automated)
@@ -384,13 +384,13 @@ groups:
             warn "$check"
           else
             pass "$check"
-          fi   
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to add the line rotateCertificates: true or remove it altogether to use the default value.
           If using command line arguments, edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS variable.
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service 
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.3.2.11
         description: Ensure that the RotateKubeletServerCertificate argument is set
           to true (Automated)
@@ -410,7 +410,7 @@ groups:
               file=$(get_argument_value "$CIS_KUBELET_CMD" '--config'|cut -d " " -f 1)
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             found=$(sed -rn '/--feature-gates=RotateKubeletServerCertificate=true/p' $file)
             if [ -z "$found" ]; then
                 warn "$check"

--- a/agent/nvbench/ocp/rh-1.4.0/master/1_control_plane_components.yaml
+++ b/agent/nvbench/ocp/rh-1.4.0/master/1_control_plane_components.yaml
@@ -52,7 +52,7 @@ groups:
           check="$id  - $description"
           file="/etc/kubernetes/manifests/kube-apiserver-pod.yaml"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -80,7 +80,7 @@ groups:
           check="$id  - $description"
           file="/etc/kubernetes/manifests/kube-controller-manager-pod.yaml"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -110,7 +110,7 @@ groups:
           check="$id  - $description"
           file="/etc/kubernetes/manifests/kube-controller-manager-pod.yaml"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -138,7 +138,7 @@ groups:
           check="$id  - $description"
           file="/etc/kubernetes/manifests/kube-scheduler-pod.yaml"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -168,7 +168,7 @@ groups:
           check="$id  - $description"
           file="/etc/kubernetes/manifests/kube-scheduler-pod.yaml"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -196,7 +196,7 @@ groups:
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -226,7 +226,7 @@ groups:
           check="$id  - $description"
           file="/etc/kubernetes/manifests/etcd-pod.yaml"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -372,7 +372,7 @@ groups:
           check="$id  - $description"
           file="/var/lib/etcd"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -d "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 700 ]; then
               pass "$check"
             else
@@ -398,7 +398,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %U:%G $file)" = "etcd:etcd" ]; then
               pass "$check"
             else
@@ -427,7 +427,7 @@ groups:
           file="/etc/kubernetes/kubeconfig"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -457,7 +457,7 @@ groups:
           check="$id  - $description"
           file="/etc/kubernetes/kubeconfig"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -569,7 +569,7 @@ groups:
             pass "$check"
           else
             warn "$check"
-          fi   
+          fi
         remediation: |
           There is no remediation for updating the permissions of the kubeconfig file. The file is owned by an OpenShift operator and any changes to the file will result in a degraded cluster state.
           Please do not attempt to remediate the permissions of this file.
@@ -604,7 +604,7 @@ groups:
             pass "$check"
           else
             warn "$check"
-          fi      
+          fi
         remediation: No remediation required; file permissions are managed by the
           operator.
       - id: K.1.1.19
@@ -699,7 +699,7 @@ groups:
           else
             warn "$check"
             warn "     * $cert_path doesn't exist."
-          fi   
+          fi
         remediation: No remediation required; file permissions are managed by the
           operator.
       - id: K.1.1.21
@@ -772,7 +772,7 @@ groups:
             warn "$check"
           else
             pass "$check"
-          fi       
+          fi
         remediation: None. The default configuration should not be modified.
       - id: K.1.2.2
         description: Ensure that the --basic-auth-file argument is not set (Manual)
@@ -916,7 +916,7 @@ groups:
             pass "$check"
           else
             warn "$check"
-          fi   
+          fi
         remediation: No remediation is required. OpenShift platform components use
           X.509 certificates for authentication. OpenShift manages the CAs and certificates
           for platform components. This is not configurable.
@@ -942,7 +942,7 @@ groups:
             warn "$check"
           else
             pass "$check"
-          fi     
+          fi
         remediation: None. RBAC is always on and the OpenShift API server does not
           use the values assigned to the flag authorization-mode.
       - id: K.1.2.8
@@ -1056,7 +1056,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi     
+          fi
         remediation: None
       - id: K.1.2.13
         description: Ensure that the admission control plugin NamespaceLifecycle is
@@ -1078,7 +1078,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi 
+          fi
         remediation: None
       - id: K.1.2.14
         description: Ensure that the admission control plugin SecurityContextConstraint
@@ -1169,7 +1169,7 @@ groups:
             pass "$check"
           else
             warn "$check"
-          fi      
+          fi
         remediation: None
       - id: K.1.2.18
         description: Ensure that the --secure-port argument is not set to 0 (Manual)
@@ -1196,7 +1196,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi     
+          fi
         remediation: None
       - id: K.1.2.19
         description: Ensure that the healthz endpoint is protected by RBAC (Manual)
@@ -1281,7 +1281,7 @@ groups:
             pass "$check"
           else
             warn "$check"
-          fi   
+          fi
         remediation: None
       - id: K.1.2.23
         description: Ensure that the maximumFileSizeMegabytes argument is set to 100
@@ -1421,7 +1421,7 @@ groups:
             pass "$check"
           else
             warn "$check"
-          fi 
+          fi
         remediation: None
       - id: K.1.2.29
         description: Ensure that the --client-ca-file argument is set as appropriate
@@ -1465,7 +1465,7 @@ groups:
             warn "$check"
           else
             pass "$check"
-          fi     
+          fi
         remediation: None
       - id: K.1.2.31
         description: Ensure that encryption providers are appropriately configured
@@ -1601,7 +1601,7 @@ groups:
             pass "$check"
           else
             warn "$check"
-          fi    
+          fi
         remediation: None
       - id: K.1.3.4
         description: Ensure that the --root-ca-file argument is set as appropriate
@@ -1623,7 +1623,7 @@ groups:
             pass "$check"
           else
             warn "$check"
-          fi      
+          fi
         remediation: None
       - id: K.1.3.5
         description: Ensure that the --bind-address argument is set to 127.0.0.1 (Manual)
@@ -1648,7 +1648,7 @@ groups:
             pass "$check"
           else
             warn "$check"
-          fi 
+          fi
         remediation: None
   - id: 1.4
     title: 1.4 - Scheduler
@@ -1710,5 +1710,5 @@ groups:
           manual "     * Login$CLUSTER_ADMIN_TOKEN' -k"
           manual "     * Verify metrics output is returned. Unset environment variables used in the test and delete the test service account:"
           manual "     * unset CLUSTER_ADMIN_TOKEN POD PORT SA_TOKEN POD_IP"
-          manual "     * oc delete sa permission-test-sa"   
+          manual "     * oc delete sa permission-test-sa"
         remediation: None

--- a/agent/nvbench/ocp/rh-1.4.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/ocp/rh-1.4.0/worker/4_worker_nodes.yaml
@@ -22,7 +22,7 @@ groups:
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -50,7 +50,7 @@ groups:
           check="$id  - $description"
           file="/etc/systemd/system/kubelet.service"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -81,7 +81,7 @@ groups:
           manual "     * do"
           manual "     *     oc exec -n openshift-sdn $i -- stat -Lc %a /config/kube-proxy-config.yaml"
           manual "     * done"
-          manual "     * Verify that the kube-proxy-config.yaml file has permissions of 644."    
+          manual "     * Verify that the kube-proxy-config.yaml file has permissions of 644."
         remediation: None
       - id: K.4.1.4
         description: If proxy kubeconfig file exists ensure ownership is set to root:root
@@ -96,7 +96,7 @@ groups:
           PCI: []
           GDPR: []
         audit: |
-          check="$id  - $description"           
+          check="$id  - $description"
           manual "$check"
           manual "     * Run the following command:"
           manual "     * for i in \$(oc get pods -n openshift-sdn -l app=sdn -oname)"
@@ -121,7 +121,7 @@ groups:
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -131,7 +131,7 @@ groups:
           else
             info "$check"
             info "     * File not found"
-          fi   
+          fi
         remediation: None
       - id: K.4.1.6
         description: Ensure that the --kubeconfig kubelet.conf file ownership is set
@@ -149,7 +149,7 @@ groups:
           check="$id  - $description"
           file="/etc/kubernetes/kubelet.conf"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -176,7 +176,7 @@ groups:
           check="$id  - $description"
           file="/etc/kubernetes/kubelet-ca.crt"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 644 -o "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -204,7 +204,7 @@ groups:
           check="$id  - $description"
           file="/etc/kubernetes/kubelet-ca.crt"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -231,7 +231,7 @@ groups:
           check="$id  - $description"
           file="/var/lib/kubelet/config.json"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 ]; then
               pass "$check"
             else
@@ -259,7 +259,7 @@ groups:
           check="$id  - $description"
           file="/var/lib/kubelet/config.json"
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -370,7 +370,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi     
+          fi
         remediation: None. Changing the clientCAFile value is unsupported.
       - id: K.4.2.5
         description: Verify that the read only port is not used or is set to 0 (Automated)
@@ -392,7 +392,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi       
+          fi
         remediation: |
           In earlier versions of OpenShift 4, the read-only-port argument is not used.
           Follow the instructions in the documentation to create a kubeletconfig CRD and set the kubelet-read-only-port is set to 0.
@@ -492,7 +492,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi  
+          fi
         remediation: OpenShift automatically manages TLS authentication for the API
           server communication with the node/kublet. This is not configurable.
       - id: K.4.2.10
@@ -541,7 +541,7 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi     
+          fi
         remediation: None
       - id: K.4.2.12
         description: Ensure that the Kubelet only makes use of Strong Cryptographic

--- a/share/scan/testdata/mock-cis/master/1_control_plane_components.yaml
+++ b/share/scan/testdata/mock-cis/master/1_control_plane_components.yaml
@@ -49,7 +49,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -77,7 +77,7 @@ groups:
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-controller-manager.yaml")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -104,7 +104,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -132,7 +132,7 @@ groups:
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/kube-scheduler.yaml")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -159,7 +159,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -187,7 +187,7 @@ groups:
           check="$id  - $description"
           file=$(append_prefix "$CONFIG_PREFIX" "/etc/kubernetes/manifests/etcd.yaml")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -214,7 +214,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -291,7 +291,7 @@ groups:
             count_files=$((count_files + 1))
             permissions=$(stat -c %u%g $file)
 
-            # Check if the ownership is set to root:root 
+            # Check if the ownership is set to root:root
             if [ "$permissions" != "00" ]; then
               non_compliant_files="$non_compliant_files$file ($permissions), "
             fi

--- a/share/scan/testdata/mock-cis/worker/4_worker_nodes.yaml
+++ b/share/scan/testdata/mock-cis/worker/4_worker_nodes.yaml
@@ -29,7 +29,7 @@ groups:
               file=$kubeadm10
           fi
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -56,7 +56,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -87,7 +87,7 @@ groups:
               file=$(get_argument_value "$CIS_PROXY_CMD" '--kubeconfig'|cut -d " " -f 1)
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -97,7 +97,7 @@ groups:
           else
             info "$check"
             info "      * kubeconfig file not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chmod 600 <proxy kubeconfig file>
       - id: K.4.1.4
@@ -113,8 +113,8 @@ groups:
           PCI: []
           GDPR: []
         audit: |
-          check="$id  - $description"           
-          if [ -f "$file" ]; then
+          check="$id  - $description"
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -124,7 +124,7 @@ groups:
           else
             info "$check"
             info "      * kubeconfig file not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chown root:root <proxy kubeconfig
           file>
@@ -148,7 +148,7 @@ groups:
           fi
           file=$(append_prefix "$CONFIG_PREFIX" "$file")
 
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %a $file)" -eq 600 -o "$(stat -c %a $file)" -eq 400 ]; then
               pass "$check"
             else
@@ -158,7 +158,7 @@ groups:
           else
             warn "$check"
             warn "      * File not found"
-          fi        
+          fi
         remediation: Run the below command (based on the file location on your system)
           on the each worker node. For example, chmod 600 /etc/kubernetes/kubelet.conf
       - id: K.4.1.6
@@ -175,7 +175,7 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -f "$file" ]; then
+          if [ -e "$file" ]; then
             if [ "$(stat -c %u%g $file)" -eq 00 ]; then
               pass "$check"
             else
@@ -244,7 +244,7 @@ groups:
           else
             info "$check"
             info "      * --client-ca-file not set"
-          fi 
+          fi
         remediation: Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>
       - id: K.4.1.9
@@ -330,11 +330,11 @@ groups:
           fi
         remediation: |
           If using a Kubelet config file, edit the file to set authentication: anonymous: enabled to false.
-          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.        
+          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
           --anonymous-auth=false
-          Based on your system, restart the kubelet service. For example:   
-          systemctl daemon-reload 
-          systemctl restart kubelet.service                   
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.4.2.2
         description: Ensure that the --authorization-mode argument is not set to AlwaysAllow
           (Automated)
@@ -356,10 +356,10 @@ groups:
           fi
         remediation: |
           If using a Kubelet config file, edit the file to set authorization: mode to Webhook.
-          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.        
+          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
           --authorization-mode=Webhook
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.4.2.3
         description: Ensure that the --client-ca-file argument is set as appropriate
@@ -382,7 +382,7 @@ groups:
               pass "      * client-ca-file: $cafile"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to set authentication: x509: clientCAFile to the location of the client CA file.
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
@@ -413,7 +413,7 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to set readOnlyPort to 0.
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
@@ -438,13 +438,13 @@ groups:
               warn "      * streaming-connection-idle-timeout: $timeout"
           else
               pass "$check"
-          fi        
+          fi
         remediation: |
-          If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a value other than 0. 
+          If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a value other than 0.
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
           --streaming-connection-idle-timeout=5m
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.4.2.6
         description: Ensure that the --make-iptables-util-chains argument is set to
@@ -461,12 +461,12 @@ groups:
               pass "$check"
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
-          If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true. 
-          If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and remove the --mak-iptables-util-chains argument from the KUBELET_SYSTEM_PODS_ARGS variable. 
-          Based on your system, restart the kubelet service. For example:        
-          systemctl daemon-reload 
+          If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true.
+          If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and remove the --mak-iptables-util-chains argument from the KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
           systemctl restart kubelet.service
       - id: K.4.2.7
         description: Ensure that the --hostname-override argument is not set (Manual)
@@ -482,7 +482,7 @@ groups:
               warn "$check"
           else
               pass "$check"
-          fi        
+          fi
         remediation: 'Edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
           on each worker node and remove the --hostname-override argument from the
           KUBELET_SYSTEM_PODS_ARGS variable. Based on your system, restart the kubelet
@@ -509,7 +509,7 @@ groups:
           else
               warn "$check"
               warn "      * --event-qps is not set"
-          fi          
+          fi
         remediation: 'If using a Kubelet config file, edit the file to set eventRecordQPS:
           to an appropriate level. If using command line arguments, edit the kubelet
           service file /etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each
@@ -544,14 +544,14 @@ groups:
               fi
           else
               warn "$check"
-          fi        
+          fi
         remediation: |
-          If using a Kubelet config file, edit the file to set tlsCertFile to the location of the certificate file to use to identify this Kubelet, and tlsPrivateKeyFile to the location of the corresponding private key file. 
-          If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameters in KUBELET_CERTIFICATE_ARGS variable.  
-          --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key-file=<path/to/tls-key-file> 
+          If using a Kubelet config file, edit the file to set tlsCertFile to the location of the certificate file to use to identify this Kubelet, and tlsPrivateKeyFile to the location of the corresponding private key file.
+          If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
+          --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key-file=<path/to/tls-key-file>
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service                    
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.4.2.10
         description: Ensure that the --rotate-certificates argument is not set to
           false (Automated)
@@ -570,13 +570,13 @@ groups:
             warn "$check"
           else
             pass "$check"
-          fi    
+          fi
         remediation: |
           If using a Kubelet config file, edit the file to add the line rotateCertificates: true or remove it altogether to use the default value.
           If using command line arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and remove --rotat-certificates=false argument from the KUBELET_CERTIFICATE_ARGS variable.
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service 
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.4.2.11
         description: Verify that the RotateKubeletServerCertificate argument is set
           to true (Manual)
@@ -651,12 +651,12 @@ groups:
           fi
         remediation: |
           If using a Kubelet config file, edit the file to set TLSCipherSuites: to TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-          ,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256 or to a subset of these values.   
-          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the --tls-cipher-suites parameter as follows, or to a subset of these values.                 
+          ,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256 or to a subset of these values.
+          If using executable arguments, edit the kubelet service file /etc/kubernetes/kubelet.conf on each worker node and set the --tls-cipher-suites parameter as follows, or to a subset of these values.
           --tls-ciphe-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
           Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload 
-          systemctl restart kubelet.service     
+          systemctl daemon-reload
+          systemctl restart kubelet.service
       - id: K.4.2.13
         description: Ensure that a limit is set on pod PIDs (Manual)
         type: worker
@@ -668,7 +668,7 @@ groups:
         audit: |
           check="$id  - $description"
           manual "$check"
-          manual "      * Review the Kubelet's start-up parameters for the value of --pod-max-pids, and check the Kubelet configuration file for the PodPidsLimit . If neither of these values is set, then there is no limit in place."   
+          manual "      * Review the Kubelet's start-up parameters for the value of --pod-max-pids, and check the Kubelet configuration file for the PodPidsLimit . If neither of these values is set, then there is no limit in place."
         remediation: Decide on an appropriate level for this parameter and set it,
           either via the --pod-max-pids command line parameter or the PodPidsLimit
           configuration file setting.


### PR DESCRIPTION
### Summary

- Fixed CIS scan detection by replacing -f (regular file) with -e (exists) in file/directory exist checks.
- On RKE2 workers K.4.2.7, prepended the correct path prefix so the enforcer finds CIS YAMLs.