### PR TITLE
code-scanning-165: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/controller/kv/helper.go
+++ b/controller/kv/helper.go
@@ -2556,9 +2556,7 @@ func (m clusterHelper) PutObjectCert(cn, keyPath, certPath string, cert *share.C
 				if !valid {
 					return cluster.Put(key, value)
 				} else {
-					h1, _ := common.HashPassword(cert.Cert, []byte(cert.Key))
-					h2, _ := common.HashPassword(certExisting.Cert, []byte(certExisting.Key))
-					log.WithFields(log.Fields{"cn": cn, "certIn": h1, "certExisting": h2}).Info("hash")
+					log.WithFields(log.Fields{"cn": cn, "certChanged": cert.Cert != certExisting.Cert}).Info()
 					err1 := os.WriteFile(keyPath, []byte(certExisting.Key), 0600)
 					err2 := os.WriteFile(certPath, []byte(certExisting.Cert), 0600)
 					if err1 == nil && err2 == nil {

--- a/controller/kv/upgrade.go
+++ b/controller/kv/upgrade.go
@@ -1389,8 +1389,7 @@ func ValidateWebhookCert() {
 						}
 					}
 					if cert != nil {
-						h, _ := common.HashPassword(cert.Cert, []byte(cert.Key))
-						log.WithFields(log.Fields{"cn": certInfo.cn, "cert": h}).Info("hash")
+						log.WithFields(log.Fields{"cn": certInfo.cn}).Info()
 						certInfo.verified = true
 					}
 				}

--- a/controller/nvk8sapi/nvvalidatewebhookcfg/nvvalidatewebhookcfg.go
+++ b/controller/nvk8sapi/nvvalidatewebhookcfg/nvvalidatewebhookcfg.go
@@ -1,8 +1,6 @@
 package admission
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -182,8 +180,7 @@ func SetCABundle(svcName string, caBundle []byte) {
 		TagKey:  fmt.Sprintf("tag-%s", svcName),
 		EchoKey: fmt.Sprintf("echo-%s", svcName),
 	}
-	b := sha256.Sum256(caBundle)
-	log.WithFields(log.Fields{"svcName": svcName, "cert": hex.EncodeToString(b[:])}).Info("sha256")
+	log.WithFields(log.Fields{"svcName": svcName}).Info()
 
 	resource.GetK8sVersion()
 }
@@ -192,8 +189,7 @@ func ResetCABundle(svcName string, caBundle []byte) bool { // return true if res
 	newCert := string(caBundle)
 	oldCert := admCaBundle[svcName]
 	if len(newCert) > 0 && oldCert != newCert {
-		b := sha256.Sum256([]byte(oldCert))
-		log.WithFields(log.Fields{"svcName": svcName, "old": hex.EncodeToString(b[:])}).Info("sha256")
+		log.WithFields(log.Fields{"svcName": svcName}).Info()
 		admCaBundle[svcName] = newCert
 		return true
 	}


### PR DESCRIPTION
## Description

Fix https://github.com/neuvector/neuvector/security/code-scanning/165 , https://github.com/neuvector/neuvector/security/code-scanning/166 , https://github.com/neuvector/neuvector/security/code-scanning/167

Because the hash calculation is for debugging only, change it to a different hashing algorithm doesn't affect any function  logic
