### PR TITLE
fix(lint): resolve errcheck in agent engine, service, system, and timer

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -649,7 +649,11 @@ func programProxyMeshDP(c *containerData, cfgApp, restore bool) {
 	var lomac_str string
 	var lo_oldmac, lo_mac, lo_umac, lo_bmac net.HardwareAddr
 	lomac_str = fmt.Sprintf(container.KubeProxyMeshLoMacStr, (c.pid>>8)&0xff, c.pid&0xff)
-	lo_mac, _ = net.ParseMAC(lomac_str)
+	var macErr error
+	lo_mac, macErr = net.ParseMAC(lomac_str)
+	if macErr != nil {
+		log.WithFields(log.Fields{"error": macErr, "mac": lomac_str}).Warn("Failed to parse proxy mesh lo MAC")
+	}
 
 	//pass parent containers IP to service mesh ep so that
 	//when src/dst IP are both 127.0.0.x, we can replace dst
@@ -727,7 +731,11 @@ func programDelProxyMeshDP(c *containerData, ns string) {
 	var lomac_str string
 	var lo_mac net.HardwareAddr
 	lomac_str = fmt.Sprintf(container.KubeProxyMeshLoMacStr, (c.pid>>8)&0xff, c.pid&0xff)
-	lo_mac, _ = net.ParseMAC(lomac_str)
+	var macErr error
+	lo_mac, macErr = net.ParseMAC(lomac_str)
+	if macErr != nil {
+		log.WithFields(log.Fields{"error": macErr, "mac": lomac_str}).Warn("Failed to parse proxy mesh lo MAC")
+	}
 
 	if c.quar || c.inline {
 		//delete dp nfq handle if any then reset iptable rules

--- a/agent/service.go
+++ b/agent/service.go
@@ -744,7 +744,11 @@ func (rs *RPCService) cbAgentCounter(buf []byte, param interface{}) bool {
 	// pid := os.Getpid()
 	// lsof, _ := sh.Command("lsof", "-Pn", "-p", strconv.Itoa(pid)).Command("grep", "-v", "IPv4\\|IPv6").Output()
 	lsof := []byte("lsof disabled")
-	ps, _ := sh.Command("ps", "-o", "pid,ppid,vsz,rss,comm", "-g", strconv.Itoa(Agent.Pid)).Output()
+	ps, err := sh.Command("ps", "-o", "pid,ppid,vsz,rss,comm", "-g", strconv.Itoa(Agent.Pid)).Output()
+	if err != nil {
+		// Suppress error: diagnostic ps output for counter reporting, failure is non-critical
+		log.WithError(err).Debug("Failed to get process list for counter")
+	}
 
 	offset := int(unsafe.Sizeof(*hdr))
 	r := bytes.NewReader(buf[offset:])

--- a/agent/system.go
+++ b/agent/system.go
@@ -262,7 +262,12 @@ func getPolicyConfig(newRuleKey string, slots, ruleslen int) []share.CLUSGroupIP
 	for i := 0; i < slots; i++ {
 		key := fmt.Sprintf("%s%v", newRuleKey, i)
 		//log.WithFields(log.Fields{"key": key,}).Debug("rule key")
-		if value, _ := cluster.Get(key); value != nil {
+		value, err := cluster.Get(key)
+		if err != nil {
+			log.WithFields(log.Fields{"error": err, "key": key}).Warn("Failed to get policy config from cluster")
+			continue
+		}
+		if value != nil {
 			pol := make([]share.CLUSGroupIPPolicy, 0)
 			uzb := utils.GunzipBytes(value)
 			if uzb == nil {
@@ -1120,7 +1125,12 @@ func getDlpRulesVersion(newRuleKey string, slots, ruleslen, wlen int) share.CLUS
 	for i := 0; i < slots; i++ {
 		key := fmt.Sprintf("%s%v", newRuleKey, i)
 		//log.WithFields(log.Fields{"key": key,}).Debug("rule key")
-		if value, _ := cluster.Get(key); value != nil {
+		value, err := cluster.Get(key)
+		if err != nil {
+			log.WithFields(log.Fields{"error": err, "key": key}).Warn("Failed to get DLP config from cluster")
+			continue
+		}
+		if value != nil {
 			dlprule := share.CLUSWorkloadDlpRules{
 				DlpRuleList: make([]*share.CLUSDlpRule, 0),
 				DlpWlRules:  make([]*share.CLUSDlpWorkloadRule, 0),

--- a/agent/timer.go
+++ b/agent/timer.go
@@ -106,7 +106,11 @@ func statsLoop(bPassiveContainerDetect bool) {
 	for {
 		select {
 		case <-statsTicker:
-			system, _ := global.SYS.GetHostCPUUsage()
+			// Suppress error: called every 5 seconds in the stats loop
+			system, err := global.SYS.GetHostCPUUsage()
+			if err != nil {
+				log.WithError(err).Debug("Failed to get host CPU usage")
+			}
 			gInfoRLock()
 			updateAgentStats(system)
 			updateContainerStats(system)
@@ -228,10 +232,20 @@ func dpTaskCallback(task *dp.DPTask) {
 func updateAgentStats(cpuSystem uint64) {
 	var mem, cpu uint64 = 0, 0
 	if agentEnv.cgroupMemory != "" {
-		mem, _ = global.SYS.GetContainerMemoryUsage(agentEnv.cgroupMemory)
+		var err error
+		// Suppress error: called every 5 seconds in the stats loop
+		mem, err = global.SYS.GetContainerMemoryUsage(agentEnv.cgroupMemory)
+		if err != nil {
+			log.WithError(err).Debug("Failed to get agent memory usage")
+		}
 	}
 	if agentEnv.cgroupCPUAcct != "" {
-		cpu, _ = global.SYS.GetContainerCPUUsage(agentEnv.cgroupCPUAcct)
+		var err error
+		// Suppress error: called every 5 seconds in the stats loop
+		cpu, err = global.SYS.GetContainerCPUUsage(agentEnv.cgroupCPUAcct)
+		if err != nil {
+			log.WithError(err).Debug("Failed to get agent CPU usage")
+		}
 	}
 	system.UpdateStats(&gInfo.agentStats, mem, cpu, cpuSystem)
 }
@@ -241,10 +255,20 @@ func updateContainerStats(cpuSystem uint64) {
 	for _, c := range gInfo.activeContainers {
 		var mem, cpu uint64 = 0, 0
 		if c.cgroupMemory != "" {
-			mem, _ = global.SYS.GetContainerMemoryUsage(c.cgroupMemory)
+			var err error
+			// Suppress error: called per-container every 5 seconds, can be high-frequency
+			mem, err = global.SYS.GetContainerMemoryUsage(c.cgroupMemory)
+			if err != nil {
+				log.WithFields(log.Fields{"error": err, "cgroup": c.cgroupMemory}).Debug("Failed to get container memory usage")
+			}
 		}
 		if c.cgroupCPUAcct != "" {
-			cpu, _ = global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct)
+			var err error
+			// Suppress error: called per-container every 5 seconds, can be high-frequency
+			cpu, err = global.SYS.GetContainerCPUUsage(c.cgroupCPUAcct)
+			if err != nil {
+				log.WithFields(log.Fields{"error": err, "cgroup": c.cgroupCPUAcct}).Debug("Failed to get container CPU usage")
+			}
 		}
 		system.UpdateStats(&c.stats, mem, cpu, cpuSystem)
 	}


### PR DESCRIPTION
## Description

Handle previously ignored errors from net.ParseMAC, cluster.Get, sh.Command.Output, and SYS resource stats calls. Log at Warn for unexpected cluster/MAC failures, Debug for high-frequency stats loops.

## Test

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

### Special notes for your reviewer

<!-- Please describe, if any special design or notes you want to share with your reviewer in this pull request -->

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
