### PR TITLE
feat: move readiness probe from exec to httpget

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -546,16 +546,17 @@ func main() {
 	var internalCertControllerCancel context.CancelFunc
 	var ctx context.Context
 
-	if os.Getenv("AUTO_INTERNAL_CERT") != "" {
-
-		log.Info("start initializing k8s internal secret controller and wait for internal secret creation if it's not created")
-
+	// Healthz server handles internal cert migration (enabled by default) and readiness checks (always enabled in k8s).
+	if platform == share.PlatformKubernetes {
 		go func() {
 			if err := healthz.StartHealthzServer(); err != nil {
 				log.WithError(err).Warn("failed to start healthz server")
 			}
 		}()
+	}
 
+	if os.Getenv("AUTO_INTERNAL_CERT") != "" {
+		log.Info("start initializing k8s internal secret controller and wait for internal secret creation if it's not created")
 		ctx, internalCertControllerCancel = context.WithCancel(context.Background())
 		defer internalCertControllerCancel()
 		// Initialize secrets.  Most of services are not running at this moment, so skip their reload functions.

--- a/share/healthz/healthz.go
+++ b/share/healthz/healthz.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"sync"
 
+	"github.com/neuvector/neuvector/share/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -42,6 +44,15 @@ func HealthzHandler(w http.ResponseWriter, r *http.Request) {
 func StartHealthzServer() error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", HealthzHandler)
+	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
+		// This handles all errors in addition to the file not existing.
+		if _, err := os.Stat(utils.ReadyFile); err != nil {
+			log.WithError(err).Warn("ready file not accessible")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
 
 	return http.ListenAndServe(fmt.Sprintf(":%d", healthzPort), mux)
 }

--- a/share/utils/utils.go
+++ b/share/utils/utils.go
@@ -51,7 +51,7 @@ const cliAny string = "any"
 const reStrNonPrintable string = "[^\x20-\x7E]"
 const reStrURLReserved string = "[/?%& ]"
 
-const readyFile string = "/tmp/ready"
+const ReadyFile string = "/tmp/ready"
 
 var reNonPrintable, reURLReserved *regexp.Regexp
 
@@ -1194,7 +1194,7 @@ func Exec(dir string, bin string, args ...string) ([]byte, error) {
 
 func SetReady(value string) error {
 	log.WithFields(log.Fields{"value": value}).Info("")
-	f, err := os.Create(readyFile)
+	f, err := os.Create(ReadyFile)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err, "value": value}).Error("Unable to create ready file")
 		return err
@@ -1206,7 +1206,7 @@ func SetReady(value string) error {
 
 func UnsetReady() error {
 	log.Info("")
-	return os.Remove(readyFile)
+	return os.Remove(ReadyFile)
 }
 
 // Utilities: find group attribute from the grou's name definitions, based on controller/api/apis.go


### PR DESCRIPTION
## Description

This PR implements an alternative readiness probe to replace the existing readiness probe.  

This is to address the issue where [NV Protect can't handle readiness probe correctly](https://github.com/neuvector/neuvector/blob/9ae6ca2349ce2e117a39707689655a4875731be5/agent/probe/process.go#L3072) when the base image is ubi9 image.

In the ubi9 image, `/usr/bin/cat` is actually a shell script pointing to `/usr/bin/coreutils --coreutils-prog-shebang=cat`.  That's why the executable is not allowed by the NV allow list.  

However, to allow `/usr/bin/coreutils` correctly using an allow list, there are a few challenges:

1. If we check only `proc.path == "/usr/bin/coreutils"`, we have to make sure that only `cat` is allowed.  However, coreutils can be used for `cp`, `mv` and other commands, which opens a relatively big attack surface. 
2. Additionally, we have to verify what file `cat` can access.  The current implementation relies on `proc.cmdline` to check what file the `/usr/bin/cat` accesses.  This is actually not reliable as `proc.cmdline` is prone to race condition.  I can reproduce the false positives from the readiness probe even with BCI images as the base image. 
3. Besides, even if we figure out how to allow the `/usr/bin/cat` on UBI9, we still have to define two allow list, one for normal NV release and one for UBI images.   

With these, it makes more sense to just switch to a `httpGet` in readiness probe. This comes with these benefits:

- We address the false positives from `/usr/bin/cat`.
- Consistent behavior in OpenShift scenario and k8s secenario.
- Potentially less attack surface in the future since `/usr/bin/cat` could be changed to not allowed.  Having said that, the allow list is kept for backward compatibility reason for now, so readiness probes of old controllers won't be affected during controller rolling update.

The link of helm chart PR: https://github.com/neuvector/neuvector-helm/pull/575

Fix #2227 

## Test

Install neuvector and verify if controller becomes ready. 

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

### Special notes for your reviewer

<!-- Please describe, if any special design or notes you want to share with your reviewer in this pull request -->

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
