### PR TITLE
fix: add AddPkgs for bitnami vuls support

### DIFF
--- a/share/scan/apps.go
+++ b/share/scan/apps.go
@@ -175,6 +175,12 @@ func (s *ScanApps) marshal() []byte {
 	return buf.Bytes()
 }
 
+func (s *ScanApps) AddPkgs(pkgs []AppPackage) {
+	for _, pkg := range pkgs {
+		s.pkgs[pkg.FileName] = append(s.pkgs[pkg.FileName], pkg)
+	}
+}
+
 func (s *ScanApps) ExtractAppPkg(filename, fullpath string) {
 	if _, ok := s.pkgs[filename]; ok && !s.replace {
 		return


### PR DESCRIPTION
### Problem
Bitnami vulnerability parsing needs package metadata (`AddPkgs`), but we currently handle this via hard-coded logic. This PR adds a proper helper to populate `AddPkgs` so Bitnami vulnerability data can be parsed consistently.

### What changed
- Introduced a helper to build/populate `AddPkgs` instead of relying on hard-coded handling.
- Updated the Bitnami vuln parsing path to use the new helper.