### PR TITLE
feat: support reading go stdlib

### DIFF
--- a/share/scan/apps.go
+++ b/share/scan/apps.go
@@ -250,7 +250,7 @@ func (s *ScanApps) parseGolangPackage(filename, fullpath string) {
 	}
 	defer f.Close()
 
-	_, mod, err := readRawBuildInfo(f, false)
+	goVersion, mod, err := readRawBuildInfo(f, false)
 	if err != nil {
 		return
 	}
@@ -275,6 +275,18 @@ func (s *ScanApps) parseGolangPackage(filename, fullpath string) {
 		}
 		pkgs[i] = pkg
 	}
+
+	if goVersion != "" {
+		goVersion := strings.TrimPrefix(goVersion, "go")
+		stdLibPkg := AppPackage{
+			AppName:    golang,
+			ModuleName: "go:stdlib",
+			Version:    goVersion,
+			FileName:   filename,
+		}
+		pkgs = append(pkgs, stdLibPkg)
+	}
+
 	s.pkgs[filename] = pkgs
 }
 


### PR DESCRIPTION
### Summary
Previously, the scanner did not parse Go stdlib vulnerabilities. We have now added a basic stub (following Trivy’s implementation) to handle cases when a Go file is detected.