### PR TITLE
NVSHAS-10049: Follow up on the NV scan JFrog Subdomain mode issue

### DIFF
--- a/controller/rest/registry_kits.go
+++ b/controller/rest/registry_kits.go
@@ -320,7 +320,7 @@ func handlerRegistryTest(w http.ResponseWriter, r *http.Request, ps httprouter.P
 			if rconf.Filters != nil {
 				filters := rconf.Filters
 				sort.Slice(filters, func(i, j int) bool { return filters[i] < filters[j] })
-				rfilters, err := parseFilter(filters, config.Type)
+				rfilters, err := parseFilter(filters, config)
 				if err != nil {
 					restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrInvalidRequest, err.Error())
 					return

--- a/controller/rest/registry_test.go
+++ b/controller/rest/registry_test.go
@@ -85,7 +85,7 @@ func TestFilterPositive(t *testing.T) {
 	}
 
 	for k, v := range cases {
-		if f, err := parseFilter([]string{k}, share.RegistryTypeDocker); err != nil {
+		if f, err := parseFilter([]string{k}, share.CLUSRegistryConfig{Type: share.RegistryTypeDocker}); err != nil {
 			t.Errorf("Error: %v %v\n", k, err)
 		} else if *f[0] != v {
 			t.Errorf("Error: %v\n", k)
@@ -107,7 +107,7 @@ func TestFilterNegative(t *testing.T) {
 		"*neuvector/*:*",
 	}
 	for _, v := range cases {
-		if f, err := parseFilter([]string{v}, share.RegistryTypeDocker); err == nil {
+		if f, err := parseFilter([]string{v}, share.CLUSRegistryConfig{Type: share.RegistryTypeDocker}); err == nil {
 			t.Errorf("Error: %v\n", v)
 			t.Errorf("  Expect: invalid format\n")
 			t.Errorf("  Actual: %v\n", *f[0])
@@ -119,7 +119,7 @@ func TestFilterNegative(t *testing.T) {
 		"iperf",
 	}
 	for _, v := range cases {
-		if f, err := parseFilter([]string{v}, share.RegistryTypeOpenShift); err == nil {
+		if f, err := parseFilter([]string{v}, share.CLUSRegistryConfig{Type: share.RegistryTypeOpenShift}); err == nil {
 			t.Errorf("Error: %v\n", v)
 			t.Errorf("  Expect: invalid format\n")
 			t.Errorf("  Actual: %v\n", *f[0])


### PR DESCRIPTION
Solve the issue when the jfrog(subdomain mode) registry URL starts with tweaked-subdomain in the hostname.
Older NV versions worked well on this special env before NV supports newer versions of JFrog.
However, after NV started supporting newer versions of JFrog, NV doesn't work on this special env anymore.