### PR TITLE
fix(lint): resolve errcheck in agent, cluster, and kv/config packages

### DIFF
--- a/agent/bench.go
+++ b/agent/bench.go
@@ -1303,7 +1303,11 @@ func (b *Bench) putBenchReport(id string, bench share.BenchType, items []*benchI
 		default:
 			key = share.CLUSBenchStateWorkloadKey(id)
 		}
-		value, _ = json.Marshal(&share.CLUSBenchState{RunAt: now})
+		value, err = json.Marshal(&share.CLUSBenchState{RunAt: now})
+		if err != nil {
+			log.WithError(err).Warn("Failed to marshal bench state")
+			return
+		}
 		if dbgError := cluster.PutBinary(key, value); dbgError != nil {
 			log.WithFields(log.Fields{"dbgError": dbgError}).Debug()
 		}

--- a/agent/cluster.go
+++ b/agent/cluster.go
@@ -356,14 +356,22 @@ func putLocalInfo() {
 		return
 	}
 
-	value, _ := json.Marshal(Host)
+	value, err := json.Marshal(Host)
+	if err != nil {
+		log.WithError(err).Warn("Failed to marshal host info")
+		return
+	}
 	key := share.CLUSHostKey(Host.ID, "agent")
 	if err := cluster.Put(key, value); err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("")
 	}
 
 	Agent.ClusterIP = selfAddr
-	value, _ = json.Marshal(Agent)
+	value, err = json.Marshal(Agent)
+	if err != nil {
+		log.WithError(err).Warn("Failed to marshal agent info")
+		return
+	}
 	key = share.CLUSAgentKey(Host.ID, Agent.ID)
 	if err := cluster.Put(key, value); err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("")
@@ -373,7 +381,11 @@ func putLocalInfo() {
 func putHostIfInfo() {
 	log.Debug()
 
-	value, _ := json.Marshal(Host)
+	value, err := json.Marshal(Host)
+	if err != nil {
+		log.WithError(err).Warn("Failed to marshal host info")
+		return
+	}
 	key := share.CLUSHostKey(Host.ID, "agent")
 	if err := cluster.Put(key, value); err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("")

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -1265,7 +1265,11 @@ func fillContainerProperties(c *containerData, parent *containerData,
 		log.WithError(err).WithField("pid", info.Pid).Debug("Failed to get container cpuacct cgroup path")
 	}
 
-	c.upperDir, c.rootFs, _ = lookupContainerLayerPath(c.pid, c.id)
+	c.upperDir, c.rootFs, err = lookupContainerLayerPath(c.pid, c.id)
+	if err != nil {
+		// Suppress error: storage driver may not support layer path lookup
+		log.WithError(err).Debug("Failed to lookup container layer path")
+	}
 	c.propertyFilled = true
 	log.WithFields(log.Fields{"uppDir": c.upperDir, "rootFs": c.rootFs, "id": c.id}).Debug()
 }
@@ -1734,7 +1738,12 @@ func startNeuVectorMonitors(id, role string, info *container.ContainerMetaExtra)
 	if agentEnv.containerShieldMode {
 		prober.BuildProcessFamilyGroups(c.id, c.nvRole, c.pid, false, info.Privileged, nil)
 		pe.InsertNeuvectorProcessProfilePolicy(group, role)
-		c.upperDir, c.rootFs, _ = lookupContainerLayerPath(c.pid, c.id)
+		var err error
+		c.upperDir, c.rootFs, err = lookupContainerLayerPath(c.pid, c.id)
+		if err != nil {
+			// Suppress error: storage driver may not support layer path lookup
+			log.WithError(err).Debug("Failed to lookup container layer path")
+		}
 		// file monitors : protect mode, core-definitions, only modification alerts
 		fileWatcher.ContainerCleanup(c.pid, false)
 		conf := &fsmon.FsmonConfig{Profile: &fsmon.DefaultContainerConf}

--- a/controller/kv/config.go
+++ b/controller/kv/config.go
@@ -130,7 +130,10 @@ func applyTransaction(txn *cluster.ClusterTransact, importTask *share.CLUSImport
 				if importTask.Status != share.IMPORT_RUNNING {
 					importTask.Status = share.IMPORT_RUNNING
 				}
-				_ = clusHelper.PutImportTask(importTask) // Ignore error because progress update is non-critical
+				if err := clusHelper.PutImportTask(importTask); err != nil {
+					// Suppress error: progress update is non-critical
+					log.WithError(err).Debug("Failed to update import task progress")
+				}
 			}
 		}
 	}
@@ -249,7 +252,10 @@ func (c *configHelper) startBackupThread() {
 		for {
 			select {
 			case <-c.backupTimer.C:
-				_ = c.doBackup()
+				if err := c.doBackup(); err != nil {
+					// Log error: this is the top of goroutine
+					log.WithError(err).Warn("Failed to backup config")
+				}
 			case <-c_sig:
 				break LOOP
 			}
@@ -278,7 +284,9 @@ func (c *configHelper) isKvRestoring() (string, bool) {
 		log.WithError(err).Warn("Failed to get KV restore key")
 	}
 	if value != nil {
-		_ = nvJsonUnmarshal(share.CLUSKvRestoreKey, value, &kvRestore)
+		if err := nvJsonUnmarshal(share.CLUSKvRestoreKey, value, &kvRestore); err != nil {
+			log.WithError(err).Warn("Failed to unmarshal KV restore state")
+		}
 		if !kvRestore.StartAt.IsZero() && time.Since(kvRestore.StartAt) < time.Duration(2)*time.Minute {
 			return kvRestore.CtrlerID, true
 		}
@@ -314,7 +322,9 @@ func (c *configHelper) doBackup() error {
 		fedRole, _ := getFedRole()
 		return c.foreachWithLock(cfgEndpoints, func(ep *cfgEndpoint, txn *cluster.ClusterTransact) error { // txn is not used for backup
 			if changes.Contains(ep.name) {
-				_ = ep.backup(fedRole)
+				if err := ep.backup(fedRole); err != nil {
+					log.WithError(err).Warn("Failed to backup endpoint")
+				}
 			}
 			return nil
 		}, nil)
@@ -340,7 +350,9 @@ func (c *configHelper) BackupAll() {
 	}
 	c.cfgMutex.Unlock()
 	c.backupTimer.Reset(backupDelayIdle)
-	_ = c.writeBackupVersion()
+	if err := c.writeBackupVersion(); err != nil {
+		log.WithError(err).Warn("Failed to write backup version")
+	}
 }
 
 func restoreEP(ep *cfgEndpoint, ch chan<- error, importInfo *fedRulesRevInfo) error {
@@ -392,7 +404,10 @@ func (c *configHelper) Restore(host share.CLUSHost, ctrler share.CLUSController)
 		scanRevs, rev, err := clusHelper.GetFedScanRevisions()
 		if err == nil && scanRevs.Restoring {
 			scanRevs.Restoring = false
-			_ = clusHelper.PutFedScanRevisions(&scanRevs, &rev)
+			err = clusHelper.PutFedScanRevisions(&scanRevs, &rev)
+			if err != nil {
+				log.WithError(err).Warn("Failed to put fed scan revisions")
+			}
 		}
 
 		return "", false, false, "", nil
@@ -407,7 +422,9 @@ func (c *configHelper) Restore(host share.CLUSHost, ctrler share.CLUSController)
 					log.WithFields(log.Fields{"id": id}).Info("Restoring is ongoing")
 					skipRestore = true
 				} else {
-					_ = cluster.Put(share.CLUSKvRestoreKey, kvRestoreValue)
+					if err := cluster.Put(share.CLUSKvRestoreKey, kvRestoreValue); err != nil {
+						log.WithError(err).Warn("Failed to set KV restore key")
+					}
 				}
 			} else {
 				log.WithFields(log.Fields{"ver": ver}).Info("No need")
@@ -500,20 +517,30 @@ func (c *configHelper) Restore(host share.CLUSHost, ctrler share.CLUSController)
 	c.cfgMutex.Unlock()
 
 	ver := getBackupVersion()
-	_ = putControlVersion(&ver)
+	if putErr := putControlVersion(&ver); putErr != nil {
+		log.WithError(putErr).Warn("Failed to write control version after restore")
+		if err == nil {
+			err = putErr // propagate only when no earlier restore error exists
+		}
+	}
 	log.WithFields(log.Fields{"version": ver}).Info("Done")
 
 	if len(importInfo.fedRulesRevValue) > 0 {
 		log.WithFields(log.Fields{"fedRulesRevValue": importInfo.fedRulesRevValue}).Info()
 		var fedRulesRev share.CLUSFedRulesRevision
 		if err := json.Unmarshal([]byte(importInfo.fedRulesRevValue), &fedRulesRev); err == nil {
-			_ = clusHelper.PutFedRulesRevision(nil, &fedRulesRev)
+			if err := clusHelper.PutFedRulesRevision(nil, &fedRulesRev); err != nil {
+				log.WithError(err).Warn("Failed to put fed rules revision")
+			}
 		} else {
 			log.WithFields(log.Fields{"err": err}).Info("Unmarshal")
 		}
 	}
 
-	_ = cluster.Delete(share.CLUSKvRestoreKey)
+	// use delErr to avoid overwriting the restore error accumulated in err
+	if delErr := cluster.Delete(share.CLUSKvRestoreKey); delErr != nil {
+		log.WithError(delErr).Warn("Failed to delete KV restore key")
+	}
 
 	return importInfo.fedRole, importInfo.defAdminRestored, true, ver.KVVersion, err
 }
@@ -692,7 +719,10 @@ func (c *configHelper) importInternal(rpcEps []*common.RPCEndpoint, localCtrlerI
 	importTask.Percentage += 1
 	importTask.LastUpdateTime = time.Now().UTC()
 	importTask.Status = share.IMPORT_RUNNING
-	_ = clusHelper.PutImportTask(importTask) // Ignore error because progress update is non-critical
+	if err := clusHelper.PutImportTask(importTask); err != nil {
+		// Suppress error: progress update is non-critical
+		log.WithError(err).Debug("Failed to update import task progress")
+	}
 
 	// Consul gets unexpectedly killed while importing a large file. We suspect the active write and watch
 	// actions triggers race conditions in consul, so here the object store watch is paused.

--- a/controller/nvk8sapi/neuvectorcrd/crd.go
+++ b/controller/nvk8sapi/neuvectorcrd/crd.go
@@ -54,8 +54,13 @@ func (b *nvCrdSchmaBuilder) Init() {
 		share.DefaultPolicyName,
 	}
 	b.enumMap = make(map[string][]byte, len(enums))
+	var err error
 	for _, k := range enums {
-		b.enumMap[k], _ = json.Marshal(k)
+		b.enumMap[k], err = json.Marshal(k)
+		if err != nil {
+			// Suppress error: json.Marshal of string never fails in practice
+			log.WithError(err).Debug("Failed to marshal enum key")
+		}
 	}
 }
 

--- a/share/cluster/consul.go
+++ b/share/cluster/consul.go
@@ -182,7 +182,9 @@ func createConfigFile(cc *ClusterConfig) error {
 		Performance             tConsulConfigPerformance `json:"performance"`
 	}
 
-	_ = os.MkdirAll(consulDataDir, os.ModePerm)
+	if err := os.MkdirAll(consulDataDir, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create consul data directory: %w", err)
+	}
 	f, err := os.Create(consulConf)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Failed to create consul config file")
@@ -244,8 +246,7 @@ func isBootstrap(cc *ClusterConfig) bool {
 func (m *consulMethod) stopRunningInstance() error {
 	if m.pid > 0 {
 		if err := syscall.Kill((-1)*m.pid, syscall.SIGKILL); err != nil {
-			log.WithFields(log.Fields{"pid": m.pid, "error": err}).Error("can not signal")
-			return err
+			return fmt.Errorf("failed to signal consul pid %d: %w", m.pid, err)
 		}
 
 		// it should be very soon but we add some buffering time
@@ -259,8 +260,7 @@ func (m *consulMethod) stopRunningInstance() error {
 		}
 
 		if nWaitCnt == 0 {
-			log.WithFields(log.Fields{"pid": m.pid}).Error("can not stop")
-			return errors.New("Can not stop consul")
+			return fmt.Errorf("timed out stopping consul pid %d", m.pid)
 		}
 		m.pid = 0
 	}
@@ -277,7 +277,10 @@ func (m *consulMethod) getClient() (*api.Client, error) {
 }
 
 func (m *consulMethod) Start(cc *ClusterConfig, eCh chan error, recover bool) {
-	_ = m.stopRunningInstance()
+	if err := m.stopRunningInstance(); err != nil {
+		// Log error: stale consul process may still hold ports; starting a new one risks split-brain
+		log.WithError(err).Error("Failed to stop running consul instance")
+	}
 
 	args := []string{"agent", "-datacenter", cc.DataCenter, "-data-dir", consulDataDir}
 
@@ -415,7 +418,9 @@ func (m *consulMethod) Leave(server bool) error {
 	log.Info("Consul process exit")
 
 	if server {
-		_ = m.leaveRaft(m.clusterIP)
+		if err := m.leaveRaft(m.clusterIP); err != nil {
+			log.WithError(err).Warn("Failed to remove local node from raft")
+		}
 	}
 
 	cmd := exec.Command(consulExe, "leave")
@@ -433,7 +438,9 @@ func (m *consulMethod) Leave(server bool) error {
 func (m *consulMethod) ForceLeave(node string, server bool) error {
 
 	if server {
-		_ = m.leaveRaft(node)
+		if err := m.leaveRaft(node); err != nil {
+			log.WithError(err).Warn("Failed to remove node from raft")
+		}
 	}
 
 	c, err := m.getClient()

--- a/share/cluster/messenger.go
+++ b/share/cluster/messenger.go
@@ -156,7 +156,15 @@ func (msgr *msgrMethod) unicast(subject, key string, data []byte, cb UnicastCall
 	}
 
 	msg := CLUSUnicast{Expect: expect, Data: data}
-	value, _ := json.Marshal(msg)
+	value, err := json.Marshal(msg)
+	if err != nil {
+		log.WithError(err).Warn("Failed to marshal unicast message")
+		if cb != nil {
+			msgr.unicastRemoveReceiver(expect)
+			cb(subject, nil, args...)
+		}
+		return err
+	}
 
 	if err := Put(key, value); err != nil {
 		if cb != nil {
@@ -178,7 +186,9 @@ func (msgr *msgrMethod) unicast(subject, key string, data []byte, cb UnicastCall
 	}
 
 	if delKey {
-		_ = Delete(key)
+		if err := Delete(key); err != nil {
+			log.WithError(err).Warn("Failed to delete unicast message key")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Fix 20 errcheck issues across 7 files:
- agent/bench.go: handle json.Marshal error for bench state
- agent/cluster.go: handle json.Marshal errors in putLocalInfo and putHostIfInfo
- agent/engine.go: handle lookupContainerLayerPath errors (Debug: storage driver may not support it)
- controller/nvk8sapi/neuvectorcrd/crd.go: handle json.Marshal in enum initialization
- share/cluster/consul.go: propagate MkdirAll error; move stopRunningInstance logging to caller; log leaveRaft failures
- share/cluster/messenger.go: handle json.Marshal and Delete errors in Unicast
- controller/kv/config.go: handle PutImportTask, doBackup, cluster.Get, ep.backup, writeBackupVersion, PutFedScanRevisions, cluster.Put, PutFedRulesRevision, cluster.Delete errors


## Test

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

### Special notes for your reviewer

<!-- Please describe, if any special design or notes you want to share with your reviewer in this pull request -->

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
