### PR TITLE
enhance: reject load or upload the empty or corrupt cvedb

### DIFF
--- a/controller/cache/scan.go
+++ b/controller/cache/scan.go
@@ -1235,12 +1235,22 @@ func ScannerUpdateHandler(nType cluster.ClusterNotifyType, key string, value []b
 					CVEDB:           make(map[string]*share.ScanVulnerability),
 				}
 
-				// Reassemble
-				dbs := clusHelper.GetScannerDB(newStore)
+				// Reassemble. Keep the current in-memory DB if the new store cannot be read
+				// or contains no usable entries.
+				dbs, err := clusHelper.GetScannerDB(newStore)
+				if err != nil {
+					log.WithFields(log.Fields{"error": err, "store": newStore, "version": s.CVEDBVersion}).Error("Failed to load scanner DB")
+					return
+				}
 				for _, db := range dbs {
 					for _, cve := range db.CVEDB {
 						newDB.CVEDB[cve.Name] = cve
 					}
+				}
+
+				if len(newDB.CVEDB) == 0 {
+					log.WithFields(log.Fields{"store": newStore, "version": s.CVEDBVersion}).Error("Dropping empty scanner DB update")
+					return
 				}
 
 				log.WithFields(log.Fields{"cvedb": newDB.CVEDBVersion, "entries": len(newDB.CVEDB)}).Info()

--- a/controller/grpc.go
+++ b/controller/grpc.go
@@ -178,7 +178,11 @@ func (ss *ScanService) HealthCheck(ctx context.Context, data *share.ScannerRegis
 	}
 
 	clusHelper := kv.GetClusterHelper()
-	s := clusHelper.GetScanner(scannerID, access.NewReaderAccessControl())
+	s, err := clusHelper.GetScanner(scannerID, access.NewReaderAccessControl())
+	if err != nil && !errors.Is(err, cluster.ErrKeyNotFound) {
+		log.WithFields(log.Fields{"error": err, "scanner": scannerID}).Warn("Failed to get scanner during health check")
+		return nil, fmt.Errorf("failed to get scanner %s: %w", scannerID, err)
+	}
 	if s != nil {
 		visible = true
 	}
@@ -220,8 +224,18 @@ func (ss *ScanService) scannerRegister(data *share.ScannerRegisterData) error {
 	}
 	defer clusHelper.ReleaseLock(lock)
 
+	hasCveDB := len(data.CVEDB) > 0
+	if !hasCveDB {
+		log.WithFields(log.Fields{"scanner": data.ID, "version": data.CVEDBVersion}).Warn("Skip empty scanner DB update")
+		return errors.New("scanner cvedb is empty")
+	}
+
 	// Check if the database is newer.
-	s := clusHelper.GetScanner(share.CLUSScannerDBVersionID, access.NewReaderAccessControl())
+	s, err := clusHelper.GetScanner(share.CLUSScannerDBVersionID, access.NewReaderAccessControl())
+	if err != nil && !errors.Is(err, cluster.ErrKeyNotFound) {
+		log.WithFields(log.Fields{"error": err, "version": data.CVEDBVersion}).Warn("Failed to get scanner DB version record")
+		return fmt.Errorf("failed to get scanner DB version record: %w", err)
+	}
 	if s == nil {
 		writeDB = true
 	} else {

--- a/controller/kv/helper.go
+++ b/controller/kv/helper.go
@@ -134,14 +134,14 @@ type ClusterHelper interface {
 	DeleteProcessProfileTxn(txn *cluster.ClusterTransact, group string) error
 	GetAllProcessProfileSubKeys(scope string) utils.Set
 
-	GetScanner(id string, acc *access.AccessControl) *share.CLUSScanner
+	GetScanner(id string, acc *access.AccessControl) (*share.CLUSScanner, error)
 	GetAllScanner(acc *access.AccessControl) []*share.CLUSScanner
 	PutScannerTxn(txn *cluster.ClusterTransact, s *share.CLUSScanner) error
 	DeleteScanner(id string) error
 	GetScannerStats(id string) (*share.CLUSScannerStats, error)
 	CreateScannerStats(id string) error
 	PutScannerStats(id string, objType share.ScanObjectType, result *share.ScanResult) error
-	GetScannerDB(store string) []*share.CLUSScannerDB
+	GetScannerDB(store string) ([]*share.CLUSScannerDB, error)
 
 	// InitCreditOwners initializes the scan credit owners for the cluster.
 	InitCreditOwners() error
@@ -1502,7 +1502,7 @@ func (m clusterHelper) GetScannerStats(id string) (*share.CLUSScannerStats, erro
 	key := share.CLUSScannerStatsKey(id)
 	value, _, _ := m.get(key)
 	if value == nil {
-		return nil, common.ErrObjectNotFound
+		return nil, cluster.ErrKeyNotFound
 	}
 
 	_ = nvJsonUnmarshal(key, value, &s)
@@ -1578,20 +1578,25 @@ func (m clusterHelper) PutScannerStats(id string, objType share.ScanObjectType, 
 	return common.ErrAtomicWriteFail
 }
 
-func (m clusterHelper) GetScanner(id string, acc *access.AccessControl) *share.CLUSScanner {
+func (m clusterHelper) GetScanner(id string, acc *access.AccessControl) (*share.CLUSScanner, error) {
 	key := share.CLUSScannerKey(id)
-	value, _, _ := m.get(key)
+	value, _, err := m.get(key)
+	if err != nil {
+		return nil, err
+	}
 	if value != nil {
 		var s share.CLUSScanner
-		_ = nvJsonUnmarshal(key, value, &s)
-
-		if !acc.Authorize(&s, nil) {
-			return nil
+		if err := nvJsonUnmarshal(key, value, &s); err != nil {
+			return nil, err
 		}
 
-		return &s
+		if !acc.Authorize(&s, nil) {
+			return nil, common.ErrObjectAccessDenied
+		}
+
+		return &s, nil
 	}
-	return nil
+	return nil, cluster.ErrKeyNotFound
 }
 
 // GetScannerRev gets scanner with revision for internal operations (no auth check)
@@ -1599,7 +1604,8 @@ func (m clusterHelper) GetScannerRev(id string) (*share.CLUSScanner, uint64, err
 	key := share.CLUSScannerKey(id)
 	value, rev, err := m.get(key)
 	if err != nil || value == nil {
-		return nil, 0, common.ErrObjectNotFound
+		// Use cluster.ErrKeyNotFound to stay consistent with the KV store layer abstraction.
+		return nil, 0, cluster.ErrKeyNotFound
 	}
 
 	var s share.CLUSScanner
@@ -1617,28 +1623,33 @@ func (m clusterHelper) DeleteScanner(id string) error {
 	return cluster.Delete(key)
 }
 
-func (m clusterHelper) GetScannerDB(store string) []*share.CLUSScannerDB {
+func (m clusterHelper) GetScannerDB(store string) ([]*share.CLUSScannerDB, error) {
 	dbs := make([]*share.CLUSScannerDB, 0)
-	keys, _ := cluster.GetStoreKeys(store)
+	keys, err := cluster.GetStoreKeys(store)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list scanner db keys for %s: %w", store, err)
+	}
 	for _, key := range keys {
-		if value, _, _ := m.get(key); value != nil {
+		value, _, err := m.get(key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read scanner db key %s: %w", key, err)
+		}
+		if value != nil {
 			var db share.CLUSScannerDB
 			uzb := utils.GunzipBytes(value)
 			if uzb == nil {
-				log.Error("Failed to unzip data")
-				continue
+				return nil, fmt.Errorf("failed to unzip scanner db key %s: %w", key, err)
 			}
 
 			err := json.Unmarshal(uzb, &db)
 			if err != nil {
-				log.WithFields(log.Fields{"error": err}).Error("Cannot decode db")
-				continue
+				return nil, fmt.Errorf("failed to decode scanner db key %s: %w", key, err)
 			}
 
 			dbs = append(dbs, &db)
 		}
 	}
-	return dbs
+	return dbs, nil
 }
 
 func (m clusterHelper) GetAvailableScanners() []share.CLUSScanner {
@@ -1729,7 +1740,7 @@ func (m clusterHelper) ReleaseScanCredit(scannerId string, releaseCredit int) er
 		scanner, rev, err := m.GetScannerRev(scannerId)
 		if err != nil {
 			// Check if scanner was deleted (object not found)
-			if errors.Is(err, common.ErrObjectNotFound) {
+			if errors.Is(err, cluster.ErrKeyNotFound) {
 				// Scanner has been deleted - credit is implicitly released with the scanner
 				log.WithFields(log.Fields{"scanner": scannerId}).Debug("Scanner not found during credit release, likely deleted")
 				return nil

--- a/controller/kv/mock.go
+++ b/controller/kv/mock.go
@@ -526,6 +526,20 @@ func (m *MockCluster) GetScannerRev(id string) (*share.CLUSScanner, uint64, erro
 	return nil, 0, common.ErrObjectNotFound
 }
 
+func (m *MockCluster) GetScanner(id string, acc *access.AccessControl) (*share.CLUSScanner, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if scanner, ok := m.scanners[id]; ok {
+		clone := *scanner
+		if !acc.Authorize(&clone, nil) {
+			return nil, common.ErrObjectAccessDenied
+		}
+		return &clone, nil
+	}
+	return nil, cluster.ErrKeyNotFound
+}
+
 func (m *MockCluster) PickLeastLoadedScanner() (*share.CLUSScanner, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
## Description
- Skip empty CVEDB updates from scanner registration
- Reject KV reloads that fail or reconstruct to an empty DB so the controller does not replace a valid in-memory DB with empty/corrupt data.

## Issue
https://github.com/neuvector/neuvector/issues/2423