### PR TITLE
chore: bump toolchain to 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/neuvector/neuvector
 
 go 1.24.0
 
-toolchain go1.24.5
+toolchain go1.24.6
 
 replace (
 	github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.9.0


### PR DESCRIPTION
### Summary
- stdlib has cve in 1.24.5