### PR TITLE
fix: remove empty items for audit in support bundle

### DIFF
--- a/agent/task.go
+++ b/agent/task.go
@@ -468,6 +468,10 @@ func logContainerAudit(name, id string, items []share.CLUSAuditBenchItem, lid sh
 }
 
 func logHostAudit(items []share.CLUSAuditBenchItem, auditId share.TLogAudit) {
+	if len(items) == 0 {
+		return
+	}
+
 	alog := &share.CLUSAuditLog{
 		ID:         auditId,
 		HostID:     Host.ID,


### PR DESCRIPTION
### Root Cause
- we were producing empty host audit logs (no items) that got included in the support bundle, adding noise. With this guard, only meaningful audit logs are cached/emitted.

### Change
- skip logging when `items` is empty (`len(items)==0`).