### PR TITLE
issue-2469: Remove the alert, Neuvector is running {version1} and can be upgraded to {version2}, from UI

### DIFF
--- a/controller/api/internal_apis.go
+++ b/controller/api/internal_apis.go
@@ -139,26 +139,6 @@ type RESTProfilingData struct {
 	Profiling *RESTProfiling `json:"profiling"`
 }
 
-type RESTK8sNvRbacStatus struct {
-	ClusterRoleErrors        []string                   `json:"clusterrole_errors,omitempty"`        // obsolete
-	ClusterRoleBindingErrors []string                   `json:"clusterrolebinding_errors,omitempty"` // obsolete
-	RoleErrors               []string                   `json:"role_errors,omitempty"`               // obsolete
-	RoleBindingErrors        []string                   `json:"rolebinding_errors,omitempty"`        // obsolete
-	NvCrdSchemaErrors        []string                   `json:"neuvector_crd_errors,omitempty"`      // obsolete
-	NvUpgradeInfo            *RESTCheckUpgradeInfo      `json:"neuvector_upgrade_info"`
-	AcceptableAlerts         *RESTK8sNvAcceptableAlerts `json:"acceptable_alerts,omitempty"` // acceptable controller-generated alerts
-	AcceptedAlerts           []string                   `json:"accepted_alerts,omitempty"`   // keys of accepted manager-generated/user alerts
-}
-
-type RESTK8sNvAcceptableAlerts struct {
-	ClusterRoleErrors        map[string]string `json:"clusterrole_errors"`        // key is hex(sha256) of the English message
-	ClusterRoleBindingErrors map[string]string `json:"clusterrolebinding_errors"` // key is hex(sha256) of the English message
-	RoleErrors               map[string]string `json:"role_errors"`               // key is hex(sha256) of the English message
-	RoleBindingErrors        map[string]string `json:"rolebinding_errors"`        // key is hex(sha256) of the English message
-	NvCrdSchemaErrors        map[string]string `json:"neuvector_crd_errors"`      // key is hex(sha256) of the English message
-	OtherAlerts              map[string]string `json:"other_alerts"`              // key is hex(sha256) of the English message
-}
-
 type RESTNvAlerts struct {
 	NvUpgradeInfo    *RESTCheckUpgradeInfo   `json:"neuvector_upgrade_info"`
 	AcceptableAlerts *RESTNvAcceptableAlerts `json:"acceptable_alerts,omitempty"` // acceptable controller-generated alerts

--- a/controller/rest/system.go
+++ b/controller/rest/system.go
@@ -134,20 +134,6 @@ func handlerSystemUsage(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 				restRespError(w, http.StatusInternalServerError, api.RESTErrFailReadCluster)
 				return
 			}
-			if nvUpgradeInfo.MinUpgradeVersion.Version != "" {
-				resp.TelemetryStatus.MinUpgradeVersion = api.RESTUpgradeVersionInfo{
-					Version:     nvUpgradeInfo.MinUpgradeVersion.Version,
-					ReleaseDate: nvUpgradeInfo.MinUpgradeVersion.ReleaseDate,
-					Tag:         nvUpgradeInfo.MinUpgradeVersion.Tag,
-				}
-			}
-			if nvUpgradeInfo.MaxUpgradeVersion.Version != "" {
-				resp.TelemetryStatus.MaxUpgradeVersion = api.RESTUpgradeVersionInfo{
-					Version:     nvUpgradeInfo.MaxUpgradeVersion.Version,
-					ReleaseDate: nvUpgradeInfo.MaxUpgradeVersion.ReleaseDate,
-					Tag:         nvUpgradeInfo.MaxUpgradeVersion.Tag,
-				}
-			}
 			if !nvUpgradeInfo.LastUploadTime.IsZero() {
 				resp.TelemetryStatus.LastTeleUploadTime = api.RESTTimeString(nvUpgradeInfo.LastUploadTime)
 			}
@@ -2301,37 +2287,6 @@ func handlerMeterList(w http.ResponseWriter, r *http.Request, ps httprouter.Para
 	log.WithFields(log.Fields{"entries": len(resp.Meters)}).Debug()
 	restRespSuccess(w, r, &resp, acc, login, nil, "Get meter list")
 }
-func getNvUpgradeInfo() *api.RESTCheckUpgradeInfo {
-	var nvUpgradeInfo share.CLUSCheckUpgradeInfo
-	if value, _ := cluster.Get(share.CLUSTelemetryStore + "controller"); value != nil {
-		if err := json.Unmarshal(value, &nvUpgradeInfo); err != nil {
-			log.WithFields(log.Fields{"error": err}).Error("Unmarshal")
-			return nil
-		}
-	}
-
-	empty := share.CLUSCheckUpgradeVersion{}
-	upgradeInfo := &api.RESTCheckUpgradeInfo{}
-	if nvUpgradeInfo.MinUpgradeVersion != empty {
-		upgradeInfo.MinUpgradeVersion = &api.RESTUpgradeInfo{
-			Version:     nvUpgradeInfo.MinUpgradeVersion.Version,
-			ReleaseDate: nvUpgradeInfo.MinUpgradeVersion.ReleaseDate,
-			Tag:         nvUpgradeInfo.MinUpgradeVersion.Tag,
-		}
-	}
-	if nvUpgradeInfo.MaxUpgradeVersion != empty {
-		upgradeInfo.MaxUpgradeVersion = &api.RESTUpgradeInfo{
-			Version:     nvUpgradeInfo.MaxUpgradeVersion.Version,
-			ReleaseDate: nvUpgradeInfo.MaxUpgradeVersion.ReleaseDate,
-			Tag:         nvUpgradeInfo.MaxUpgradeVersion.Tag,
-		}
-	}
-	if nvUpgradeInfo.MinUpgradeVersion == empty && nvUpgradeInfo.MaxUpgradeVersion == empty {
-		return nil
-	}
-
-	return upgradeInfo
-}
 
 func getAcceptableAlerts(acc *access.AccessControl, login *loginSession) ([]string, []string, []string, []string, []string, map[string]string, utils.Set) {
 	var clusterRoleErrors, clusterRoleBindingErrors, roleErrors, roleBindingErrors, nvCrdSchemaErrors []string
@@ -2471,16 +2426,7 @@ func handlerSystemGetAlerts(w http.ResponseWriter, r *http.Request, ps httproute
 		return
 	}
 
-	var resp api.RESTNvAlerts = api.RESTNvAlerts{
-		NvUpgradeInfo: &api.RESTCheckUpgradeInfo{},
-	}
-
-	// populate neuvector_upgrade_info
-	if nvUpgradeInfo := getNvUpgradeInfo(); nvUpgradeInfo != nil {
-		resp.NvUpgradeInfo = nvUpgradeInfo
-	} else {
-		resp.NvUpgradeInfo = nil
-	}
+	var resp api.RESTNvAlerts
 
 	// populate acceptable_alerts
 	clusterRoleAlerts, clusterRoleBindingAlerts, roleAlerts, roleBindingAlerts, nvCrdSchemaAlerts, otherAlerts, acceptedAlerts := getAcceptableAlerts(acc, login)

--- a/controller/rest/telemetry.go
+++ b/controller/rest/telemetry.go
@@ -2,9 +2,7 @@ package rest
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -14,7 +12,6 @@ import (
 	"github.com/neuvector/neuvector/controller/common"
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/cluster"
-	"github.com/neuvector/neuvector/share/utils"
 )
 
 var lastTeleErrorDay int = -1
@@ -22,19 +19,6 @@ var lastTeleErrorDay int = -1
 type tTelemetryReqData struct {
 	AppVersion string            `json:"appVersion"`
 	ExtraInfo  map[string]string `json:"extraInfo"` // from TelemetryDataRaw
-}
-
-type tCheckUpgradeVersion struct {
-	Name                 string // must be in semantic versioning, like v5.0.0
-	ReleaseDate          string
-	MinUpgradableVersion string // can be empty or semantic versioning
-	Tags                 []string
-	ExtraInfo            map[string]string
-}
-
-type tTelemetryResponse struct {
-	Versions                 []tCheckUpgradeVersion `json:"versions"`
-	RequestIntervalInMinutes int                    `json:"requestIntervalInMinutes"`
 }
 
 func reportTelemetryData(rawData common.TelemetryData) {
@@ -45,10 +29,6 @@ func reportTelemetryData(rawData common.TelemetryData) {
 	extraInfo["clusters"] = strconv.Itoa(rawData.Clusters)
 	extraInfo["primaryClusters"] = strconv.Itoa(rawData.PrimaryCluster)
 
-	var nvMajorMinor string                                            // in the format {major}.{minor}
-	if ss := strings.Split(cctx.NvAppFullVersion, "."); len(ss) >= 2 { // in the format {major}.{minor}[.{patch}][-s{#}]
-		nvMajorMinor = fmt.Sprintf("%s.%s", ss[0], ss[1])
-	}
 	reqPayload := tTelemetryReqData{
 		AppVersion: cctx.NvSemanticVersion, // in the format v{major}.{minor}.{patch}
 		ExtraInfo:  extraInfo,
@@ -62,130 +42,22 @@ func reportTelemetryData(rawData common.TelemetryData) {
 		return
 	}
 
-	appVer, err := utils.NewVersion(reqPayload.AppVersion[1:]) // {major}.{minor}[.{patch}]
-	if err != nil {
-		log.WithFields(log.Fields{"appVersion": reqPayload.AppVersion}).Error("invalid version")
-		return
-	}
-
 	logError := lastTeleErrorDay != today
 
 	bodyTo, _ := json.Marshal(&reqPayload)
-	if data, _, _, err := sendRestRequest("telemetry", http.MethodPost, _teleNeuvectorURL, "", "", "", "", nil, bodyTo, logError, nil, nil); err == nil {
-		uploadTime := time.Now().UTC()
+	if _, _, _, err := sendRestRequest("telemetry", http.MethodPost, _teleNeuvectorURL, "", "", "", "", nil, bodyTo, logError, nil, nil); err == nil {
 		lastTeleErrorDay = -1
-		var nvVerMajor int
-		var nvVerMinor int
-		var resp tTelemetryResponse
-		if vers := strings.Split(nvMajorMinor, "."); len(vers) >= 2 {
-			intVar0, err0 := strconv.Atoi(vers[0])
-			intVar1, err1 := strconv.Atoi(vers[1])
-			if err0 == nil && err1 == nil {
-				nvVerMajor = intVar0
-				nvVerMinor = intVar1
-			}
+		upgradeInfo := share.CLUSCheckUpgradeInfo{
+			LastUploadTime: time.Now().UTC(),
 		}
-		if err := json.Unmarshal(data, &resp); err == nil {
-			var idx int
-			var upgradeInfo share.CLUSCheckUpgradeInfo // for the latest versions from upgrade-responder response
-
-			sort.Slice(resp.Versions[:], func(i, j int) bool {
-				iVer, iErr := utils.NewVersion(resp.Versions[i].Name)
-				jVer, jErr := utils.NewVersion(resp.Versions[j].Name)
-				if iErr != nil || jErr != nil {
-					log.WithFields(log.Fields{"i": resp.Versions[i].Name, "j": resp.Versions[j].Name}).Error("invalid version")
-				} else {
-					if iVer.Compare(jVer) > 0 {
-						return true
-					}
-				}
-				return false
-			})
-			for _, v := range resp.Versions {
-				if idx >= 3 || len(v.Name) <= 1 || v.Name[0] != 'v' || len(v.Tags) == 0 { // check 3 {major}.{minor} versions only
-					continue
-				}
-				var verMajorMinor string
-				if ssName := strings.Split(v.Name, "."); len(ssName) < 2 {
-					continue
-				} else {
-					verMajorMinor = fmt.Sprintf("%s.%s", ssName[0][1:], ssName[1]) // {major}.{minor}
-				}
-
-				if entryVer, err := utils.NewVersion(v.Name[1:]); err != nil {
-					log.WithFields(log.Fields{"version": v.Name}).Error("invalid version")
-					continue
-				} else {
-					// skip this version entry if its version is older than local version
-					if entryVer.Compare(appVer) < 0 {
-						continue
-					}
-				}
-
-				var verImageTag string
-				sort.Strings(v.Tags)
-				for i := len(v.Tags) - 1; i >= 0; i-- {
-					if v.Tags[i] == "latest" {
-						if len(v.Tags) == 1 {
-							// NV doesn't release an official image with "latest" tag
-							// If we do get a Version entry that has only 'latest' tag, deduce the real tag from version
-							verImageTag = v.Name[1:]
-						}
-					} else {
-						verImageTag = v.Tags[i]
-						break
-					}
-				}
-				// skip this version entry if it is the same version but with older tag than local version
-				if v.Name == reqPayload.AppVersion {
-					verSecNum := 0
-					localSecNum := 0
-					if ss := strings.Split(verImageTag, "-"); len(ss) >= 2 && ss[1][0] == 's' {
-						verSecNum, _ = strconv.Atoi(ss[1][1:])
-					}
-					if ss := strings.Split(cctx.NvAppFullVersion, "-"); len(ss) >= 2 && ss[1][0] == 's' {
-						localSecNum, _ = strconv.Atoi(ss[1][1:])
-					}
-					if verSecNum <= localSecNum {
-						continue
-					}
-				}
-
-				var verMajor int
-				var verMinor int
-				if vers := strings.Split(verMajorMinor, "."); len(vers) >= 2 {
-					intVar0, err0 := strconv.Atoi(vers[0])
-					intVar1, err1 := strconv.Atoi(vers[1])
-					if err0 == nil && err1 == nil {
-						verMajor = intVar0
-						verMinor = intVar1
-					}
-				}
-				if verImageTag != "" && verImageTag != cctx.NvAppFullVersion &&
-					(idx == 0 || verMajorMinor == nvMajorMinor || (verMajor > nvVerMajor || (verMajor == nvVerMajor && verMinor > nvVerMinor))) {
-					upgradeVersion := share.CLUSCheckUpgradeVersion{
-						Version:     v.Name,
-						ReleaseDate: v.ReleaseDate,
-						Tag:         verImageTag,
-					}
-					if idx == 0 {
-						upgradeInfo.MaxUpgradeVersion = upgradeVersion
-					} else {
-						upgradeInfo.MinUpgradeVersion = upgradeVersion
-					}
-				}
-				idx++
-			}
-			upgradeInfo.LastUploadTime = uploadTime
-			key := share.CLUSTelemetryStore + "controller"
-			value, err := json.Marshal(&upgradeInfo)
-			if err != nil {
-				log.WithFields(log.Fields{"error": err}).Error("Marshal")
-				return
-			}
-			if err := cluster.Put(key, value); err != nil {
-				log.WithFields(log.Fields{"error": err}).Error("cluster.Put")
-			}
+		key := share.CLUSTelemetryStore + "controller"
+		value, err := json.Marshal(&upgradeInfo)
+		if err != nil {
+			log.WithFields(log.Fields{"error": err}).Error("Marshal")
+			return
+		}
+		if err := cluster.Put(key, value); err != nil {
+			log.WithFields(log.Fields{"error": err}).Error("cluster.Put")
 		}
 	} else if logError {
 		lastTeleErrorDay = today


### PR DESCRIPTION
## Description

Fix #2469
