### PR TITLE
feat: implement govulncheck for neuvector repos

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,35 @@
+name: govulncheck
+on:
+  push:
+    paths:
+      - go.sum
+      - go.mod
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install Golang
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+          check-latest: true # Always check for the latest patch release
+      - name: Install dependencies
+        run: |
+          sudo apt update && sudo apt install -y libpcre3-dev
+      - name: Run govulncheck
+        env:
+          GOVULNCHECK_VERSION: d1f380186385b4f64e00313f31743df8e4b89a77 # v1.1.4
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@${{ env.GOVULNCHECK_VERSION }}
+          govulncheck -C . -format text ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/neuvector/neuvector
 
-go 1.25.0
+go 1.26.2
 
 replace (
 	github.com/fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.9.0

--- a/package/Dockerfile.controller
+++ b/package/Dockerfile.controller
@@ -1,7 +1,7 @@
 #
 # Builder
 #
-FROM registry.suse.com/bci/golang:1.25 AS builder
+FROM registry.suse.com/bci/golang:1.26.2 AS builder
 
 ARG VERSION
 

--- a/package/Dockerfile.enforcer
+++ b/package/Dockerfile.enforcer
@@ -1,7 +1,7 @@
 #
 # Builder
 #
-FROM registry.suse.com/bci/golang:1.25 AS builder
+FROM registry.suse.com/bci/golang:1.26.2 AS builder
 
 ARG VERSION
 ARG TARGETOS


### PR DESCRIPTION
## Description

This PR implements govulncheck workflow and updates go version specified in go.mod to 1.26.2.

The successful run: https://github.com/holyspectral/neuvector/actions/runs/24579130330/job/71872124193

Note: please don't merge this until scanner is also updated, otherwise scanner build could fail. 

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

### Special notes for your reviewer

<!-- Please describe, if any special design or notes you want to share with your reviewer in this pull request -->

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
