### PR TITLE
fix: allow explicit network rules in restrictive group mode

### DIFF
--- a/agent/policy/network.go
+++ b/agent/policy/network.go
@@ -958,7 +958,8 @@ func (e *Engine) parseGroupIPPolicy(p []share.CLUSGroupIPPolicy, workloadPolicyM
 					e.createWorkloadRule(from, to, &pp, pInfo, false, sameHost)
 				} else {
 					isFromNbe := pInfo.Nbe
-					isStrict := StrictGroupMode && utils.IsPolicyModeEnforce(from, addrMap) && !utils.IsPolicyModeEnforce(to, addrMap)
+					isStrict := StrictGroupMode && utils.IsPolicyModeEnforce(from, addrMap) &&
+						(!utils.IsPolicyModeEnforce(to, addrMap) || pp.ID > share.DefaultGroupRuleID)
 					// Only configure egress rule to external, as east-west egress traffic
 					// will be automatically allowed at DP
 					if isStrict || isFromNbe || to.WlID == share.CLUSWLExternal || to.WlID == share.CLUSWLAddressGroup ||
@@ -1002,7 +1003,8 @@ func (e *Engine) parseGroupIPPolicy(p []share.CLUSGroupIPPolicy, workloadPolicyM
 					e.createWorkloadRule(from, to, &pp, pInfo, true, sameHost)
 				} else {
 					isToNbe := pInfo.Nbe
-					isStrict := StrictGroupMode && utils.IsPolicyModeEnforce(to, addrMap) && !utils.IsPolicyModeEnforce(from, addrMap)
+					isStrict := StrictGroupMode && utils.IsPolicyModeEnforce(to, addrMap) &&
+						(!utils.IsPolicyModeEnforce(from, addrMap) || pp.ID > share.DefaultGroupRuleID)
 					// Only configure ingress rule from external, as east-west ingress traffic
 					// will be automatically allowed at DP
 					if isStrict || isToNbe || from.WlID == share.CLUSWLExternal || from.WlID == share.CLUSWLAddressGroup ||

--- a/controller/cache/policy.go
+++ b/controller/cache/policy.go
@@ -1589,7 +1589,7 @@ func reorgPolicyIPRulesPerNodePAI(rules []share.CLUSGroupIPPolicy) {
 							break
 						}
 					}
-					if isFromEnforce && !isToEnforce {
+					if isFromEnforce && (!isToEnforce || rul.ID > share.DefaultGroupRuleID) {
 						for _, addr := range rul.From {
 							if hid, ok := wlNode[addr.WlID]; ok {
 								t := tmpNodePolicySGM[hid]
@@ -1721,7 +1721,7 @@ func reorgPolicyIPRulesPerNode(rules []share.CLUSGroupIPPolicy) {
 						break
 					}
 				}
-				if isToEnforce && !isFromEnforce {
+				if isToEnforce && (!isFromEnforce || rul.ID > share.DefaultGroupRuleID) {
 					for _, addr := range rul.To {
 						if hid, ok := wlNode[addr.WlID]; ok {
 							t := tmpNodePolicySGM[hid]


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #2417 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
In Restrictive mode, dp no longer auto-allows east-west egress on K8s. Generate explicit egress/ingress dp rules for user-defined network rules(id > 0) when the enforcing side is in Protect mode, even if the peer is also in Protect mode. For more information, please check the detailed description in the issue.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

### Special notes for your reviewer

<!-- Please describe, if any special design or notes you want to share with your reviewer in this pull request -->

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
