### PR TITLE
feat: add new get api /v1/scan/repository/status to check if the image has scanned or not

### DIFF
--- a/controller/access/access.go
+++ b/controller/access/access.go
@@ -771,6 +771,7 @@ func CompileUriPermitsMapping() {
 				"v1/scan/sigstore/root_of_trust/*",
 				"v1/scan/sigstore/root_of_trust/*/verifier",
 				"v1/scan/sigstore/root_of_trust/*/verifier/*",
+				"v1/scan/repository/status",
 			},
 			CONST_API_INFRA: {
 				"v1/host",

--- a/controller/access/access_test.go
+++ b/controller/access/access_test.go
@@ -1207,6 +1207,7 @@ func TestCompileApiUrisMappingMapping(t *testing.T) {
 			"v1/scan/sigstore/root_of_trust/*",
 			"v1/scan/sigstore/root_of_trust/*/verifier",
 			"v1/scan/sigstore/root_of_trust/*/verifier/*",
+			"v1/scan/repository/status",
 		},
 		CONST_API_INFRA: {
 			"v1/host",

--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -2620,6 +2620,15 @@ type RESTScanRepoSubmitData struct {
 	Result *share.ScanResult `json:"result"`
 }
 
+type RESTScanRepoStatusReq struct {
+	Registry *string          `json:"registry"`
+	Request  *RESTScanRepoReq `json:"request"`
+}
+
+type RESTScanRepoStatusData struct {
+	Scanned bool                            `json:"scanned"`
+	Summary *share.CLUSRegistryImageSummary `json:"summary"`
+}
 type RESTScanAppPackage struct {
 	AppName    string `json:"app_name"`
 	ModuleName string `json:"module_name"`

--- a/controller/api/apis.yaml
+++ b/controller/api/apis.yaml
@@ -2946,6 +2946,31 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/RESTScanRepoReportData'
+  /v1/scan/repository/status:
+    get:
+      tags:
+        - Scan
+      summary: Check repository scan status
+      description: Check if a repository image has been scanned by registry, repository, and tag
+      security:
+        - ApiKeyAuth: []
+        - TokenAuth: []
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Repository scan status request
+          required: true
+          schema:
+            $ref: '#/definitions/RESTScanRepoStatusReq'
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/RESTScanRepoStatusData'
   /v1/scan/status:
     get:
       tags:
@@ -9361,7 +9386,7 @@ definitions:
       - config
     properties:
       config:
-        $ref: '#/definitions/RESTScanConfig'        
+        $ref: '#/definitions/RESTScanConfig'
   RESTScanImageSummaryData:
     type: object
     required:
@@ -9506,7 +9531,7 @@ definitions:
         example: openssl
       file:
         type: string
-        example: example.jar 
+        example: example.jar
       version:
         type: string
         example: "1.011"
@@ -9867,6 +9892,18 @@ definitions:
     properties:
       request:
         $ref: '#/definitions/RESTScanRepoReq'
+  RESTScanRepoStatusReq:
+    type: object
+    required:
+      - request
+    properties:
+      registry:
+        type: string
+        description: Optional. For registry scans, set this to the registry name as configured in the NeuVector Registry UI; otherwise the default registry is used. For CI scan results, leave this empty or omit it.
+        example: "registry.hub.docker.com"
+      request:
+        $ref: '#/definitions/RESTScanRepoReq'
+        description: Repository scan request details
   RESTScanSchedule:
     type: object
     required:
@@ -10074,6 +10111,135 @@ definitions:
     properties:
       status:
         $ref: '#/definitions/RESTScanStatus'
+  RESTScanRepoStatusData:
+    type: object
+    required:
+      - scanned
+    properties:
+      scanned:
+        type: boolean
+        description: Whether the repository image has been scanned
+        example: true
+      summary:
+        $ref: '#/definitions/RESTCLUSRegistryImageSummary'
+        nullable: true
+        description: Registry image summary. Null if the image has not been scanned.
+  RESTCLUSImage:
+    type: object
+    properties:
+      domain:
+        type: string
+        example: ""
+      repo:
+        type: string
+        example: "library/redis"
+      tag:
+        type: string
+        example: "latest"
+      reg_mod:
+        type: string
+        example: ""
+  RESTCLUSRegistryImageSummary:
+    type: object
+    properties:
+      image_id:
+        type: string
+        description: Image ID (Docker config digest)
+        example: "sha256:63e868dc880e93d92619b88395d578ea5ab37f15f873ecf4dc58aac7666582c8"
+      registry:
+        type: string
+        description: Registry URL
+        example: "https://registry.hub.docker.com/"
+      reg_name:
+        type: string
+        description: Registry name
+        example: "repo_scan"
+      repo_tag:
+        type: array
+        description: List of repository images
+        items:
+          $ref: '#/definitions/RESTCLUSImage'
+      digest:
+        type: string
+        description: Image digest
+        example: "sha256:bd8ffa77cf1c910b7a90935ca4828472e1c3e303e7cd5260f13d1e09995f173a"
+      scanned_at:
+        type: string
+        format: date-time
+        description: When the image was scanned
+        example: "2024-01-15T10:00:00Z"
+      created_at:
+        type: string
+        format: date-time
+        description: When the image was created
+        example: "2024-01-15T10:00:00Z"
+      base_os:
+        type: string
+        description: Base operating system
+        example: "alpine:3.18"
+      version:
+        type: string
+        description: CVE database version
+        example: "1.0"
+      result:
+        type: integer
+        format: int32
+        description: Scan error code (0 = success)
+        example: 0
+      status:
+        type: string
+        description: Scan status
+        example: "finished"
+      author:
+        type: string
+        description: Image author
+        example: ""
+      run_as_root:
+        type: boolean
+        description: Whether the image runs as root
+        example: false
+      signed:
+        type: boolean
+        description: Whether the image is signed
+        example: false
+      scan_flags:
+        type: integer
+        format: uint32
+        description: Scan flags (bitmask)
+        example: 1
+      provider:
+        type: integer
+        format: int32
+        description: Scan provider (0 = Neuvector, 1 = JFrogXray)
+        example: 0
+      size:
+        type: integer
+        format: int64
+        description: Image size in bytes
+        example: 123456789
+      verifiers:
+        type: array
+        description: List of signature verifiers
+        items:
+          type: string
+        example: []
+      signature_digest:
+        type: string
+        description: Signature digest
+        example: ""
+      sigstore_timestamp:
+        type: string
+        description: Sigstore timestamp
+        example: ""
+      signature_result:
+        type: integer
+        format: int32
+        description: Signature verification error code
+        example: 0
+      signature_status:
+        type: string
+        description: Signature verification status
+        example: ""
   RESTScanCacheStat:
     type: object
     required:
@@ -12197,7 +12363,7 @@ definitions:
         example: "The setup_env function in group.c in sshd in OpenSSH allows local users to gain privileges."
       file_name:
         type: string
-        example: "usr/lib/python3.9" 
+        example: "usr/lib/python3.9"
       package_name:
         type: string
         example: openssh

--- a/controller/rest/rest.go
+++ b/controller/rest/rest.go
@@ -1848,8 +1848,9 @@ func StartRESTServer(isNewCluster, isLead bool, maxConcurrentRepoScanTasks, scan
 	r.POST("/v1/scan/platform/platform", handlerScanPlatformReq)
 	r.GET("/v1/scan/platform", handlerScanPlatformSummary)
 	r.GET("/v1/scan/platform/platform", handlerScanPlatformReport)
-	r.POST("/v1/scan/result/repository", handlerScanRepositorySubmit) // Used by CI-integration, for scanner submit scan result. Skip API
-	r.POST("/v1/scan/repository", handlerScanRepositoryReq)           // Used by CI-integration, for scanning container image
+	r.POST("/v1/scan/result/repository", handlerScanRepositorySubmit)    // Used by CI-integration, for scanner submit scan result. Skip API
+	r.POST("/v1/scan/repository", handlerScanRepositoryReq)              // Used by CI-integration, for scanning container image
+	r.GET("/v1/scan/repository/status", handleCheckRepositoryScanStatus) // Used to check the repository scan status by registry/repository/tag
 	r.POST("/v1/scan/registry", handlerRegistryCreate)
 	r.POST("/v2/scan/registry", handlerRegistryCreate)
 	r.PATCH("/v1/scan/registry/:name", handlerRegistryConfig)


### PR DESCRIPTION
### What changes
- Create a new get api, support both CI scan / registry scan
- Update the api swagger doc

### Example usage
- CI scan
```bash
curl -k -X GET 'https://{controller-api-endpoint}/v1/scan/repository/status' \
  -H 'Content-Type: application/json' \
  -H 'X-Auth-Apikey: xxxx' \
  -d '{
    "request": {
      "registry": "https://registry.hub.docker.com/",
      "repository": "hhcs9527/controller",
      "tag": "t"
    }
  }'
{"scanned":true,"summary":{"author":"","base_os":"sles:15.7","created_at":"2025-12-16T15:32:46Z","digest":"sha256:f038759050b25ba2e1c603e7586fb34bd864c0db9b5886ac52a5cd49e55b0e12","image_id":"54fcaa5c8cb0a99c5cf46586ce58d83a4565a22fd1d8a67dfedd9a75c3d3fe7b","provider":0,"reg_name":"_repo_scan","registry":"https://registry.hub.docker.com/","repo_tag":[{"domain":"","reg_mod":"","repo":"https://registry.hub.docker.com/:hhcs9527/controller","tag":"t"}],"result":0,"run_as_root":true,"scan_flags":5,"scanned_at":"2026-01-16T04:20:45.711760356Z","signature_digest":"","signature_result":0,"signature_status":"","signed":false,"sigstore_timestamp":"","size":0,"status":"finished","verifiers":null,"version":"4.043"}}
```

- registry, needs to add the registry set up name in nv
```bash
curl -k -X GET 'https://{controller-api-endpoint}/v1/scan/repository/status' \
  -H 'Content-Type: application/json' \
  -H 'X-Auth-Apikey: xxx' \
  -d '{
    "registry": "test",
    "request": {
      "registry": "https://registry.hub.docker.com/",
      "repository": "nginx",
      "tag": "latest"
    }
  }'
{"scanned":true,"summary":{"author":"","base_os":"debian:13","created_at":"2026-01-13T01:22:57.074358457Z","digest":"sha256:617fef3c6adb90788d06f7ebe634fe990a6cd1e63c815facaf5fcaf3fa1ea003","image_id":"4af177a024eb8a1e43f4fb6c66735bb8260115cb5925a64f51673219bd97c144","provider":0,"reg_name":"test","registry":"https://registry.hub.docker.com/","repo_tag":[{"domain":"","reg_mod":"","repo":"library/nginx","tag":"latest"}],"result":0,"run_as_root":true,"scan_flags":5,"scanned_at":"2026-01-16T07:08:20.217305382Z","signature_digest":"","signature_result":0,"signature_status":"finished","signed":false,"sigstore_timestamp":"","size":160622448,"status":"finished","verifiers":null,"version":"4.043"}}
```