### PR TITLE
fix: support automate module name

### DIFF
--- a/share/scan/apps.go
+++ b/share/scan/apps.go
@@ -234,6 +234,16 @@ func (s *ScanApps) DerivePkg(data map[string][]byte) []AppPackage {
 	return pkgs
 }
 
+// cutLast cuts s at the last occurrence of sep.
+// This function will be replaced by strings.CutLast once it's available in Go stdlib.
+// See: https://github.com/golang/go/issues/46336
+func cutLast(s, sep string) (first, last string, ok bool) {
+	if i := strings.LastIndex(s, sep); i > 0 {
+		return s[:i], s[i+len(sep):], true
+	}
+	return "", "", false
+}
+
 func isExe(info os.FileInfo) bool {
 	return info.Mode().IsRegular() && (info.Mode()&0111) != 0
 }
@@ -414,9 +424,9 @@ func parseJarManifestFile(path string, rc io.Reader) (*AppPackage, error) {
 			vendorId = "org.postgresql"
 			title = "postgresql"
 		} else if isUnresolvedField(vendorId) || isUnresolvedField(title) {
-			if dot := strings.LastIndex(symName, "."); dot > 0 {
-				vendorId = symName[:dot]
-				title = symName[dot+1:]
+			if first, last, ok := cutLast(symName, "."); ok {
+				vendorId = first
+				title = last
 			}
 		}
 	}

--- a/share/scan/apps.go
+++ b/share/scan/apps.go
@@ -49,6 +49,7 @@ const (
 	javaMnfstBundleVersion = "Bundle-Version:"
 	javaMnfstBundleSymName = "Bundle-SymbolicName:"
 	javaMnfstBundleName    = "Bundle-Name:"
+	javaMnfstAutoModName   = "Automatic-Module-Name:"
 
 	python            = "python"
 	ruby              = "ruby"
@@ -341,8 +342,12 @@ func IsJava(filename string) bool {
 		strings.HasSuffix(filename, ".ear")
 }
 
+func isUnresolvedField(s string) bool {
+	return len(s) == 0 || s[0] == '%'
+}
+
 func parseJarManifestFile(path string, rc io.Reader) (*AppPackage, error) {
-	var vendorId, version, title, symName string
+	var vendorId, version, title, symName, autoModName string
 	var vendorSet, titleSet bool
 	var lineCount int
 
@@ -386,6 +391,8 @@ func parseJarManifestFile(path string, rc io.Reader) (*AppPackage, error) {
 				title = strings.TrimSpace(strings.TrimPrefix(line, javaMnfstBundleName))
 				title = strings.Split(title, ";")[0]
 			}
+		case strings.HasPrefix(line, javaMnfstAutoModName):
+			autoModName = strings.TrimSpace(strings.TrimPrefix(line, javaMnfstAutoModName))
 		}
 
 		if len(version) > 0 && titleSet && vendorSet {
@@ -406,7 +413,7 @@ func parseJarManifestFile(path string, rc io.Reader) (*AppPackage, error) {
 			// NVSHAS-8757
 			vendorId = "org.postgresql"
 			title = "postgresql"
-		} else if len(vendorId) == 0 || vendorId[0] == '%' || len(title) == 0 || title[0] == '%' {
+		} else if isUnresolvedField(vendorId) || isUnresolvedField(title) {
 			if dot := strings.LastIndex(symName, "."); dot > 0 {
 				vendorId = symName[:dot]
 				title = symName[dot+1:]
@@ -414,8 +421,16 @@ func parseJarManifestFile(path string, rc io.Reader) (*AppPackage, error) {
 		}
 	}
 
-	if len(vendorId) == 0 || vendorId[0] == '%' {
-		vendorId = "jar"
+	if isUnresolvedField(vendorId) {
+		switch {
+		case autoModName == "spring.boot":
+			// spring.boot maps to org.springframework.boot in the DB
+			vendorId = "org.springframework.boot"
+		case autoModName != "":
+			vendorId = autoModName
+		default:
+			vendorId = "jar"
+		}
 	}
 
 	// NVSHAS-9942

--- a/share/scan/apps_test.go
+++ b/share/scan/apps_test.go
@@ -426,6 +426,123 @@ func TestParseDotNetPackage(t *testing.T) {
 	}
 }
 
+func TestCutLast(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		sep       string
+		wantFirst string
+		wantLast  string
+		wantOk    bool
+	}{
+		{
+			name:      "normal case with multiple dots",
+			input:     "org.apache.tomcat",
+			sep:       ".",
+			wantFirst: "org.apache",
+			wantLast:  "tomcat",
+			wantOk:    true,
+		},
+		{
+			name:      "single dot in middle",
+			input:     "a.b",
+			sep:       ".",
+			wantFirst: "a",
+			wantLast:  "b",
+			wantOk:    true,
+		},
+		{
+			name:      "no dot",
+			input:     "nodot",
+			sep:       ".",
+			wantFirst: "",
+			wantLast:  "",
+			wantOk:    false,
+		},
+		{
+			name:      "dot at beginning",
+			input:     ".startdot",
+			sep:       ".",
+			wantFirst: "",
+			wantLast:  "",
+			wantOk:    false,
+		},
+		{
+			name:      "dot at end",
+			input:     "enddot.",
+			sep:       ".",
+			wantFirst: "enddot",
+			wantLast:  "",
+			wantOk:    true,
+		},
+		{
+			name:      "multiple consecutive dots",
+			input:     "a..b",
+			sep:       ".",
+			wantFirst: "a.",
+			wantLast:  "b",
+			wantOk:    true,
+		},
+		{
+			name:      "empty string",
+			input:     "",
+			sep:       ".",
+			wantFirst: "",
+			wantLast:  "",
+			wantOk:    false,
+		},
+		{
+			name:      "single dot only",
+			input:     ".",
+			sep:       ".",
+			wantFirst: "",
+			wantLast:  "",
+			wantOk:    false,
+		},
+		{
+			name:      "real package name",
+			input:     "org.springframework.boot",
+			sep:       ".",
+			wantFirst: "org.springframework",
+			wantLast:  "boot",
+			wantOk:    true,
+		},
+		{
+			name:      "single character before and after",
+			input:     "x.y",
+			sep:       ".",
+			wantFirst: "x",
+			wantLast:  "y",
+			wantOk:    true,
+		},
+		{
+			name:      "multi-char separator",
+			input:     "a::b::c",
+			sep:       "::",
+			wantFirst: "a::b",
+			wantLast:  "c",
+			wantOk:    true,
+		},
+		{
+			name:      "different separator - slash",
+			input:     "path/to/file",
+			sep:       "/",
+			wantFirst: "path/to",
+			wantLast:  "file",
+			wantOk:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFirst, gotLast, gotOk := cutLast(tt.input, tt.sep)
+			assert.Equal(t, tt.wantFirst, gotFirst, "first part mismatch")
+			assert.Equal(t, tt.wantLast, gotLast, "last part mismatch")
+			assert.Equal(t, tt.wantOk, gotOk, "ok flag mismatch")
+		})
+	}
+}
+
 func TestParseDotNetPackageWithoutScanRuntime(t *testing.T) {
 	filename := "test.deps.json"
 	fullpath := "/home/test.deps.json"

--- a/share/scan/apps_test.go
+++ b/share/scan/apps_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParsePythonPackage(t *testing.T) {
@@ -206,8 +207,15 @@ func TestParseRubyPackage(t *testing.T) {
 }
 
 func TestParseJarPackage(t *testing.T) {
-	// NVSHAS-8757
-	m := `
+	tests := []struct {
+		name       string
+		manifest   string
+		moduleName string
+		version    string
+	}{
+		{
+			name: "NVSHAS-8757 postgresql",
+			manifest: `
 Manifest-Version: 1.0
 Automatic-Module-Name: org.postgresql.jdbc
 Bundle-Activator: org.postgresql.osgi.PGBundleActivator
@@ -221,14 +229,13 @@ Bundle-Name: PostgreSQL JDBC Driver
 Bundle-SymbolicName: org.postgresql.jdbc
 Bundle-Vendor: PostgreSQL Global Development Group
 Bundle-Version: 42.2.23
-`
-	r := strings.NewReader(m)
-	pkg, _ := parseJarManifestFile("", r)
-	if pkg.ModuleName != "org.postgresql:postgresql" {
-		t.Errorf("Wrong jar package: %+v\n", pkg)
-	}
-
-	m = `
+`,
+			moduleName: "org.postgresql:postgresql",
+			version:    "42.2.23",
+		},
+		{
+			name: "tomcat-embed-core",
+			manifest: `
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: tomcat-embed-core
@@ -242,14 +249,13 @@ Specification-Vendor: Apache Software Foundation
 Specification-Version: 10.1
 X-Compile-Source-JDK: 11
 X-Compile-Target-JDK: 11
-`
-	r = strings.NewReader(m)
-	pkg, _ = parseJarManifestFile("", r)
-	if pkg.ModuleName != "org.apache.tomcat.embed:tomcat-embed-core" && pkg.Version != "10.1.11" {
-		t.Errorf("Wrong jar package: %+v\n", pkg)
-	}
-
-	m = `
+`,
+			moduleName: "org.apache.tomcat.embed:tomcat-embed-core",
+			version:    "10.1.11",
+		},
+		{
+			name: "JNA",
+			manifest: `
 Manifest-Version: 1.0
 Ant-Version: Apache Ant 1.10.6
 Created-By: 1.8.0_201-b09 (Oracle Corporation)
@@ -270,27 +276,26 @@ Bundle-Version: 5.5.0
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Vendor: JNA Development Team
 Bundle-ActivationPolicy: lazy
-`
-	r = strings.NewReader(m)
-	pkg, _ = parseJarManifestFile("", r)
-	if pkg.ModuleName != "JNA Development Team:com.sun.jna" && pkg.Version != "5.5.0" {
-		t.Errorf("Wrong jar package: %+v\n", pkg)
-	}
-
-	m = `
+`,
+			moduleName: "JNA Development Team:com.sun.jna",
+			version:    "5.5.0",
+		},
+		{
+			name: "spring boot",
+			manifest: `
 Manifest-Version: 1.0
 Automatic-Module-Name: spring.boot
 Build-Jdk-Spec: 17
 Built-By: Spring
 Implementation-Title: Spring Boot
 Implementation-Version: 3.3.10
-`
-	r = strings.NewReader(m)
-	pkg, _ = parseJarManifestFile("", r)
-	if pkg.ModuleName != "jar:spring-boot" && pkg.Version != "3.3.10" {
-		t.Errorf("Wrong jar package: %+v\n", pkg)
-	}
-	m = `
+`,
+			moduleName: "org.springframework.boot:spring-boot",
+			version:    "3.3.10",
+		},
+		{
+			name: "elasticsearch",
+			manifest: `
 Manifest-Version: 1.0
 Multi-Release: true
 Implementation-Title: org.elasticsearch#server;6.6.1
@@ -311,11 +316,47 @@ X-Compile-Source-JDK: 1.8
 X-Compile-Elasticsearch-Version: 6.6.1
 X-Compile-Lucene-Version: 7.6.0
 X-Compile-Elasticsearch-Snapshot: false
-`
-	r = strings.NewReader(m)
-	pkg, _ = parseJarManifestFile("", r)
-	if pkg.ModuleName != "jar:elasticsearch" && pkg.Version != "6.6.1" {
-		t.Errorf("Wrong jar package: %+v\n", pkg)
+`,
+			moduleName: "jar:elasticsearch",
+			version:    "6.6.1",
+		},
+		{
+			name: "opentelemetry with leading spaces",
+			manifest: `
+Manifest-Version: 1.0
+Automatic-Module-Name: io.opentelemetry.exporter.internal.otlp
+Built-By: runner
+Built-JDK: 21.0.10
+Implementation-Title: common
+Implementation-Version: 1.59.0
+		`,
+			moduleName: "io.opentelemetry.exporter.internal.otlp:common",
+			version:    "1.59.0",
+		},
+		{
+			name: "opentelemetry with leading spaces",
+			manifest: `
+Manifest-Version: 1.0
+Automatic-Module-Name: io.opentelemetry.exporter.internal
+Built-By: runner
+Built-JDK: 21.0.10
+Implementation-Title: common
+Implementation-Version: 1.59.0
+Multi-Release: true
+		`,
+			moduleName: "io.opentelemetry.exporter.internal:common",
+			version:    "1.59.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := strings.NewReader(tt.manifest)
+			pkg, err := parseJarManifestFile("", r)
+			require.NoError(t, err)
+			require.Equal(t, tt.moduleName, pkg.ModuleName)
+			require.Equal(t, tt.version, pkg.Version)
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

- Fix https://github.com/neuvector/neuvector/issues/2205
- support parsing Automatic-Module-Name in manifest (mentioned in https://docs.oracle.com/en/java/javase/17/docs/specs/jar/jar.html#manifest-specification)

## Test
- scan `docker.io/pohanhuangtw/demo-java-service:latest`, ensure no `CVE-2024-46985` , `CVE-2024-46997`

## Additional Information

The flow:

1. The scanner loads the DB files.
   - Some DB keys are added during the reading process for backward compatibility.
2. The scanner parses the JAR manifest file and extracts the `app-feature` for matching purposes.
3. The `app-feature` is matched against the DB.

### Root Cause
- Step 1 generates some DB keys named `jar:common`.
- Step 2 parses the manifest of `opentelemetry-exporter-common-1.59.0.jar` and derives the `app-feature` key as `jar:common`.
- Step 3 matches the above two, causing many false positives.

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
