### PR TITLE
fix(lint): resolve errcheck in dp, pipe, access, db, container, global, scan, and utils packages

### DIFF
--- a/agent/dp/ctrl.go
+++ b/agent/dp/ctrl.go
@@ -392,7 +392,11 @@ func DPCtrlConfigMAC(MACs []string, tap *bool, appMap map[share.CLUSProtoPort]*s
 		}
 		data.Cfg.Apps = &apps
 	}
-	msg, _ := json.Marshal(data)
+	msg, err := json.Marshal(data)
+	if err != nil {
+		log.WithError(err).Warn("failed to marshal DPConfigPort data")
+		return
+	}
 	dpSendMsg(msg)
 }
 
@@ -405,7 +409,11 @@ func DPCtrlConfigNBE(MACs []string, nbe *bool) {
 	if nbe != nil {
 		data.Cfg.Nbe = nbe
 	}
-	msg, _ := json.Marshal(data)
+	msg, err := json.Marshal(data)
+	if err != nil {
+		log.WithError(err).Warn("failed to marshal DPConfigNBE data")
+		return
+	}
 	dpSendMsg(msg)
 }
 
@@ -420,7 +428,11 @@ func DPCtrlAddPortPair(vex_iface, vin_iface string, epmac net.HardwareAddr, quar
 	if quar != nil {
 		data.AddPortPair.Quar = quar
 	}
-	msg, _ := json.Marshal(data)
+	msg, err := json.Marshal(data)
+	if err != nil {
+		log.WithError(err).Warn("failed to marshal DPAddPortPair data")
+		return
+	}
 	dpSendMsg(msg)
 }
 

--- a/agent/pipe/port.go
+++ b/agent/pipe/port.go
@@ -235,8 +235,7 @@ func pullContainerPort(
 		}
 	}
 	// Temp. set MAC address
-	tmp, _ := net.ParseMAC("00:01:02:03:04:05")
-	if err = netlink.LinkSetHardwareAddr(link, tmp); err != nil {
+	if err = netlink.LinkSetHardwareAddr(link, net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}); err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Error in changing MAC")
 		return 0, err
 	}

--- a/agent/pipe/tc.go
+++ b/agent/pipe/tc.go
@@ -102,11 +102,8 @@ func (d *tcPipeDriver) AttachPortPair(pair *InterceptPair) (net.HardwareAddr, ne
 	idx := d.attachPort(pair.exPort)
 
 	// 4e:65:75:56 - NeuV
-	var mac_str string
-	mac_str = fmt.Sprintf("4e:65:75:56:%02x:%02x", (idx>>8)&0xff, idx&0xff)
-	ucmac, _ := net.ParseMAC(mac_str)
-	mac_str = fmt.Sprintf("ff:ff:ff:00:%02x:%02x", (idx>>8)&0xff, idx&0xff)
-	bcmac, _ := net.ParseMAC(mac_str)
+	ucmac := net.HardwareAddr{0x4e, 0x65, 0x75, 0x56, byte((idx >> 8) & 0xff), byte(idx & 0xff)}
+	bcmac := net.HardwareAddr{0xff, 0xff, 0xff, 0x00, byte((idx >> 8) & 0xff), byte(idx & 0xff)}
 	return ucmac, bcmac
 }
 
@@ -414,7 +411,10 @@ func (d *tcPipeDriver) Connect(jumboframe bool) {
 }
 
 func (d *tcPipeDriver) Cleanup() {
-	link, _ := netlink.LinkByName(nvVbrPortName)
+	link, err := netlink.LinkByName(nvVbrPortName)
+	if err != nil {
+		log.WithError(err).Debug("failed to find NV bridge port during cleanup")
+	}
 	if link != nil {
 		d.delQDisc(nvVbrPortName)
 		if dbgError := netlink.LinkSetDown(link); dbgError != nil {

--- a/controller/access/access_test.go
+++ b/controller/access/access_test.go
@@ -354,7 +354,8 @@ func TestWildcardDomainAccess1(t *testing.T) {
 	obj := domainObjectTest{
 		CreatorDomains: []string{"app-US-*"},
 	}
-	req, _ := http.NewRequest(http.MethodGet, "https://10.1.1.1/v1/group/12345", nil) // method can be ignored because we use different op for testing later
+	req, err := http.NewRequest(http.MethodGet, "https://10.1.1.1/v1/group/12345", nil) // method can be ignored because we use different op for testing later
+	require.NoError(t, err)
 	userRole1 := &share.CLUSUserRoleInternal{
 		Name:        "role-1",
 		ReadPermits: share.PERMS_RUNTIME_POLICIES,
@@ -409,7 +410,8 @@ func TestWildcardDomainAccess2(t *testing.T) {
 	obj := domainObjectTest{
 		CreatorDomains: []string{"app-1", "app-US-dev"},
 	}
-	req, _ := http.NewRequest(http.MethodGet, "https://10.1.1.1/v1/group/12345", nil) // method can be ignored because we use different op for testing later
+	req, err := http.NewRequest(http.MethodGet, "https://10.1.1.1/v1/group/12345", nil) // method can be ignored because we use different op for testing later
+	require.NoError(t, err)
 	userRole1 := &share.CLUSUserRoleInternal{
 		Name:        "role-1",
 		ReadPermits: share.PERMS_RUNTIME_POLICIES,
@@ -463,7 +465,8 @@ func TestWildcardDomainAccess3(t *testing.T) {
 	obj := domainObjectTest{
 		CreatorDomains: []string{"app-1", "app-US-*"},
 	}
-	req, _ := http.NewRequest(http.MethodGet, "https://10.1.1.1/v1/group/12345", nil) // method can be ignored because we use different op for testing later
+	req, err := http.NewRequest(http.MethodGet, "https://10.1.1.1/v1/group/12345", nil) // method can be ignored because we use different op for testing later
+	require.NoError(t, err)
 	userRole1 := &share.CLUSUserRoleInternal{
 		Name:        "role-1",
 		ReadPermits: share.PERMS_RUNTIME_POLICIES,

--- a/db/querystats.go
+++ b/db/querystats.go
@@ -79,7 +79,10 @@ func GetQueryStat(token string) (*QueryStat, error) {
 	dialect := goqu.Dialect("sqlite3")
 
 	columns := []interface{}{"id", "token", "create_timestamp", "login_type", "login_id", "login_name", "data1", "data2", "data3", "filedb_ready", "type"}
-	sql, args, _ := dialect.From(queryStatTablename).Select(columns...).Where(goqu.C("token").Eq(token)).Prepared(true).ToSQL()
+	sql, args, err := dialect.From(queryStatTablename).Select(columns...).Where(goqu.C("token").Eq(token)).Prepared(true).ToSQL()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
 
 	var lastErr error
 	for retry := 0; retry < 50; retry++ {
@@ -126,8 +129,11 @@ func GetExceededSessions(loginName, loginID string, loginType int) ([]string, er
 	if loginType == 1 {
 		nLimit = 2 // apikey
 	}
-	// sql, args, _ := dialect.From(Table_querystats).Select(columns...).Where(goqu.And(expLoginName, expLoginId)).Order(goqu.C("create_timestamp").Desc()).Limit(100).Offset(uint(nLimit)).Prepared(true).ToSQL()
-	sql, args, _ := dialect.From(Table_querystats).Select(columns...).Where(goqu.And(expLoginName)).Order(goqu.C("create_timestamp").Desc()).Limit(100).Offset(uint(nLimit)).Prepared(true).ToSQL()
+	// sql, args, err := dialect.From(Table_querystats).Select(columns...).Where(goqu.And(expLoginName, expLoginId)).Order(goqu.C("create_timestamp").Desc()).Limit(100).Offset(uint(nLimit)).Prepared(true).ToSQL()
+	sql, args, err := dialect.From(Table_querystats).Select(columns...).Where(goqu.And(expLoginName)).Order(goqu.C("create_timestamp").Desc()).Limit(100).Offset(uint(nLimit)).Prepared(true).ToSQL()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
 
 	rows, err := dbHandle.Query(sql, args...)
 	if err != nil {
@@ -147,7 +153,10 @@ func GetExceededSessions(loginName, loginID string, loginType int) ([]string, er
 
 	// exceed 2 hours of create_timestamp
 	t := time.Now().UTC().Unix() - 7200
-	sql, args, _ = dialect.From(Table_querystats).Select(columns...).Where(goqu.Ex{"create_timestamp": goqu.Op{"lt": t}}).Prepared(true).ToSQL()
+	sql, args, err = dialect.From(Table_querystats).Select(columns...).Where(goqu.Ex{"create_timestamp": goqu.Op{"lt": t}}).Prepared(true).ToSQL()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build time-based query: %w", err)
+	}
 
 	rows, err = dbHandle.Query(sql, args...)
 	if err != nil {

--- a/share/container/crio.go
+++ b/share/container/crio.go
@@ -93,7 +93,10 @@ func crioConnect(endpoint string, sys *system.SystemTools) (Runtime, error) {
 	}
 
 	var sockPath string
-	id, _, _ := sys.GetSelfContainerID() // not relaible, could be sandboxID
+	id, _, err := sys.GetSelfContainerID() // not reliable, could be sandboxID
+	if err != nil {
+		log.WithError(err).Debug("failed to get self container ID")
+	}
 	id, _ = criGetSelfID(cri, ctx, id)
 	sockPath, err = criGetContainerSocketPath(cri, ctx, id, endpoint) // update id
 	if err == nil {
@@ -114,7 +117,9 @@ func crioConnect(endpoint string, sys *system.SystemTools) (Runtime, error) {
 			log.WithFields(log.Fields{"error": err}).Error("Fail to get pause image info")
 		} else {
 			driver.podImgRepoDigest = repoDig
-			_ = driver.setPodImageInfo()
+			if err := driver.setPodImageInfo(); err != nil {
+				log.WithError(err).Warn("failed to set pod image info")
+			}
 			log.WithFields(log.Fields{"repoDig": driver.podImgRepoDigest, "imgID": driver.podImgID, "imgDigest": driver.podImgDigest}).Debug("CRIO:")
 		}
 	}
@@ -412,7 +417,11 @@ func (d *crioDriver) getContainer(id string, ctx context.Context) (*ContainerMet
 		}
 
 		// image ID
-		if image, _ := d.GetImage(meta.Image); image != nil {
+		image, err := d.GetImage(meta.Image)
+		if err != nil {
+			log.WithError(err).Debug("failed to get image")
+		}
+		if image != nil {
 			meta.ImageID = image.ID
 			meta.Author = image.Author
 			meta.ImgCreateAt = image.CreatedAt
@@ -425,11 +434,15 @@ func (d *crioDriver) getContainer(id string, ctx context.Context) (*ContainerMet
 		} else {
 			// 2nd chance
 			if meta.ImageID == "" && meta.ImageDigest != "" {
-				if image, _ := d.GetImage(cs.Status.ImageRef); image != nil {
-					meta.ImageID = image.ID
-					meta.Author = image.Author
-					meta.ImgCreateAt = image.CreatedAt
-					for k, v := range image.Labels {
+				image2, err := d.GetImage(cs.Status.ImageRef)
+				if err != nil {
+					log.WithError(err).Debug("failed to get image by ref")
+				}
+				if image2 != nil {
+					meta.ImageID = image2.ID
+					meta.Author = image2.Author
+					meta.ImgCreateAt = image2.CreatedAt
+					for k, v := range image2.Labels {
 						// Not to overwrite container labels when merging
 						if _, ok := meta.Labels[k]; !ok {
 							meta.Labels[k] = v
@@ -477,7 +490,11 @@ func (d *crioDriver) getContainer(id string, ctx context.Context) (*ContainerMet
 			meta.ImageDigest = d.podImgDigest
 		} else {
 			meta.ImageDigest = imageRef2Digest(meta.Image)
-			if imageMeta, _ := d.GetImage(meta.Image); imageMeta != nil {
+			imageMeta, err := d.GetImage(meta.Image)
+			if err != nil {
+				log.WithError(err).Debug("failed to get pod image")
+			}
+			if imageMeta != nil {
 				meta.ImageID = imageMeta.ID
 				meta.Author = imageMeta.Author
 			}

--- a/share/container/stub.go
+++ b/share/container/stub.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -61,7 +62,10 @@ func InitStubRtDriver(sys *system.SystemTools) (Runtime, error) {
 	log.Info()
 	ppid := os.Getppid()
 
-	id, _, _, _ = sys.GetContainerIDByPID(ppid)
+	id, _, err, _ := sys.GetContainerIDByPID(ppid)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.WithError(err).Debug("failed to get container ID by PID")
+	}
 	if dat, err := os.ReadFile("/etc/hostname"); err == nil {
 		podname = strings.TrimSpace(string(dat))
 		if dat, err = os.ReadFile("/etc/hosts"); err == nil {

--- a/share/container/types.go
+++ b/share/container/types.go
@@ -491,11 +491,13 @@ func obtainRtEndpointFromKubelet(sys *system.SystemTools) (string, string, bool)
 		if files, err := d.Readdir(-1); err != nil {
 			log.WithFields(log.Fields{"err": err}).Error("read")
 		} else {
-			var pid int
 			for _, file := range files {
 				if file.IsDir() {
 					// get all the process
-					pid, _ = strconv.Atoi(file.Name())
+					pid, err := strconv.Atoi(file.Name())
+					if err != nil {
+						continue // not a numeric PID directory
+					}
 					if cmds, err := sys.ReadCmdLine(pid); err == nil && len(cmds) > 0 {
 						if endpt, ok := isK3sLikely(cmds); ok {
 							return defaultK3sContainerdSock, endpt, true

--- a/share/global/global.go
+++ b/share/global/global.go
@@ -233,12 +233,12 @@ func IdentifyK8sContainerID(id string) (string, error) {
 }
 
 func (d *orchHub) SetFlavor(flavor string) error {
-	_ = d.Driver.SetFlavor(flavor)
+	var driverErr, resourceErr error
+	driverErr = d.Driver.SetFlavor(flavor)
 	if d.ResourceDriver != nil {
-		_ = d.ResourceDriver.SetFlavor(flavor)
+		resourceErr = d.ResourceDriver.SetFlavor(flavor)
 	}
-
-	return nil
+	return errors.Join(driverErr, resourceErr)
 }
 
 func SetPseudoOrchHub_UnitTest(platform, flavor, k8sVer, ocVer string, regResource RegisterDriverFunc) {

--- a/share/orchestration/kubernetes_test.go
+++ b/share/orchestration/kubernetes_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestKubeProxy(t *testing.T) {
@@ -22,9 +24,7 @@ func TestKubeProxy(t *testing.T) {
 		},
 	}
 
-	if !driver.isKubeProxy(&wl) {
-		t.Errorf("Unable to ignore kube-proxy pod\n")
-	}
+	assert.True(t, driver.isKubeProxy(&wl), "Unable to ignore kube-proxy pod")
 
 	wl = share.CLUSWorkload{
 		Labels: map[string]string{
@@ -34,9 +34,7 @@ func TestKubeProxy(t *testing.T) {
 		},
 	}
 
-	if !driver.isKubeProxy(&wl) {
-		t.Errorf("Unable to ignore kube-proxy container\n")
-	}
+	assert.True(t, driver.isKubeProxy(&wl), "Unable to ignore kube-proxy container")
 }
 
 func TestKubeRancherImportService(t *testing.T) {
@@ -58,9 +56,9 @@ func TestKubeRancherImportService(t *testing.T) {
 		},
 	}
 
-	if svc := driver.GetService(&meta, ""); svc.Domain != "cattle-system" || svc.Name != "rancher-agent" {
-		t.Errorf("Invalid service for Rancher agent container: %+v\n", svc)
-	}
+	svc := driver.GetService(&meta, "")
+	assert.Equal(t, "cattle-system", svc.Domain, "Invalid service domain for Rancher agent container")
+	assert.Equal(t, "rancher-agent", svc.Name, "Invalid service name for Rancher agent container")
 
 	meta = container.ContainerMeta{
 		Labels: map[string]string{
@@ -97,9 +95,9 @@ func TestKubeRancherImportService(t *testing.T) {
 		},
 	}
 
-	if svc := driver.GetService(&meta, ""); svc.Domain != "cattle-system" || svc.Name != "core-services-metadata" {
-		t.Errorf("Invalid service for Rancher metadata container: %+v\n", svc)
-	}
+	svc = driver.GetService(&meta, "")
+	assert.Equal(t, "cattle-system", svc.Domain, "Invalid service domain for Rancher metadata container")
+	assert.Equal(t, "core-services-metadata", svc.Name, "Invalid service name for Rancher metadata container")
 }
 
 func TestKubeService(t *testing.T) {
@@ -120,9 +118,7 @@ func TestKubeService(t *testing.T) {
 		},
 	}
 
-	if svc := driver.GetService(&meta, ""); svc.Name != "httpserver-pod-20" {
-		t.Errorf("Invalid service name with matching hash: %+v\n", svc.Name)
-	}
+	assert.Equal(t, "httpserver-pod-20", driver.GetService(&meta, "").Name, "10-digit hash: service name")
 
 	meta = container.ContainerMeta{
 		Labels: map[string]string{
@@ -139,9 +135,7 @@ func TestKubeService(t *testing.T) {
 		},
 	}
 
-	if svc := driver.GetService(&meta, ""); svc.Name != "httpserver-pod-20" {
-		t.Errorf("Invalid service name with matching hash: %+v\n", svc.Name)
-	}
+	assert.Equal(t, "httpserver-pod-20", driver.GetService(&meta, "").Name, "9-digit hash: service name")
 
 	meta = container.ContainerMeta{
 		Labels: map[string]string{
@@ -158,9 +152,9 @@ func TestKubeService(t *testing.T) {
 		},
 	}
 
-	if svc := driver.GetService(&meta, ""); svc.Domain != "default" || svc.Name != "httpserver-pod-20" {
-		t.Errorf("Invalid service name without matching hash: %+v\n", svc)
-	}
+	svc := driver.GetService(&meta, "")
+	assert.Equal(t, "default", svc.Domain, "non-matching hash: service domain")
+	assert.Equal(t, "httpserver-pod-20", svc.Name, "non-matching hash: service name")
 
 	meta = container.ContainerMeta{
 		Labels: map[string]string{
@@ -176,9 +170,9 @@ func TestKubeService(t *testing.T) {
 		},
 	}
 
-	if svc := driver.GetService(&meta, ""); svc.Domain != "default" || svc.Name != "calico-node" {
-		t.Errorf("Invalid service name: %+v\n", svc)
-	}
+	svc = driver.GetService(&meta, "")
+	assert.Equal(t, "default", svc.Domain, "calico-node: service domain")
+	assert.Equal(t, "calico-node", svc.Name, "calico-node: service name")
 
 	meta = container.ContainerMeta{
 		Labels: map[string]string{
@@ -207,9 +201,9 @@ func TestKubeService(t *testing.T) {
 		},
 	}
 
-	if svc := driver.GetService(&meta, ""); svc.Domain != "connectservices" || svc.Name != "update-traveler-service" {
-		t.Errorf("Invalid service name: %+v\n", svc)
-	}
+	svc = driver.GetService(&meta, "")
+	assert.Equal(t, "connectservices", svc.Domain, "OpenShift: service domain")
+	assert.Equal(t, "update-traveler-service", svc.Name, "OpenShift: service name")
 
 	// IBM
 	meta = container.ContainerMeta{
@@ -224,9 +218,9 @@ func TestKubeService(t *testing.T) {
 		},
 	}
 
-	if svc := driver.GetService(&meta, ""); svc.Domain != "kube-system" || svc.Name != "ibm-kube-fluentd" {
-		t.Errorf("Invalid service name: %+v\n", svc)
-	}
+	svc = driver.GetService(&meta, "")
+	assert.Equal(t, "kube-system", svc.Domain, "IBM: service domain")
+	assert.Equal(t, "ibm-kube-fluentd", svc.Name, "IBM: service name")
 }
 
 func TestScriptTemplate(t *testing.T) {
@@ -251,12 +245,8 @@ if [ $? -eq 0 ]; then
 fi
 `
 	script.Reset()
-	_ = driver.createCleanupScript(&script, test)
-	e := strings.TrimSpace(ret)
-	r := strings.TrimSpace(script.String())
-	if e != r {
-		t.Errorf("Error: \nexpect=\n%v\nactual=\n%v\n", e, r)
-	}
+	require.NoError(t, driver.createCleanupScript(&script, test))
+	assert.Equal(t, strings.TrimSpace(ret), strings.TrimSpace(script.String()))
 
 	// --
 	test = map[string][]share.CLUSIPAddr{
@@ -282,12 +272,8 @@ if [ $? -eq 0 ]; then
 fi
 `
 	script.Reset()
-	_ = driver.createCleanupScript(&script, test)
-	e = strings.TrimSpace(ret)
-	r = strings.TrimSpace(script.String())
-	if e != r {
-		t.Errorf("Error: \nexpect=\n%v\nactual=\n%v\n", e, r)
-	}
+	require.NoError(t, driver.createCleanupScript(&script, test))
+	assert.Equal(t, strings.TrimSpace(ret), strings.TrimSpace(script.String()))
 
 	// --
 	test = map[string][]share.CLUSIPAddr{
@@ -320,12 +306,8 @@ if [ $? -eq 0 ]; then
 fi
 `
 	script.Reset()
-	_ = driver.createCleanupScript(&script, test)
-	e = strings.TrimSpace(ret)
-	r = strings.TrimSpace(script.String())
-	if e != r {
-		t.Errorf("Error: \nexpect=\n%v\nactual=\n%v\n", e, r)
-	}
+	require.NoError(t, driver.createCleanupScript(&script, test))
+	assert.Equal(t, strings.TrimSpace(ret), strings.TrimSpace(script.String()))
 
 	// --
 	test = map[string][]share.CLUSIPAddr{
@@ -340,12 +322,8 @@ if [ $? -eq 0 ]; then
 fi
 `
 	script.Reset()
-	_ = driver.createCleanupScript(&script, test)
-	e = strings.TrimSpace(ret)
-	r = strings.TrimSpace(script.String())
-	if e != r {
-		t.Errorf("Error: \nexpect=\n%v\nactual=\n%v\n", e, r)
-	}
+	require.NoError(t, driver.createCleanupScript(&script, test))
+	assert.Equal(t, strings.TrimSpace(ret), strings.TrimSpace(script.String()))
 }
 
 func TestKubeServiceName_nodename(t *testing.T) {
@@ -361,9 +339,7 @@ func TestKubeServiceName_nodename(t *testing.T) {
 		},
 	}
 
-	if svc := driver.GetService(&pod_meta, "qalongruncluster4oc4-kxq6x-master-2"); svc.Name != "apiserver-watcher" {
-		t.Errorf("Invalid service name: %+v\n", svc.Name)
-	}
+	assert.Equal(t, "apiserver-watcher", driver.GetService(&pod_meta, "qalongruncluster4oc4-kxq6x-master-2").Name)
 }
 
 func TestKubeServiceName_batchnumber_nodename(t *testing.T) {
@@ -379,9 +355,7 @@ func TestKubeServiceName_batchnumber_nodename(t *testing.T) {
 		},
 	}
 
-	if svc := driver.GetService(&pod_meta, "qalongruncluster4oc4-kxq6x-master-2"); svc.Name != "installer" {
-		t.Errorf("Invalid service name: %+v\n", svc.Name)
-	}
+	assert.Equal(t, "installer", driver.GetService(&pod_meta, "qalongruncluster4oc4-kxq6x-master-2").Name)
 }
 
 func TestIbmClusterID(t *testing.T) {
@@ -403,9 +377,7 @@ func TestIbmClusterID(t *testing.T) {
 		},
 	}
 
-	if svc := driver.GetService(&pod_meta, ""); svc.Name != "rbac-sync-operator" {
-		t.Errorf("Invalid service name: %+v\n", svc.Name)
-	}
+	assert.Equal(t, "rbac-sync-operator", driver.GetService(&pod_meta, "").Name)
 }
 
 func TestUUIDSuffix(t *testing.T) {
@@ -430,9 +402,7 @@ func TestUUIDSuffix(t *testing.T) {
 		},
 	}
 
-	if svc := driver.GetService(&pod_meta, ""); svc.Name != "kubx-deployer" {
-		t.Errorf("Invalid service name: %+v\n", svc.Name)
-	}
+	assert.Equal(t, "kubx-deployer", driver.GetService(&pod_meta, "").Name)
 }
 
 func TestKubxEtcdBackupApp(t *testing.T) {
@@ -455,7 +425,5 @@ func TestKubxEtcdBackupApp(t *testing.T) {
 		},
 	}
 
-	if svc := driver.GetService(&pod_meta, ""); svc.Name != "kubx-etcd-backup" {
-		t.Errorf("Invalid service name: %+v\n", svc.Name)
-	}
+	assert.Equal(t, "kubx-etcd-backup", driver.GetService(&pod_meta, "").Name)
 }

--- a/share/osutil/process_linux.go
+++ b/share/osutil/process_linux.go
@@ -77,13 +77,19 @@ func GetProcessPIDs(pid int) (ppid, gid, sid int, status, cmd string) {
 	}
 
 	status = procStatusMap[sa[2]]
-	ppid, _ = strconv.Atoi(sa[3])
+	ppid, err = strconv.Atoi(sa[3])
+	if err != nil {
+		log.WithError(err).Debug("failed to parse ppid from proc stat")
+	}
 
 	if len(sa) < 5 {
 		return
 	}
 
-	gid, _ = strconv.Atoi(sa[4])
+	gid, err = strconv.Atoi(sa[4])
+	if err != nil {
+		log.WithError(err).Debug("failed to parse gid from proc stat")
+	}
 	sid, _ = strconv.Atoi(sa[5])
 	return
 }
@@ -236,10 +242,16 @@ func getCGroupSocketTable(rootPid int, tbl map[uint32]SocketInfo, file string, t
 
 		// TCP: TCP_LISTEN, UDP: TCP_CLOSE (idle)
 		if (tcp && tokens[3] == "0A") || (!tcp && tokens[3] == "07") {
-			fd, _ := strconv.ParseUint(tokens[9], 10, 32)
+			fd, err := strconv.ParseUint(tokens[9], 10, 32)
+			if err != nil {
+				log.WithError(err).Debug("failed to parse inode from net table")
+			}
 			inode := uint32(fd)
 			ip_port := strings.Split(tokens[1], ":")
-			port, _ := strconv.ParseUint(ip_port[1], 16, 16)
+			port, err := strconv.ParseUint(ip_port[1], 16, 16)
+			if err != nil {
+				log.WithError(err).Debug("failed to parse port from net table")
+			}
 			if tcp {
 				tbl[inode] = SocketInfo{Port: uint16(port), IPProto: syscall.IPPROTO_TCP, INode: inode}
 			} else {

--- a/share/scan/gobuild.go
+++ b/share/scan/gobuild.go
@@ -223,7 +223,10 @@ func parseBuildInfo(data string) (bi *BuildInfo, err error) {
 				if c := kv[len(rawKey)]; c != '=' {
 					return nil, fmt.Errorf("unexpected character after quoted key: %q", c)
 				}
-				key, _ = strconv.Unquote(rawKey)
+				key, err = strconv.Unquote(rawKey)
+				if err != nil {
+					return nil, fmt.Errorf("failed to unquote key %q: %w", rawKey, err)
+				}
 				rawValue = kv[len(rawKey)+1:]
 
 			default:

--- a/share/scan/registry.go
+++ b/share/scan/registry.go
@@ -31,8 +31,10 @@ type RegClient struct {
 func NewRegClient(url, token, username, password, proxy string, trace httptrace.HTTPTrace) *RegClient {
 	log.WithFields(log.Fields{"url": url}).Debug("")
 
-	// Ignore errors
-	hub, _, _ := registry.New(url, token, username, password, proxy, trace)
+	hub, _, err := registry.New(url, token, username, password, proxy, trace)
+	if err != nil {
+		log.WithError(err).Warn("failed to create registry client")
+	}
 	return &RegClient{Registry: hub}
 }
 

--- a/share/scan/secrets/secrets_test.go
+++ b/share/scan/secrets/secrets_test.go
@@ -10,12 +10,14 @@ import (
 	"testing"
 
 	"github.com/neuvector/neuvector/share/utils"
+	"github.com/stretchr/testify/require"
 )
 
 // ////////////////////
 func TestSampleFiles(t *testing.T) {
-	path, _ := filepath.Abs("samples")
-	// path, _ := filepath.Abs("/etc")
+	path, err := filepath.Abs("samples")
+	require.NoError(t, err)
+	// path, err = filepath.Abs("/etc")
 
 	/////
 	var myFileSpec = []FileType{

--- a/share/system/cgroup_test.go
+++ b/share/system/cgroup_test.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDockerIDDebian(t *testing.T) {
@@ -699,7 +701,8 @@ func TestDockerNative_Container_Cgroupv2(t *testing.T) {
 	}
 
 	// Optional:
-	_, _ = r.Seek(0, io.SeekStart)
+	_, err := r.Seek(0, io.SeekStart)
+	require.NoError(t, err)
 	id, _, found = getContainerIDByCgroupReaderV2(r, from_fscgroup)
 	if id != "1f1d6e2d4940ddac13abd421a2617992bf89f0e0f9a902ed58278c5f843e9ae7" || !found {
 		t.Errorf("detect wrong container ID, fscgroup: %v, %v\n", id, found)
@@ -755,7 +758,8 @@ func TestDockerK8s_Ubuntu_Container_Cgroupv2(t *testing.T) {
 	}
 
 	// Optional:
-	_, _ = r.Seek(0, io.SeekStart)
+	_, err := r.Seek(0, io.SeekStart)
+	require.NoError(t, err)
 	id, _, found = getContainerIDByCgroupReaderV2(r, from_fscgroup)
 	if id != "2cc65c162ca1388b6b8d5ccfb701d22fc96675ccf8b2f1590c490c2c4039547f" || !found {
 		t.Errorf("detect wrong dcontainer ID, fscgroup: %v, %v\n", id, found)

--- a/share/utils/extract.go
+++ b/share/utils/extract.go
@@ -36,7 +36,10 @@ func ExtractAllArchiveData(r io.Reader, maxFileSize int64) (map[string][]byte, e
 			log.WithFields(log.Fields{"size": size, "filename": filename}).Error("file too big")
 			return tarutil.ErrExtractedFileTooBig
 		}
-		d, _ := io.ReadAll(reader)
+		d, err := io.ReadAll(reader)
+		if err != nil {
+			return fmt.Errorf("failed to read file %q: %w", filename, err)
+		}
 		data[filename] = d
 		return nil
 	}
@@ -86,10 +89,16 @@ func ExtractAllArchiveToFiles(path string, r io.Reader, maxFileSize int64, encry
 
 		// Extract the element
 		if hdr.Typeflag == tar.TypeReg {
-			data, _ := io.ReadAll(tr)
+			data, err := io.ReadAll(tr)
+			if err != nil {
+				return fmt.Errorf("failed to read archive entry %q: %w", filename, err)
+			}
 
 			if encryptKey != nil {
-				data, _ = Encrypt(encryptKey, data)
+				data, err = Encrypt(encryptKey, data)
+				if err != nil {
+					return fmt.Errorf("failed to encrypt file %q: %w", filename, err)
+				}
 			}
 
 			err = os.WriteFile(path+filename, data, 0400)

--- a/share/utils/perf.go
+++ b/share/utils/perf.go
@@ -123,8 +123,15 @@ func PerfSnapshot(pid int, memLimit, profileLimit, usage uint64, folder, cid, pr
 		}
 
 		// get auxiliary data
-		lsof, _ := sh.Command("lsof", "+D", "/usr/local/bin").Output()
-		ps, _ := sh.Command("ps", "-o", "%cpu,pid,ppid,pgid,vsz,rss,ni,comm", "-g", strconv.Itoa(pid)).Output()
+		// Suppress error: these diagnostic commands may fail on some environments
+		lsof, err := sh.Command("lsof", "+D", "/usr/local/bin").Output()
+		if err != nil {
+			log.WithError(err).Debug("lsof command failed")
+		}
+		ps, err := sh.Command("ps", "-o", "%cpu,pid,ppid,pgid,vsz,rss,ni,comm", "-g", strconv.Itoa(pid)).Output()
+		if err != nil {
+			log.WithError(err).Debug("ps command failed")
+		}
 		data := snapshotData{
 			RecordedAt:        lastSnapshot,
 			MemoryLimit:       memLimit,
@@ -136,7 +143,11 @@ func PerfSnapshot(pid int, memLimit, profileLimit, usage uint64, folder, cid, pr
 			Lsof:              strings.Split(string(lsof), "\n"),
 			Ps:                strings.Split(string(ps), "\n"),
 		}
-		file, _ := json.MarshalIndent(data, "", " ")
+		file, err := json.MarshalIndent(data, "", " ")
+		if err != nil {
+			log.WithError(err).Warn("failed to marshal snapshot data")
+			return
+		}
 
 		// get golang profiles
 		req := &share.CLUSProfilingRequest{

--- a/share/utils/utils.go
+++ b/share/utils/utils.go
@@ -155,12 +155,20 @@ func GetGuid() (string, error) {
 }
 
 func GetTimeUUID(t time.Time) string {
-	uuid, _ := simpleuuid.NewTime(t)
+	uuid, err := simpleuuid.NewTime(t)
+	if err != nil {
+		log.WithError(err).Warn("failed to create time UUID")
+		return ""
+	}
 	return uuid.String()
 }
 
 func GetStringUUID(s string) string {
-	uuid, _ := simpleuuid.NewString(s)
+	uuid, err := simpleuuid.NewString(s)
+	if err != nil {
+		log.WithError(err).Warn("failed to create string UUID")
+		return ""
+	}
 	return uuid.String()
 }
 
@@ -194,7 +202,10 @@ func GunzipBytes(buf []byte) []byte {
 		return nil
 	}
 	defer r.Close()
-	uzb, _ := io.ReadAll(r)
+	uzb, err := io.ReadAll(r)
+	if err != nil {
+		log.WithError(err).Warn("failed to read gzip data")
+	}
 	return uzb
 }
 
@@ -302,7 +313,11 @@ func NewEnvironParser(envs []string) *EnvironParser {
 				switch k {
 				case share.ENV_PLATFORM_INFO:
 					// platform=aliyun;if-eth0=local;if-eth1=global
-					p.platformEnv, _ = parseQuery(v)
+					var err error
+					p.platformEnv, err = parseQuery(v)
+					if err != nil {
+						log.WithError(err).Warn("failed to parse platform env")
+					}
 				case share.ENV_SYSTEM_GROUPS:
 					// NV_SYSTEM_GROUPS=ucp-*;calico-*
 					p.sysGroups = make([]*regexp.Regexp, 0)
@@ -829,7 +844,10 @@ func GetGID() uint64 {
 	b = b[:runtime.Stack(b, false)]
 	b = bytes.TrimPrefix(b, []byte("goroutine "))
 	b = b[:bytes.IndexByte(b, ' ')]
-	n, _ := strconv.ParseUint(string(b), 10, 64)
+	n, err := strconv.ParseUint(string(b), 10, 64)
+	if err != nil {
+		log.WithError(err).Debug("failed to parse goroutine ID")
+	}
 	return n
 }
 
@@ -1013,7 +1031,10 @@ func DecryptPassword(encrypted string) string {
 		return ""
 	}
 
-	password, _ := DecryptFromBase64(getPasswordSymKey(), encrypted)
+	password, err := DecryptFromBase64(getPasswordSymKey(), encrypted)
+	if err != nil {
+		log.WithError(err).Warn("failed to decrypt password")
+	}
 	return password
 }
 

--- a/share/utils/utils_test.go
+++ b/share/utils/utils_test.go
@@ -1,13 +1,12 @@
 package utils
 
 import (
+	"net"
 	"testing"
 
-	"net"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/neuvector/neuvector/share"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNormalizeForURL(t *testing.T) {
@@ -80,8 +79,10 @@ func TestSubnetContains(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		_, n1, _ := net.ParseCIDR(c.n1)
-		_, n2, _ := net.ParseCIDR(c.n2)
+		_, n1, err := net.ParseCIDR(c.n1)
+		require.NoError(t, err)
+		_, n2, err := net.ParseCIDR(c.n2)
+		require.NoError(t, err)
 		contain, compare := SubnetContains(n1, n2)
 		if contain != c.contain || compare != c.compare {
 			t.Errorf("Error: n1=%v n2=%v\n", n1.String(), n2.String())
@@ -128,7 +129,8 @@ func TestSubnetLoose(t *testing.T) {
 		{"1.2.3.4/32", share.CLUSIPAddrScopeGlobal, "1.2.3.0/24"},
 	}
 	for _, c := range cases {
-		_, ipnet, _ := net.ParseCIDR(c.input)
+		_, ipnet, err := net.ParseCIDR(c.input)
+		require.NoError(t, err)
 		parsed := IPNet2SubnetLoose(ipnet, c.scope)
 		if parsed.String() != c.output {
 			t.Errorf("Error: input=%s scope=%s", c.input, c.scope)


### PR DESCRIPTION

## Description

Fix 50 unchecked error returns across 20 files: propagate errors where possible, log at appropriate levels (Warn default, Debug for high-frequency or advisory paths), and use t.Fatalf/require.NoError in test code. Notable: replace net.ParseMAC with byte-literal HardwareAddr in tc.go to eliminate the error path entirely for format-computed MACs.


## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

### Special notes for your reviewer

<!-- Please describe, if any special design or notes you want to share with your reviewer in this pull request -->

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
