### PR TITLE
NVSHAS-10198: cannot add/edit user-created process profile rule in CRD group

### DIFF
--- a/controller/rest/file_monitor.go
+++ b/controller/rest/file_monitor.go
@@ -197,8 +197,9 @@ func handlerFileMonitorConfig(w http.ResponseWriter, r *http.Request, ps httprou
 	profConf, profRev := clusHelper.GetFileMonitorProfile(group)
 	ruleConf, ruleRev := clusHelper.GetFileAccessRule(group)
 
-	if profConf != nil && profConf.CfgType == share.GroundCfg {
-		restRespError(w, http.StatusBadRequest, api.RESTErrOpNotAllowed)
+	if profConf == nil || ruleConf == nil {
+		log.WithFields(log.Fields{"group": group, "profConf": profConf, "ruleConf": ruleConf}).Error("Get profile from cluster failed")
+		restRespError(w, http.StatusInternalServerError, api.RESTErrObjectNotFound)
 		return
 	}
 

--- a/controller/rest/process.go
+++ b/controller/rest/process.go
@@ -282,11 +282,6 @@ func handlerProcessProfileConfig(w http.ResponseWriter, r *http.Request, ps http
 		return
 	}
 
-	if profile.CfgType == share.GroundCfg {
-		restRespError(w, http.StatusBadRequest, api.RESTErrOpNotAllowed)
-		return
-	}
-
 	// --
 	if conf.HashEnable != nil {
 		profile.HashEnable = *conf.HashEnable


### PR DESCRIPTION
In NV 5.4.7, user-created process profile/file monitor rule in CRD group can still be added/edited thru REST API.
This PR is to have the same behavior as in NV 5.4.7