### PR TITLE
Allow CRD validation webhook dry-run requests

### DIFF
--- a/controller/rest/crdvalidatewebhook.go
+++ b/controller/rest/crdvalidatewebhook.go
@@ -530,7 +530,13 @@ func (whsvr *WebhookServer) crdserveK8s(w http.ResponseWriter, r *http.Request, 
 		} else {
 			if ar.Request.DryRun != nil && *ar.Request.DryRun {
 				skip = true
-				resultMsg = fmt.Sprintf(" %s denied in dry-run", reqOp)
+				if reqOp != "DELETE" && reqOp != "CREATE" && reqOp != "UPDATE" {
+					log.WithFields(log.Fields{"op": reqOp, "name": ar.Request.Name}).Debug("unsupported operation")
+					resultMsg = fmt.Sprintf(" %s denied: unsupported operation", reqOp)
+				} else {
+					allowed = true
+					resultMsg = fmt.Sprintf(" %s done in dry-run", reqOp)
+				}
 			} else {
 				allowed = true
 				if reqOp != "DELETE" && reqOp != "CREATE" && reqOp != "UPDATE" {

--- a/controller/rest/crdvalidatewebhook_test.go
+++ b/controller/rest/crdvalidatewebhook_test.go
@@ -1,0 +1,115 @@
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/neuvector/neuvector/controller/api"
+	"github.com/neuvector/neuvector/controller/kv"
+	"github.com/neuvector/neuvector/controller/resource"
+	"github.com/neuvector/neuvector/share"
+)
+
+func TestCrdServeK8sAllowsDryRunWithoutQueue(t *testing.T) {
+	preTest()
+	defer postTest()
+
+	var mockCluster kv.MockCluster
+	mockCluster.Init(nil, nil)
+	clusHelper = &mockCluster
+	cacher = &mockCache{}
+
+	oldCrdReqMgr := crdReqMgr
+	crdReqMgr = nil
+	defer func() {
+		crdReqMgr = oldCrdReqMgr
+	}()
+
+	policyMode := share.PolicyModeEnforce
+	secRule := resource.NvSecurityRule{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "neuvector.com/v1",
+			Kind:       resource.NvSecurityRuleKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ubuntu",
+			Namespace: "default",
+		},
+		Spec: resource.NvSecurityRuleSpec{
+			Target: resource.NvSecurityTarget{
+				PolicyMode: &policyMode,
+				Selector: api.RESTCrdGroupConfig{
+					Name: "nv.ubuntu.default",
+					Criteria: []api.RESTCriteriaEntry{
+						{Key: share.CriteriaKeyService, Value: "ubuntu.default", Op: share.CriteriaOpEqual},
+						{Key: share.CriteriaKeyDomain, Value: "default", Op: share.CriteriaOpEqual},
+					},
+				},
+			},
+		},
+	}
+	rawSecRule, err := json.Marshal(secRule)
+	if err != nil {
+		t.Fatalf("marshal security rule: %v", err)
+	}
+
+	dryRun := true
+	ar := admissionv1beta1.AdmissionReview{
+		Request: &admissionv1beta1.AdmissionRequest{
+			UID: types.UID("dry-run-test"),
+			Kind: metav1.GroupVersionKind{
+				Group:   "neuvector.com",
+				Version: "v1",
+				Kind:    resource.NvSecurityRuleKind,
+			},
+			Resource: metav1.GroupVersionResource{
+				Group:    "neuvector.com",
+				Version:  "v1",
+				Resource: resource.NvSecurityRulePlural,
+			},
+			Operation: admissionv1beta1.Create,
+			Name:      secRule.Name,
+			Namespace: secRule.Namespace,
+			Object:    runtime.RawExtension{Raw: rawSecRule},
+			DryRun:    &dryRun,
+		},
+	}
+	body, err := json.Marshal(ar)
+	if err != nil {
+		t.Fatalf("marshal admission review: %v", err)
+	}
+
+	w := new(mockResponseWriter)
+	r := httptest.NewRequest(http.MethodPost, "/validate", nil)
+	(&WebhookServer{}).crdserveK8s(w, r, body)
+
+	if w.status != 0 && w.status != http.StatusOK {
+		t.Fatalf("dry-run request status=%v, want %v: %s", w.status, http.StatusOK, string(w.body))
+	}
+
+	var resp admissionv1beta1.AdmissionReview
+	if err := json.Unmarshal(w.body, &resp); err != nil {
+		t.Fatalf("unmarshal admission response: %v", err)
+	}
+	if resp.Response == nil {
+		t.Fatalf("missing admission response")
+	}
+	if !resp.Response.Allowed {
+		message := ""
+		if resp.Response.Result != nil {
+			message = resp.Response.Result.Message
+		}
+		t.Fatalf("dry-run request was denied: %s", message)
+	}
+	if resp.Response.Result == nil || !strings.Contains(resp.Response.Result.Message, "done in dry-run") {
+		t.Fatalf("unexpected dry-run response message: %#v", resp.Response.Result)
+	}
+}


### PR DESCRIPTION
## Description
Fix #2275

Allows Kubernetes admission dry-run requests for CRD CREATE, UPDATE, and DELETE operations after the existing early size, metadata-name, and operation checks. Dry-run requests now skip CRD queue enqueueing, so server-side dry-run validation does not create asynchronous CRD processing side effects.

## Test
To test this pull request, you can run:

`go test ./controller/rest -run TestCrdServeK8sAllowsDryRunWithoutQueue -count=1`

## Additional Information

### Tradeoff
Dry-run keeps the webhook's current admission behavior by avoiding asynchronous CRD processing instead of introducing a new synchronous deep-validation path that normal CRD admission does not currently use.

### Potential improvement
A future change could add broader synchronous CRD validation for both normal and dry-run admission if maintainers want webhook-time semantic validation.

### Special notes for your reviewer
None.

### Checklist
- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
