### PR TITLE
Generate shell-safe API key secrets

### DIFF
--- a/controller/resource/kubernetes_resource.go
+++ b/controller/resource/kubernetes_resource.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 	"net/http"
 	"os"
@@ -2461,6 +2462,25 @@ func GenRandomString(length int) (string, error) {
 	}
 	for i := range length {
 		bytes[i] = charset[int(bytes[i])%len(charset)]
+	}
+	return string(bytes), nil
+}
+
+func GenShellSafeRandomString(length int) (string, error) {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	if length <= 0 {
+		return "", nil
+	}
+
+	bytes := make([]byte, length)
+	max := big.NewInt(int64(len(charset)))
+	for i := range bytes {
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			log.WithFields(log.Fields{"err": err}).Error()
+			return "", err
+		}
+		bytes[i] = charset[n.Int64()]
 	}
 	return string(bytes), nil
 }

--- a/controller/resource/random_test.go
+++ b/controller/resource/random_test.go
@@ -1,0 +1,19 @@
+package resource
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestGenShellSafeRandomString(t *testing.T) {
+	value, err := GenShellSafeRandomString(64)
+	if err != nil {
+		t.Fatalf("GenShellSafeRandomString returned error: %v", err)
+	}
+	if len(value) != 64 {
+		t.Fatalf("GenShellSafeRandomString length=%d, want 64", len(value))
+	}
+	if !regexp.MustCompile(`^[a-zA-Z0-9]+$`).MatchString(value) {
+		t.Fatalf("GenShellSafeRandomString returned shell-unsafe characters")
+	}
+}

--- a/controller/rest/user.go
+++ b/controller/rest/user.go
@@ -1399,7 +1399,7 @@ func handlerApikeyCreate(w http.ResponseWriter, r *http.Request, ps httprouter.P
 
 	// Generate secret key
 	var apikey share.CLUSApikey
-	secretKey, err := resource.GenRandomString(64)
+	secretKey, err := resource.GenShellSafeRandomString(64)
 	if err == nil {
 		apikey = share.CLUSApikey{
 			ExpirationType:   rapikey.ExpirationType,

--- a/controller/rest/user_test.go
+++ b/controller/rest/user_test.go
@@ -1,9 +1,11 @@
 package rest
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -620,6 +622,20 @@ func TestApikeyCreateDelete(t *testing.T) {
 	if w.status != http.StatusOK {
 		t.Fatalf("Failed to create apikey: status=%v.", w.status)
 	}
+	var generatedResp api.RESTApikeyGeneratedData
+	unmarshalJSON(t, w.body, &generatedResp)
+	if generatedResp.Apikey == nil {
+		t.Fatalf("Missing generated apikey response")
+	}
+	if generatedResp.Apikey.Name != "token-12345" {
+		t.Errorf("Incorrect generated apikey name: %s", generatedResp.Apikey.Name)
+	}
+	if len(generatedResp.Apikey.SecretKey) != 64 {
+		t.Errorf("Incorrect generated secret length: length=%v expect=64", len(generatedResp.Apikey.SecretKey))
+	}
+	if !regexp.MustCompile(`^[a-zA-Z0-9]+$`).MatchString(generatedResp.Apikey.SecretKey) {
+		t.Errorf("Generated secret contains shell-unsafe characters")
+	}
 
 	// Check apikey in cluster
 	apikey, _, _ := clusHelper.GetApikeyRev("token-12345", accAdmin)
@@ -628,6 +644,14 @@ func TestApikeyCreateDelete(t *testing.T) {
 	}
 	if apikey.Name != "token-12345" || apikey.Role != api.UserRoleReader {
 		t.Errorf("Incorrect apikey in cluster: user=%v", apikey)
+	}
+
+	r, _ := http.NewRequest("GET", "/v1/selfapikey", bytes.NewBuffer([]byte{}))
+	r.Header.Add(api.RESTAPIKeyHeader, generatedResp.Apikey.Name+":"+generatedResp.Apikey.SecretKey)
+	w = new(mockResponseWriter)
+	router.ServeHTTP(w, r)
+	if w.status != http.StatusOK {
+		t.Fatalf("Failed to authenticate with generated apikey: status=%v.", w.status)
 	}
 
 	// Check get users by REST


### PR DESCRIPTION
## Description
Fix #2217

Generates API key secrets with a dedicated alphanumeric random string generator so newly created API keys do not include shell metacharacters such as `$`, `&`, quotes, whitespace, or `:`. The existing bootstrap password generator is left unchanged, and generated API key secrets remain 64 characters long.

## Test
To test this pull request, you can run:

`go test ./controller/resource -run TestGenShellSafeRandomString -count=1`

`go test ./controller/rest -run TestApikeyCreateDelete -count=1`

## Additional Information

### Tradeoff
The API key secret alphabet is restricted to alphanumeric characters for shell safety. A 64-character secret from this alphabet still provides substantially more entropy than needed for API key authentication.

### Potential improvement
None.

### Special notes for your reviewer
None.

### Checklist
- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
