### PR TITLE
fix: controller does not return rpc void cause the register stream fail

### DIFF
--- a/controller/grpc.go
+++ b/controller/grpc.go
@@ -149,7 +149,13 @@ func (ss *ScanService) ScannerRegisterStream(stream share.ControllerScanService_
 		}
 	}
 
-	return ss.scannerRegister(data)
+	if data == nil {
+		return status.Error(codes.Aborted, "empty scanner registration stream")
+	}
+	if err := ss.scannerRegister(data); err != nil {
+		return err
+	}
+	return stream.SendAndClose(&share.RPCVoid{})
 }
 
 func (ss *ScanService) ScannerRegister(ctx context.Context, data *share.ScannerRegisterData) (*share.RPCVoid, error) {


### PR DESCRIPTION
## Description
Controller does not return rpc void cause the register stream fail with following errors
```
2026-03-24T08:18:07.297|WARN|SCN|main.scannerRegisterStream: Ignore stream close compatibility error - error=rpc error: code = Internal desc = cardinality violation: received no response message from non-server-streaming RPC {code}
```

## Solution
- Add send and close in controller, ensure the client get the right response.
- Add error check on scanner side for backward compatible.

## Additional Information

### Special notes for your reviewer
- It cause the scanner daily build slows down 2x times.
- Error comes from https://github.com/grpc/grpc-go/blob/52bf4d9ecf923c7fdecd8c3985966e96353fa721/stream.go#L1189, related PR https://github.com/grpc/grpc-go/commit/39400b925537bd75655274a1f68a34928c8603ad
- Related Scanner PR https://github.com/neuvector/scanner/pull/338
