### PR TITLE
Integrate GitHub App token in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/create-github-app-token@v2
+      id: app-token
+      with:
+        app-id: ${{ secrets.NEUVECTOR_RELEASE_APP_ID }}
+        private-key: ${{ secrets.NEUVECTOR_RELEASE_PRIVATE_KEY }}
     - name: Load Secrets from Vault
       uses: rancher-eio/read-vault-secrets@main
       with:
@@ -63,7 +68,7 @@ jobs:
 
     - name: Get controller
       env:
-        GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         gh release download ${{ github.ref_name }} -D controller/ -p controller-amd64 -R ${{ github.repository_owner }}/neuvector-private
         gh release download ${{ github.ref_name }} -D controller/ -p controller-arm64 -R ${{ github.repository_owner }}/neuvector-private


### PR DESCRIPTION
The current access token used generate 401 issues.
We are adding a GitHub App token creation step for authentication.