### PR TITLE
fix: add task count to avoid the autoscale down the scanner replica number

### DIFF
--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -1791,7 +1791,7 @@ func startWorkerThread(ctx *Context) {
 					cacheMutexRUnlock()
 
 					taskCount := scan.RegTaskCount()
-					taskCount = taskCount + scanScher.TaskCount()
+					taskCount = taskCount + scanScher.TaskCount() + rpc.ScannerAcquisitionMgr.TaskCount()
 					replicas := atomic.LoadUint32(&scannerReplicas)
 					if (autoscaleCfg.Strategy != api.AutoScaleImmediate && autoscaleCfg.Strategy != api.AutoScaleDelayed) || (replicas == 0) ||
 						(replicas <= autoscaleCfg.MinPods && taskCount == 0) || (replicas >= autoscaleCfg.MaxPods && taskCount > 0) {

--- a/controller/kv/helper.go
+++ b/controller/kv/helper.go
@@ -1776,10 +1776,7 @@ func (m clusterHelper) ReleaseScanCredit(scannerId string, releaseCredit int) er
 
 func (m clusterHelper) InitCreditOwners() error {
 	key := share.CLUSScannerCreditOwnerKey(m.id)
-
-	return RetryOnCASError(m.maxScanCreditRetries, func() error {
-		return cluster.PutRev(key, []byte("{}"), 0)
-	})
+	return cluster.Put(key, []byte("{}"))
 }
 
 // TrackCreditAcquisition records or removes a controller's ownership of scanner credits.

--- a/controller/rpc/scanner.go
+++ b/controller/rpc/scanner.go
@@ -116,7 +116,7 @@ func (mgr *ScannerAcquisitionManager) requestProcessLoop() {
 		}
 		scanner, err := mgr.clusterHelper.PickLeastLoadedScanner()
 
-		if err != nil {
+		if err != nil || scanner == nil {
 			// Retry - add backoff and keep it in queue for next iteration
 			req.attempts++
 			time.Sleep(req.backoff.NextBackOff())
@@ -234,6 +234,14 @@ func (mgr *ScannerAcquisitionManager) CountScanners() (busy, idle uint32) {
 		}
 	}
 	return busy, idle
+}
+
+func (mgr *ScannerAcquisitionManager) TaskCount() int {
+	taskCount := 0
+	for _, scanner := range mgr.clusterHelper.GetAvailableScanners() {
+		taskCount += (mgr.maxConcurrentScansPerScanner - scanner.ScanCredit)
+	}
+	return taskCount
 }
 
 // This function performs a task on all scanners.


### PR DESCRIPTION
### Problem
- Autoscale task count is incomplete — it does not account for tasks tracked by ScannerAcquisitionMgr, causing premature scale-down and RPC failures.
- Ensure the ownership with no CAS

### Solution
Add rpc.ScannerAcquisitionMgr.TaskCount() to the total task count.