### PR TITLE
fix: NVSHAS-10071 policy enforcement issue

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1222,6 +1222,14 @@ func fillContainerProperties(c *containerData, parent *containerData,
 			}
 			parent.hasDatapath = false
 		}
+
+		if Host.Platform == share.PlatformKubernetes {
+			if pct, secure := global.ORCH.GetPlatformRole(&info.ContainerMeta); pct != "" {
+				c.capBlock = secure
+			} else {
+				c.capBlock = true
+			}
+		}
 	}
 
 	c.cgroupMemory, _ = global.SYS.GetContainerCgroupPath(info.Pid, "memory")

--- a/agent/policy/process.go
+++ b/agent/policy/process.go
@@ -37,6 +37,7 @@ var k8sGrpProbe utils.Set = utils.NewSet()
 func (e *Engine) UpdateProcessPolicy(name string, profile *share.CLUSProcessProfile) (bool, *share.CLUSProcessProfile) {
 	e.Mutex.Lock()
 	defer e.Mutex.Unlock()
+
 	exist, ok := e.ProcessPolicy[name]
 	if !ok || !reflect.DeepEqual(exist, profile) {
 		e.ProcessPolicy[name] = profile
@@ -56,18 +57,7 @@ func (e *Engine) ObtainProcessPolicy(name, id string) (*share.CLUSProcessProfile
 	e.Mutex.Lock()
 	profile := e.ProcessPolicy[name]
 	e.Mutex.Unlock()
-	if profile == nil { // a temporary learned group
-		profile = &share.CLUSProcessProfile{
-			Group:    name,
-			Mode:     share.PolicyModeLearn,
-			Process:  make([]*share.CLUSProcessProfileEntry, 0),
-			CfgType:  share.Learned,
-			Baseline: share.ProfileBasic, // avoid false positive events
-		}
-		e.Mutex.Lock()
-		e.ProcessPolicy[name] = profile
-		e.Mutex.Unlock()
-	} else { // the process policy per group has been fetched
+	if profile != nil { // the process policy per group has been fetched
 		if grp_profile, ok := e.getGroupRule(id); ok {
 			if grp_profile == nil { // neuvector pods only
 				return profile, true
@@ -84,7 +74,9 @@ func (e *Engine) ObtainProcessPolicy(name, id string) (*share.CLUSProcessProfile
 			return grp_profile, true
 		}
 	}
-	return profile, true
+
+	// log.WithFields(log.Fields{"name": name}).Debug("GRP: process profile not ready")
+	return nil, false
 }
 
 func (e *Engine) IsK8sGroupWithProbe(name string) bool {

--- a/agent/policy/process.go
+++ b/agent/policy/process.go
@@ -55,6 +55,7 @@ func (e *Engine) UpdateProcessPolicy(name string, profile *share.CLUSProcessProf
 func (e *Engine) ObtainProcessPolicy(name, id string) (*share.CLUSProcessProfile, bool) {
 	e.Mutex.Lock()
 	profile := e.ProcessPolicy[name]
+	e.Mutex.Unlock()
 	if profile == nil { // a temporary learned group
 		profile = &share.CLUSProcessProfile{
 			Group:    name,
@@ -63,10 +64,10 @@ func (e *Engine) ObtainProcessPolicy(name, id string) (*share.CLUSProcessProfile
 			CfgType:  share.Learned,
 			Baseline: share.ProfileBasic, // avoid false positive events
 		}
+		e.Mutex.Lock()
 		e.ProcessPolicy[name] = profile
 		e.Mutex.Unlock()
 	} else { // the process policy per group has been fetched
-		e.Mutex.Unlock()
 		if grp_profile, ok := e.getGroupRule(id); ok {
 			if grp_profile == nil { // neuvector pods only
 				return profile, true

--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -795,7 +795,6 @@ func (p *Probe) evalNewRunningApp(pid int) {
 
 	if !ok || c == nil {
 		// disappeared, short-live application
-		mLog.WithFields(log.Fields{"proc": proc, "pid": pid}).Debug()
 		return
 	}
 
@@ -2496,15 +2495,8 @@ func (p *Probe) procProfileEval(id string, proc *procInternal, bKeepAlive bool) 
 	nShellCmd := p.isShellScript(id, proc)
 	mode, baseline, derivedGroup, svcGroup, allowSuspicious, err := p.procPolicyLookupFunc(id, proc.riskType, proc.pname, proc.ppath, proc.pid, proc.pgid, nShellCmd, pp)
 	if err != nil {
-		// add container task has not established yets
-		go func() {
-			time.Sleep(3 * time.Second)
-			if (proc.reported & profileReported) == 0 {
-				p.lockProcMux()
-				p.procProfileEval(id, proc, bKeepAlive)
-				p.unlockProcMux()
-			}
-		}()
+		// add conatiner task has not established yet
+		// log.WithFields(log.Fields{"name": proc.name, "error": err}).Debug("PROC:")
 		return share.PolicyActionAllow, false // assuming it is allowed so far
 	}
 
@@ -2609,7 +2601,7 @@ func (p *Probe) procProfileEval(id string, proc *procInternal, bKeepAlive bool) 
 	}
 
 	// multiple learn process event are okay because they are merged at controllers.
-	if derivedGroup != share.GroupNVProtect && pp.Action == share.PolicyActionLearn {
+	if pp.Action == share.PolicyActionLearn {
 		p.reportLearnProc(svcGroup, pp)
 	}
 

--- a/agent/system.go
+++ b/agent/system.go
@@ -655,10 +655,6 @@ func processPolicyLookup(id, riskType, pname, ppath string, pid, pgid, shellCmd 
 			ppe.Action = share.PolicyActionAllow // not recording
 		}
 
-		if bNeuvector {
-			group = share.GroupNVProtect // updated
-		}
-
 		switch ppe.Action {
 		case share.PolicyActionLearn:
 			if riskType != "" { // risky processs

--- a/controller/cache/profile.go
+++ b/controller/cache/profile.go
@@ -93,10 +93,6 @@ func handleProfileReport(gproc map[string][]*share.CLUSProcessProfileEntry) erro
 					return errors.New("fail to find group")
 				}
 			}
-			// not at the learning stage
-			if profile.Mode == share.PolicyModeEvaluate || profile.Mode == share.PolicyModeEnforce {
-				continue
-			}
 			for _, proc := range procs {
 				if proc.Action == share.PolicyActionLearn {
 					proc.Action = share.PolicyActionAllow


### PR DESCRIPTION
The process policy enforcement could fail due to a race condition when setting up the capability flag in per-container storage.

This PR fixes the issue by ensuring that the flag is setup without depending on its parent container. 