### PR TITLE
add category to webhook json output

### DIFF
--- a/controller/common/output.go
+++ b/controller/common/output.go
@@ -382,7 +382,7 @@ func (w *Webhook) Notify(elog interface{}, level, category, cluster, title, comm
 			ctype = ctypeJSON
 			var extra string
 			if comment != "" {
-				extra = fmt.Sprintf("{\"cluster\":\"%s\",\"category\":\"%s\",\"comment\":\"%s\",", cluster, comment, category)
+				extra = fmt.Sprintf("{\"cluster\":\"%s\",\"category\":\"%s\",\"comment\":\"%s\",", cluster, category, comment)
 			} else {
 				extra = fmt.Sprintf("{\"cluster\":\"%s\",\"category\":\"%s\",", cluster, category)
 			}


### PR DESCRIPTION
Add the alert category into the Webhook JSON output to match what Slack and Teams get (by way of formatted payload). The assumption (my assumption at least) is that a Violation is a process violation and an Incident is a network violation. Having category in the JSON output will allow logic from a receiving webhook to determine what template or output is necessary to match the data in the JSON output based on the category type. 