### PR TITLE
fix: update-upgrade-responder job triggered based on the parsed tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
         COMMIT_MESSAGE: "chore: update upgrade-responder.json"
         BRANCH_NAME_PREFIX: "auto-update/upgrade-responder-"
         GIT_PATH_EXTERNAL_PROD: "external-production/"
-      if: ${{ needs.parse_tag.outputs.parsed_tag != '' }} 
+      if: ${{ needs.publish.outputs.parsed_tag != '' }}
       steps:
         - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 


### PR DESCRIPTION
After the last release: https://github.com/neuvector/neuvector/actions/runs/18658307700/

The job `update-upgrade-responder` was skipped because a bug on the if condition: https://github.com/neuvector/neuvector/blob/f03ceec7f33193b0c22ac7a91d3f90990e5d9142/.github/workflows/release.yml#L123

It was not pointing to the job output, as was suppose to do.

Now the `upgrade-responder.json` should be generated and a PR created