### PR TITLE
test: skip unstable test

### DIFF
--- a/controller/rest/longpoll_test.go
+++ b/controller/rest/longpoll_test.go
@@ -269,6 +269,8 @@ func TestJobQueueCapacityZero(t *testing.T) {
 // TestShutdownResourceCleanup verifies that Shutdown correctly cleans up all resources,
 // closes the jobQueue, and ensures no goroutine leaks.
 func TestShutdownResourceCleanup(t *testing.T) {
+	t.Skip("this test is not stable")
+
 	initialGoroutines := runtime.NumGoroutine()
 	mockTimeOut := 1 * time.Second
 	mockPoolSize := 2


### PR DESCRIPTION
## Description

I've seen `TestShutdownResourceCleanup` failed a few times randomly in different places.  Maybe we should disable it for now and re-enable it when we're sure it's stable.  

## Test

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

### Special notes for your reviewer

<!-- Please describe, if any special design or notes you want to share with your reviewer in this pull request -->

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
