### PR TITLE
refactor: add reexam intf if container's intf is empty at first time

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1852,6 +1852,9 @@ func examNetworkInterface(c *containerData) bool {
 		if intfAdded {
 			programBridge(c)
 			programDP(c, false, nil)
+		} else if schedErr := scheduleTask(c.id, c.info, TASK_REEXAM_INTF_CONTAINER, containerReexamIntfIPv4Min); schedErr != nil {
+			// If the interface is empty, schedule a task to reexam the interface 4s later.
+			log.WithFields(log.Fields{"id": c.id}).Error("schedule reexam intf failed")
 		}
 
 		if subnetChanged {


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
This is an improvement that in recent OpenShift cluster, customer's build pod cannot detect interfaces. 
There is a race condition, when the Build pod starts, NV intercept runs early which doesn't find any network interfaces(CNI not ready yet, or not fully ready). Then CNI/OVN finishes: veth + IP assigned to the pod early before NV starts to monitor interface changes. So during the build runs, there is no further netlink changes, which `intfMonitorLoop` is never triggered, and interfaces stay empty until pod exits.
This PR schedule a reexam after 4s if the first time interface is empty.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

### Special notes for your reviewer

<!-- Please describe, if any special design or notes you want to share with your reviewer in this pull request -->

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
