### PR TITLE
fix(lint): resolve errcheck in dp, pipe, and scan packages

### DIFF
--- a/agent/dp/ctrl.go
+++ b/agent/dp/ctrl.go
@@ -283,7 +283,11 @@ func DPCtrlSetEnableIcmpPolicy(enableIcmpPolicy *bool) {
 			EnableIcmpPolicy: enableIcmpPolicy,
 		},
 	}
-	msg, _ := json.Marshal(data)
+	msg, err := json.Marshal(data)
+	if err != nil {
+		log.WithError(err).Warn("Failed to marshal DPEnableIcmpPolicyReq")
+		return
+	}
 	dpSendMsg(msg)
 }
 
@@ -294,7 +298,11 @@ func DPCtrlSetStrictGroupMode(strictGroupMode *bool) {
 			StrictGroupMode: strictGroupMode,
 		},
 	}
-	msg, _ := json.Marshal(data)
+	msg, err := json.Marshal(data)
+	if err != nil {
+		log.WithError(err).Warn("Failed to marshal DPStrictGroupModeReq")
+		return
+	}
 	dpSendMsg(msg)
 }
 
@@ -323,7 +331,11 @@ func DPCtrlAddMAC(iface string, mac, ucmac, bcmac, oldmac, pmac net.HardwareAddr
 	if len(pips) <= 0 {
 		data.AddMAC.PIPS = nil
 	}
-	msg, _ := json.Marshal(data)
+	msg, err := json.Marshal(data)
+	if err != nil {
+		log.WithError(err).Warn("Failed to marshal DPAddMACReq")
+		return
+	}
 	dpSendMsg(msg)
 }
 

--- a/agent/pipe/clm.go
+++ b/agent/pipe/clm.go
@@ -11,8 +11,8 @@ var clmPipe clmPipeDriver = clmPipeDriver{}
 
 func (d *clmPipeDriver) AttachPortPair(pair *InterceptPair) (net.HardwareAddr, net.HardwareAddr) {
 	// 4e:65:75:56 - NeuV
-	ucmac, _ := net.ParseMAC("4e:65:75:56:00:00")
-	bcmac, _ := net.ParseMAC("ff:ff:ff:00:00:00")
+	ucmac := net.HardwareAddr{0x4e, 0x65, 0x75, 0x56, 0x00, 0x00}
+	bcmac := net.HardwareAddr{0xff, 0xff, 0xff, 0x00, 0x00, 0x00}
 	return ucmac, bcmac
 }
 

--- a/agent/pipe/link_linux.go
+++ b/agent/pipe/link_linux.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"syscall"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
@@ -14,7 +15,10 @@ var native = nl.NativeEndian()
 
 func ensureIndex(link *netlink.LinkAttrs) {
 	if link != nil && link.Index == 0 {
-		newlink, _ := netlink.LinkByName(link.Name)
+		newlink, err := netlink.LinkByName(link.Name)
+		if err != nil {
+			log.WithFields(log.Fields{"link": link.Name, "error": err}).Debug("Link not found by name")
+		}
 		if newlink != nil {
 			link.Index = newlink.Attrs().Index
 		}

--- a/agent/pipe/no_tc.go
+++ b/agent/pipe/no_tc.go
@@ -11,8 +11,8 @@ var notcPipe notcPipeDriver = notcPipeDriver{}
 
 func (d *notcPipeDriver) AttachPortPair(pair *InterceptPair) (net.HardwareAddr, net.HardwareAddr) {
 	// 4e:65:75:56 - NeuV
-	ucmac, _ := net.ParseMAC("4e:65:75:56:00:00")
-	bcmac, _ := net.ParseMAC("ff:ff:ff:00:00:00")
+	ucmac := net.HardwareAddr{0x4e, 0x65, 0x75, 0x56, 0x00, 0x00}
+	bcmac := net.HardwareAddr{0xff, 0xff, 0xff, 0x00, 0x00, 0x00}
 	return ucmac, bcmac
 }
 

--- a/agent/pipe/port.go
+++ b/agent/pipe/port.go
@@ -114,7 +114,10 @@ func waitLinkReady(port string) (netlink.Link, uint) {
 
 func createNVPorts(jumboframe bool) {
 	// Create port with large ifindex so it won't be in the same range of container ports
-	link, _ := netlink.LinkByName(nvVbrPortName)
+	link, err := netlink.LinkByName(nvVbrPortName)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Debug("NV bridge port not found, will create")
+	}
 	if link == nil {
 		veth := &linkVeth{
 			LinkAttrs: netlink.LinkAttrs{
@@ -470,7 +473,11 @@ func readLinkIPRoute() ([]netlink.Link, map[netlink.Link][]netlink.Addr, []netli
 	}
 
 	// Read all neigh
-	neighs, _ := getPermanentNeighList(links)
+	// getPermanentNeighList always returns nil error (handles errors internally with continue)
+	neighs, err := getPermanentNeighList(links)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Warn("Error in reading permanent neighs")
+	}
 	for _, neigh := range neighs {
 		log.WithFields(log.Fields{"neigh": neigh}).Debug("")
 	}

--- a/agent/pipe/tc.go
+++ b/agent/pipe/tc.go
@@ -393,7 +393,10 @@ func (d *tcPipeDriver) Connect(jumboframe bool) {
 	d.prefs = utils.NewSet()
 	d.portMap = make(map[string]*tcPortInfo)
 
-	link, _ := netlink.LinkByName(nvVbrPortName)
+	link, err := netlink.LinkByName(nvVbrPortName)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Debug("NV bridge port not found")
+	}
 	if link != nil {
 		d.delQDisc(nvVbrPortName)
 		if dbgError := netlink.LinkSetDown(link); dbgError != nil {

--- a/controller/scan/interface.go
+++ b/controller/scan/interface.go
@@ -459,7 +459,10 @@ func (m *scanMethod) GetRegistryVulnerabilities(name string, vpf scanUtils.VPFIn
 			if sum, ok := rs.summary[id]; ok {
 				refreshScanCache(rs, id, sum, c, vpf)
 
-				reportVuls, _ := db.GetVulnerability(id)
+				reportVuls, err := db.GetVulnerability(id)
+				if err != nil {
+					log.WithFields(log.Fields{"id": id, "error": err}).Warn("Failed to get vulnerability data")
+				}
 				localVulTraits := scanUtils.ExtractVulnerability(reportVuls)
 				vmap[id] = scanUtils.FillVulTraits(sdb.CVEDB, sum.BaseOS, localVulTraits, showTag, false)
 				nmap[id] = images2IDNames(rs, sum)
@@ -471,7 +474,10 @@ func (m *scanMethod) GetRegistryVulnerabilities(name string, vpf scanUtils.VPFIn
 				if acc.Authorize(sum, func(s string) share.AccessObject { return rs.config }) {
 					refreshScanCache(rs, id, sum, c, vpf)
 
-					reportVuls, _ := db.GetVulnerability(id)
+					reportVuls, err := db.GetVulnerability(id)
+					if err != nil {
+						log.WithFields(log.Fields{"id": id, "error": err}).Warn("Failed to get vulnerability data")
+					}
 					localVulTraits := scanUtils.ExtractVulnerability(reportVuls)
 					vmap[id] = scanUtils.FillVulTraits(sdb.CVEDB, sum.BaseOS, localVulTraits, showTag, false)
 					nmap[id] = images2IDNames(rs, sum)
@@ -527,19 +533,29 @@ func (m *scanMethod) GetRegistryBenches(name string, tagMap map[string][]string,
 }
 
 func (m *scanMethod) getAllRegistryImageReport(id string, vpf scanUtils.VPFInterface, showTag string, tagMap map[string][]string, acc *access.AccessControl) (*api.RESTScanReport, error) {
-	rpt, _ := m.GetRegistryImageReport(common.RegistryRepoScanName, id, vpf, showTag, tagMap, acc)
+	// Suppress error: searching multiple registries; not found in one is expected
+	rpt, err := m.GetRegistryImageReport(common.RegistryRepoScanName, id, vpf, showTag, tagMap, acc)
+	if err != nil {
+		log.WithFields(log.Fields{"registry": common.RegistryRepoScanName, "id": id, "error": err}).Debug("Report not found in registry")
+	}
 	if rpt != nil {
 		return rpt, nil
 	}
 
-	rpt, _ = m.GetRegistryImageReport(common.RegistryFedRepoScanName, id, vpf, showTag, tagMap, acc)
+	rpt, err = m.GetRegistryImageReport(common.RegistryFedRepoScanName, id, vpf, showTag, tagMap, acc)
+	if err != nil {
+		log.WithFields(log.Fields{"registry": common.RegistryFedRepoScanName, "id": id, "error": err}).Debug("Report not found in registry")
+	}
 	if rpt != nil {
 		return rpt, nil
 	}
 
 	regs := regMapToArray(true, true)
 	for _, rs := range regs {
-		rpt, _ = m.GetRegistryImageReport(rs.config.Name, id, vpf, showTag, tagMap, acc)
+		rpt, err = m.GetRegistryImageReport(rs.config.Name, id, vpf, showTag, tagMap, acc)
+		if err != nil {
+			log.WithFields(log.Fields{"registry": rs.config.Name, "id": id, "error": err}).Debug("Report not found in registry")
+		}
 		if rpt != nil {
 			return rpt, nil
 		}

--- a/controller/scan/registry.go
+++ b/controller/scan/registry.go
@@ -371,7 +371,11 @@ func RegistryConfigHandler(nType cluster.ClusterNotifyType, key string, value []
 		}
 
 	case cluster.ClusterNotifyDelete:
-		if config, _, _ := clusHelper.GetRegistry(name, access.NewFedAdminAccessControl()); config != nil {
+		config, _, err := clusHelper.GetRegistry(name, access.NewFedAdminAccessControl())
+		if err != nil {
+			smd.scanLog.WithFields(log.Fields{"registry": name, "error": err}).Warn("Failed to get registry config on delete notification")
+		}
+		if config != nil {
 			// after kv data is unexpectedly wiped out, Restore() could be triggered very fast that RegistryConfigHandler(type=delete) is called after Restore() is done.
 			// in this case, do not really delete the restored registry & its scan data
 			smd.scanLog.WithFields(log.Fields{"registry": name}).Info("skip delete because it Still exists in kv")
@@ -1193,7 +1197,10 @@ func (rs *Registry) imageScanAdd(img *share.CLUSImage) {
 
 	var imageTagFilter *share.CLUSImage
 	for _, filter := range rs.config.ParsedFilters {
-		filteredRepos, _ := filterRepos(repos, filter, rs.config.CreaterDomains, 0)
+		filteredRepos, err := filterRepos(repos, filter, rs.config.CreaterDomains, 0)
+		if err != nil {
+			smd.scanLog.WithFields(log.Fields{"filter": filter, "error": err}).Warn("Failed to filter repos")
+		}
 		if len(filteredRepos) > 0 {
 			filteredRepos[0].Tag = filter.Tag
 			imageTagFilter = filteredRepos[0]
@@ -1206,7 +1213,10 @@ func (rs *Registry) imageScanAdd(img *share.CLUSImage) {
 		return
 	}
 
-	filteredTags, _ := filterTags(tags, imageTagFilter.Tag, 0)
+	filteredTags, err := filterTags(tags, imageTagFilter.Tag, 0)
+	if err != nil {
+		smd.scanLog.WithFields(log.Fields{"tag": imageTagFilter.Tag, "error": err}).Warn("Failed to filter tags")
+	}
 
 	if err := rs.backupDrv.Login(rs.config); err != nil {
 		smd.scanLog.WithFields(log.Fields{"registry": rs.config.Name, "error": err}).Error()

--- a/controller/scan/repo_test.go
+++ b/controller/scan/repo_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 
 	"github.com/neuvector/neuvector/controller/common"
 	"github.com/neuvector/neuvector/controller/kv"
@@ -130,7 +131,7 @@ func TestLocalRepoScan(t *testing.T) {
 	}
 
 	// Store another result, same name different ID
-	_ = smd.StoreRepoScanResult(&sr2)
+	require.NoError(t, smd.StoreRepoScanResult(&sr2))
 	key = share.CLUSRegistryImageStateKey(common.RegistryRepoScanName, sr1.ImageID)
 	_, ok = mockCluster.ScanSums[key]
 	if !ok {
@@ -175,13 +176,13 @@ func TestRemoteRepoScan(t *testing.T) {
 	newRepoScanRegistry(common.RegistryRepoScanName)
 
 	// store a local image
-	_ = smd.StoreRepoScanResult(&sr1)
+	require.NoError(t, smd.StoreRepoScanResult(&sr1))
 	key := share.CLUSRegistryImageStateKey(common.RegistryRepoScanName, sr1.ImageID)
 	sum := mockCluster.ScanSums[key]
 	RegistryImageStateUpdate(common.RegistryRepoScanName, sr1.ImageID, sum, false, nil)
 
 	// store a remote image
-	_ = smd.StoreRepoScanResult(&sr3)
+	require.NoError(t, smd.StoreRepoScanResult(&sr3))
 	key = share.CLUSRegistryImageStateKey(common.RegistryRepoScanName, sr3.ImageID)
 	sum = mockCluster.ScanSums[key]
 	RegistryImageStateUpdate(common.RegistryRepoScanName, sr3.ImageID, sum, false, nil)


### PR DESCRIPTION

## Description

Fixed 22 unhandled error returns across agent/dp/ctrl.go, agent/pipe/{clm,link_linux,no_tc,port,tc}.go, and
controller/scan/{interface,registry,repo_test}.go. Replaced net.ParseMAC constant calls with byte literals, added error logging for json.Marshal/netlink/db operations, and replaced blank-identifier test assertions with require.NoError.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

### Special notes for your reviewer

<!-- Please describe, if any special design or notes you want to share with your reviewer in this pull request -->

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
