### PR TITLE
issue-2255: Unable to scan image registry by API(v1/scan/repository) with proxy enabled through curl

### DIFF
--- a/controller/api/apis.go
+++ b/controller/api/apis.go
@@ -2651,14 +2651,15 @@ type RESTScanMeta struct {
 }
 
 type RESTScanRepoReq struct {
-	Metadata   RESTScanMeta `json:"metadata"`
-	Registry   string       `json:"registry"`
-	Username   string       `json:"username,omitempty"`
-	Password   string       `json:"password,omitempty"`
-	Repository string       `json:"repository"`
-	Tag        string       `json:"tag"`
-	ScanLayers bool         `json:"scan_layers"`
-	BaseImage  string       `json:"base_image"`
+	Metadata    RESTScanMeta `json:"metadata"`
+	Registry    string       `json:"registry"`
+	Username    string       `json:"username,omitempty"`
+	Password    string       `json:"password,omitempty"`
+	Repository  string       `json:"repository"`
+	Tag         string       `json:"tag"`
+	ScanLayers  bool         `json:"scan_layers"`
+	BaseImage   string       `json:"base_image"`
+	IgnoreProxy *bool        `json:"ignore_proxy,omitempty"`
 }
 
 type RESTScanRepoReqData struct {

--- a/controller/api/apis.yaml
+++ b/controller/api/apis.yaml
@@ -10089,6 +10089,9 @@ definitions:
       base_image:
         type: string
         example: alpine
+      ignore_proxy:
+        type: boolean
+        example: true
   RESTScanRepoReqData:
     type: object
     required:

--- a/controller/rest/repository.go
+++ b/controller/rest/repository.go
@@ -99,7 +99,8 @@ func (r *repoScanTask) Run(arg interface{}) (interface{}, *JobError) {
 	var err error
 
 	// Determine if a proxy is needed based on the registry
-	if req.Registry != "" {
+	ignoreProxySetting := req.IgnoreProxy != nil && *req.IgnoreProxy
+	if req.Registry != "" && !ignoreProxySetting {
 		proxy = scan.GetProxy(req.Registry)
 	}
 


### PR DESCRIPTION
2255

## Description

When proxy setting is configured for https in NV, there is no way to ignore it for repository scan POST(/v1/scan/repository)

## Solution

Add an optional boolean field in request payload of API POST(/v1/scan/repository) to ignore proxy setting (it overrides the proxy settings configured in NV)
