### PR TITLE
fix(lint): resolve errcheck in batch 2 (agent, controller/cache, controller/kv, db, share)

### DIFF
--- a/agent/pipe/tc.go
+++ b/agent/pipe/tc.go
@@ -382,11 +382,19 @@ func (d *tcPipeDriver) GetPortPairRules(pair *InterceptPair) (string, string, st
 
 	if inInfo, ok := d.portMap[pair.inPort]; ok {
 		cmd = fmt.Sprintf("tc filter show dev %v pref %v parent ffff:", nvVbrPortName, inInfo.pref)
-		inEnfRules, _ = shellCombined(cmd)
+		inEnfRules, err = shellCombined(cmd)
+		if err != nil {
+			// Suppress error: diagnostic command, failures are non-fatal
+			log.WithFields(log.Fields{"error": err}).Debug("Failed to get in enforcement rules")
+		}
 	}
 	if exInfo, ok := d.portMap[pair.exPort]; ok {
 		cmd = fmt.Sprintf("tc filter show dev %v pref %v parent ffff:", nvVbrPortName, exInfo.pref)
-		exEnfRules, _ = shellCombined(cmd)
+		exEnfRules, err = shellCombined(cmd)
+		if err != nil {
+			// Suppress error: diagnostic command, failures are non-fatal
+			log.WithFields(log.Fields{"error": err}).Debug("Failed to get ex enforcement rules")
+		}
 	}
 
 	return strings.ReplaceAll(string(inRules[:]), "\t", "    "),

--- a/agent/timer.go
+++ b/agent/timer.go
@@ -284,7 +284,11 @@ func putFqdnIps() {
 
 	for _, fqdnip := range fqdnips {
 		key := share.CLUSFqdnIpKey(Host.ID, fqdnip.FqdnName)
-		value, _ := json.Marshal(fqdnip)
+		value, err := json.Marshal(fqdnip)
+		if err != nil {
+			log.WithError(err).Warn("Failed to marshal fqdnip")
+			continue
+		}
 		zb := utils.GzipBytes(value)
 		log.WithFields(log.Fields{"key": key, "fqdnip": fqdnip}).Debug("Put fqdn ip")
 		if err := cluster.PutBinary(key, zb); err != nil {
@@ -321,7 +325,11 @@ func putThreatLogs() {
 
 	if len(tlogs) > 0 {
 		key := share.CLUSThreatLogKey(Host.ID, Agent.ID)
-		value, _ := json.Marshal(tlogs)
+		value, err := json.Marshal(tlogs)
+		if err != nil {
+			log.WithError(err).Warn("Failed to marshal threat logs")
+			return
+		}
 		zb := utils.GzipBytes(value)
 		log.WithFields(log.Fields{"key": key}).Debug("Put threat log")
 		if err := cluster.PutBinary(key, zb); err != nil {
@@ -339,7 +347,11 @@ func putIncidentLogs() {
 
 	if len(tmp) > 0 {
 		key := share.CLUSIncidentLogKey(Host.ID, Agent.ID)
-		value, _ := json.Marshal(tmp)
+		value, err := json.Marshal(tmp)
+		if err != nil {
+			log.WithError(err).Warn("Failed to marshal incident logs")
+			return
+		}
 		zb := utils.GzipBytes(value)
 		log.WithFields(log.Fields{"key": key, "len": len(tmp)}).Debug("Put incident log")
 		if err := cluster.PutBinary(key, zb); err != nil {

--- a/controller/cache/custom_role.go
+++ b/controller/cache/custom_role.go
@@ -63,7 +63,10 @@ func userRoleConfigUpdate(nType cluster.ClusterNotifyType, key string, value []b
 	switch nType {
 	case cluster.ClusterNotifyAdd, cluster.ClusterNotifyModify:
 		var role share.CLUSUserRole
-		_ = json.Unmarshal(value, &role)
+		if err := json.Unmarshal(value, &role); err != nil {
+			log.WithError(err).Warn("Failed to unmarshal custom role")
+			return
+		}
 		if roleInternal := parseUserRolePermissions(&role); roleInternal != nil {
 			access.AddRole(name, roleInternal)
 		}

--- a/controller/cache/domain.go
+++ b/controller/cache/domain.go
@@ -109,7 +109,10 @@ func domainConfigUpdate(nType cluster.ClusterNotifyType, key string, value []byt
 	switch nType {
 	case cluster.ClusterNotifyAdd, cluster.ClusterNotifyModify:
 		var domain share.CLUSDomain
-		_ = json.Unmarshal(value, &domain)
+		if err := json.Unmarshal(value, &domain); err != nil {
+			log.WithError(err).Warn("Failed to unmarshal domain")
+			return
+		}
 
 		domainMutex.Lock()
 		oDomain := domainCacheMap[name]

--- a/controller/cache/federation.go
+++ b/controller/cache/federation.go
@@ -251,7 +251,10 @@ func fedConfigUpdate(nType cluster.ClusterNotifyType, key string, value []byte) 
 		case share.CLUSFedClustersStatusSubKey:
 			id := share.CLUSFedKey2ClusterIdKey(key)
 			var status share.CLUSFedClusterStatus
-			_ = json.Unmarshal(value, &status)
+			if err := json.Unmarshal(value, &status); err != nil {
+				log.WithError(err).Warn("Failed to unmarshal federation cluster status")
+				return
+			}
 			if status.Nodes == 0 {
 				status.Nodes = 1
 			}

--- a/controller/cache/group.go
+++ b/controller/cache/group.go
@@ -1138,7 +1138,10 @@ func rmEmptyGroupsFromCluster() {
 	defer txn.Close()
 
 	for _, name := range groups {
-		cg, _, _ := clusHelper.GetGroup(name, accAll)
+		cg, _, err := clusHelper.GetGroup(name, accAll)
+		if err != nil {
+			log.WithFields(log.Fields{"group": name, "error": err}).Warn("Failed to get group from kv")
+		}
 		if cg == nil {
 			log.WithFields(log.Fields{"group": name}).Error("Group doesn't exist in kv")
 			delete(groupCacheMap, name)
@@ -1331,7 +1334,9 @@ func hostWorkloadStart(id string, param interface{}) {
 		}
 		host.runningCntrs.Add(wl.ID)
 		host.workloads.Add(wl.ID)
-		_ = db.UpdateHostContainers(wl.HostID, host.workloads.Cardinality())
+		if err := db.UpdateHostContainers(wl.HostID, host.workloads.Cardinality()); err != nil {
+			log.WithError(err).Warn("Failed to update host container count")
+		}
 	}
 }
 
@@ -1359,7 +1364,9 @@ func hostWorkloadDelete(id string, param interface{}) {
 		host.runningPods.Remove(wl.ID)
 		host.runningCntrs.Remove(wl.ID)
 		host.workloads.Remove(wl.ID)
-		_ = db.UpdateHostContainers(wl.HostID, host.workloads.Cardinality())
+		if err := db.UpdateHostContainers(wl.HostID, host.workloads.Cardinality()); err != nil {
+			log.WithError(err).Warn("Failed to update host container count")
+		}
 	}
 }
 
@@ -1986,16 +1993,28 @@ func (m CacheMethod) DeleteGroupCache(name string, acc *access.AccessControl) er
 
 	txn := cluster.Transact()
 	//delete group related policy
-	_ = clusHelper.DeleteProcessProfileTxn(txn, name)
-	_ = clusHelper.DeleteFileMonitorTxn(txn, name)
+	if err := clusHelper.DeleteProcessProfileTxn(txn, name); err != nil {
+		log.WithError(err).Warn("Failed to delete process profile txn")
+	}
+	if err := clusHelper.DeleteFileMonitorTxn(txn, name); err != nil {
+		log.WithError(err).Warn("Failed to delete file monitor txn")
+	}
 	if cache != nil && cache.group != nil {
 		if cache.group.Kind == share.GroupKindContainer {
-			_ = clusHelper.DeleteDlpGroup(txn, name)
-			_ = clusHelper.DeleteWafGroup(txn, name)
+			if err := clusHelper.DeleteDlpGroup(txn, name); err != nil {
+				log.WithError(err).Warn("Failed to delete DLP group")
+			}
+			if err := clusHelper.DeleteWafGroup(txn, name); err != nil {
+				log.WithError(err).Warn("Failed to delete WAF group")
+			}
 		}
 	}
-	_ = clusHelper.DeleteCustomCheckConfig(txn, name)
-	_, _ = txn.Apply()
+	if err := clusHelper.DeleteCustomCheckConfig(txn, name); err != nil {
+		log.WithError(err).Warn("Failed to delete custom check config")
+	}
+	if ok, err := txn.Apply(); err != nil || !ok {
+		log.WithFields(log.Fields{"ok": ok, "error": err}).Warn("Failed to apply group deletion transaction")
+	}
 	txn.Close()
 
 	return nil

--- a/controller/cache/learn.go
+++ b/controller/cache/learn.go
@@ -785,7 +785,10 @@ func deleteRuleFromLprWrapperMap(r *share.CLUSPolicyRule) {
 }
 
 func getNodesFromGroup(groupName string) []string {
-	gr, _ := cacher.GetGroup(groupName, "", false, access.NewReaderAccessControl())
+	gr, err := cacher.GetGroup(groupName, "", false, access.NewReaderAccessControl())
+	if err != nil {
+		log.WithError(err).Warn("Failed to get group members")
+	}
 	if gr != nil && len(gr.Members) > 0 {
 		nodes := make([]string, len(gr.Members))
 		for i, wl := range gr.Members {
@@ -971,7 +974,9 @@ func procLearnedPolicy(updateCluster bool) int {
 				cr.Applications = rule.Applications
 				cr.Ports = rule.Ports
 				cr.LastModAt = time.Now().UTC()
-				_ = clusHelper.PutPolicyRuleTxn(txn, cr)
+				if err := clusHelper.PutPolicyRuleTxn(txn, cr); err != nil {
+					log.WithError(err).Warn("Failed to put policy rule txn")
+				}
 				cctx.ConnLog.WithFields(log.Fields{
 					"from": cr.From, "to": cr.To, "id": cr.ID,
 				}).Debug("update")
@@ -995,14 +1000,18 @@ func procLearnedPolicy(updateCluster bool) int {
 
 			if lenDel > 0 {
 				for id := range deleteMap {
-					_ = clusHelper.DeletePolicyRuleTxn(txn, id)
+					if err := clusHelper.DeletePolicyRuleTxn(txn, id); err != nil {
+						log.WithError(err).Warn("Failed to delete policy rule txn")
+					}
 				}
 			}
 
 			if lenAdd > 0 {
 				sort.Slice(addList, func(i, j int) bool { return addList[i].ID < addList[j].ID })
 				for _, rule := range addList {
-					_ = clusHelper.PutPolicyRuleTxn(txn, rule)
+					if err := clusHelper.PutPolicyRuleTxn(txn, rule); err != nil {
+						log.WithError(err).Warn("Failed to put policy rule txn")
+					}
 					cctx.ConnLog.WithFields(log.Fields{
 						"from": rule.From, "to": rule.To, "id": rule.ID,
 					}).Debug("add")
@@ -1062,7 +1071,9 @@ func syncLearnedPolicyToCluster() int {
 				if !cmpLearnedApps(cr.Applications, lpr.objs) {
 					cr.Applications = apps2Slice(lpr.objs)
 					cr.LastModAt = time.Now().UTC()
-					_ = clusHelper.PutPolicyRuleTxn(txn, cr)
+					if err := clusHelper.PutPolicyRuleTxn(txn, cr); err != nil {
+						log.WithError(err).Warn("Failed to put policy rule txn")
+					}
 
 					log.WithFields(log.Fields{
 						"from": pair.from, "to": pair.to, "apps": lpr.objs,
@@ -1073,7 +1084,9 @@ func syncLearnedPolicyToCluster() int {
 				if cr.Ports != newPorts {
 					cr.Ports = newPorts
 					cr.LastModAt = time.Now().UTC()
-					_ = clusHelper.PutPolicyRuleTxn(txn, cr)
+					if err := clusHelper.PutPolicyRuleTxn(txn, cr); err != nil {
+						log.WithError(err).Warn("Failed to put policy rule txn")
+					}
 				}
 			}
 		} else {
@@ -1090,14 +1103,18 @@ func syncLearnedPolicyToCluster() int {
 		} else if _, ok := lprWrapperMapById[r.ID]; ok {
 			newList = append(newList, r)
 		} else {
-			_ = clusHelper.DeletePolicyRuleTxn(txn, r.ID)
+			if err := clusHelper.DeletePolicyRuleTxn(txn, r.ID); err != nil {
+				log.WithError(err).Warn("Failed to delete policy rule txn")
+			}
 		}
 	}
 
 	if len(addList) > 0 {
 		sort.Slice(addList, func(i, j int) bool { return addList[i].ID < addList[j].ID })
 		for _, rule := range addList {
-			_ = clusHelper.PutPolicyRuleTxn(txn, rule)
+			if err := clusHelper.PutPolicyRuleTxn(txn, rule); err != nil {
+				log.WithError(err).Warn("Failed to put policy rule txn")
+			}
 			log.WithFields(log.Fields{
 				"from": rule.From, "to": rule.To, "id": rule.ID,
 			}).Debug("add")

--- a/controller/cache/log.go
+++ b/controller/cache/log.go
@@ -993,14 +993,18 @@ func incidentLogUpdate(nType cluster.ClusterNotifyType, key string, value []byte
 						enableAutoScanHost = *scanCfg.EnableAutoScanHost
 					}
 					if enableAutoScanHost && incd.ID == share.CLUSIncidHostPackageUpdated {
-						_ = cacher.ScanHost(incd.HostID, access.NewReaderAccessControl())
+						if err := cacher.ScanHost(incd.HostID, access.NewReaderAccessControl()); err != nil {
+							log.WithError(err).Warn("Failed to trigger host scan")
+						}
 					}
 					enableAutoScanWorkload := scanCfg.AutoScan
 					if scanCfg.EnableAutoScanWorkload != nil {
 						enableAutoScanWorkload = *scanCfg.EnableAutoScanWorkload
 					}
 					if enableAutoScanWorkload && incd.ID == share.CLUSIncidContainerPackageUpdated {
-						_ = cacher.ScanWorkload(incd.WorkloadID, access.NewReaderAccessControl())
+						if err := cacher.ScanWorkload(incd.WorkloadID, access.NewReaderAccessControl()); err != nil {
+							log.WithError(err).Warn("Failed to trigger workload scan")
+						}
 					}
 				}
 			}
@@ -1788,11 +1792,26 @@ func auditLog2API(audit *share.CLUSAuditLog) *api.Audit {
 					rlog.AggregationFrom = t.Unix()
 				}
 			case nvsysadmission.AuditLogPropCriticalVulsCnt:
-				rlog.CriticalCnt, _ = strconv.Atoi(v)
+				cnt, err := strconv.Atoi(v)
+				if err != nil {
+					// Suppress error: audit log field may be malformed
+					log.WithError(err).Debug("Failed to parse critical vuln count")
+				}
+				rlog.CriticalCnt = cnt
 			case nvsysadmission.AuditLogPropHighVulsCnt:
-				rlog.HighCnt, _ = strconv.Atoi(v)
+				cnt, err := strconv.Atoi(v)
+				if err != nil {
+					// Suppress error: audit log field may be malformed
+					log.WithError(err).Debug("Failed to parse high vuln count")
+				}
+				rlog.HighCnt = cnt
 			case nvsysadmission.AuditLogPropMedVulsCnt:
-				rlog.MediumCnt, _ = strconv.Atoi(v)
+				cnt, err := strconv.Atoi(v)
+				if err != nil {
+					// Suppress error: audit log field may be malformed
+					log.WithError(err).Debug("Failed to parse medium vuln count")
+				}
+				rlog.MediumCnt = cnt
 			case nvsysadmission.AuditLogPropPVCName:
 				rlog.PVCName = v
 			case nvsysadmission.AuditLogPVCStorageClassName:
@@ -2131,7 +2150,10 @@ func auditSuppressSetIdRpts(rlog *api.Audit) {
 
 func checkDefAdminPwd(throttleMinutes uint) {
 	acc := access.NewReaderAccessControl()
-	u, _, _ := clusHelper.GetUserRev(common.DefaultAdminUser, acc)
+	u, _, err := clusHelper.GetUserRev(common.DefaultAdminUser, acc)
+	if err != nil {
+		log.WithError(err).Warn("Failed to get default admin user")
+	}
 	if u == nil || common.IsSaltedPasswordHash(u.PasswordHash) {
 		return
 	}
@@ -2140,7 +2162,10 @@ func checkDefAdminPwd(throttleMinutes uint) {
 		var evtsTime share.CLUSThrottledEvents
 		id := share.CLUSEvAuthDefAdminPwdUnchanged
 		key := share.CLUSThrottledEventStore + "events"
-		value, rev, _ := cluster.GetRev(key)
+		value, rev, err := cluster.GetRev(key)
+		if err != nil {
+			log.WithError(err).Warn("Failed to get throttled events from cluster")
+		}
 		if value != nil {
 			_ = json.Unmarshal(value, &evtsTime)
 		}
@@ -2160,9 +2185,13 @@ func checkDefAdminPwd(throttleMinutes uint) {
 			evtsTime.LastReportTime[id] = now.Unix()
 			value, _ := json.Marshal(&evtsTime)
 			if rev == 0 {
-				_ = cluster.Put(key, value)
+				if err := cluster.Put(key, value); err != nil {
+					log.WithError(err).Warn("Failed to put throttled events to cluster")
+				}
 			} else {
-				_ = cluster.PutRev(key, value, rev)
+				if err := cluster.PutRev(key, value, rev); err != nil {
+					log.WithError(err).Warn("Failed to put throttled events with rev to cluster")
+				}
 			}
 		}
 	}

--- a/controller/cache/node.go
+++ b/controller/cache/node.go
@@ -131,7 +131,11 @@ func scheduleHostRemoval(cache *hostCache) {
 	task := &hostRemovalEvent{
 		hostID: cache.host.ID,
 	}
-	cache.timerTask, _ = cctx.TimerWheel.AddTask(task, hostRemovalDelay)
+	var err error
+	cache.timerTask, err = cctx.TimerWheel.AddTask(task, hostRemovalDelay)
+	if err != nil {
+		log.WithError(err).Warn("Failed to add host removal timer task")
+	}
 	if cache.timerTask == "" {
 		log.Error("Fail to insert timer")
 	} else {

--- a/controller/kv/helper.go
+++ b/controller/kv/helper.go
@@ -995,7 +995,11 @@ func (m clusterHelper) GetAllGroups(scope string, acc *access.AccessControl) map
 	for _, key := range keys {
 		gprName := share.CLUSGroupKey2Name(key)
 		if (getFed && strings.HasPrefix(gprName, api.FederalGroupPrefix)) || (getLocal && !strings.HasPrefix(gprName, api.FederalGroupPrefix)) {
-			if value, _, _ := m.get(key); value != nil {
+			value, _, err := m.get(key)
+			if err != nil {
+				log.WithError(err).Warn("Failed to get group from cluster")
+			}
+			if value != nil {
 				var group share.CLUSGroup
 				_ = nvJsonUnmarshal(key, value, &group)
 
@@ -1022,7 +1026,11 @@ func (m clusterHelper) GetGroup(name string, acc *access.AccessControl) (*share.
 	var group share.CLUSGroup
 
 	key := share.CLUSGroupKey(name)
-	if value, rev, _ := m.get(key); value != nil {
+	value, rev, err := m.get(key)
+	if err != nil {
+		return nil, 0, err
+	}
+	if value != nil {
 		_ = nvJsonUnmarshal(key, value, &group)
 		if !acc.Authorize(&group, nil) {
 			return nil, 0, common.ErrObjectAccessDenied
@@ -1104,7 +1112,11 @@ func (m clusterHelper) GetPolicyRuleList() []*share.CLUSRuleHead {
 	//since 3.2.1 rulelist key is changed to
 	//CLUSPolicyZipRuleListKey from CLUSPolicyRuleListKey
 	key := share.CLUSPolicyZipRuleListKey(share.DefaultPolicyName)
-	if value, _, _ := m.get(key); value != nil {
+	value, _, err := m.get(key)
+	if err != nil {
+		log.WithError(err).Warn("Failed to get policy rule list from cluster")
+	}
+	if value != nil {
 		_ = nvJsonUnmarshal(key, value, &crhs)
 		return crhs
 	}
@@ -1374,7 +1386,10 @@ func (m clusterHelper) DeleteServer(name string) error {
 func (m clusterHelper) GetAllUsers(acc *access.AccessControl) map[string]*share.CLUSUser {
 	users := make(map[string]*share.CLUSUser)
 
-	keys, _ := cluster.GetStoreKeys(share.CLUSConfigUserStore)
+	keys, err := cluster.GetStoreKeys(share.CLUSConfigUserStore)
+	if err != nil {
+		log.WithError(err).Warn("Failed to get user store keys")
+	}
 	for _, key := range keys {
 		if value, _, _ := m.get(key); value != nil {
 			var user share.CLUSUser
@@ -1394,7 +1409,10 @@ func (m clusterHelper) GetAllUsers(acc *access.AccessControl) map[string]*share.
 func (m clusterHelper) GetAllUsersNoAuth() map[string]*share.CLUSUser {
 	users := make(map[string]*share.CLUSUser)
 
-	keys, _ := cluster.GetStoreKeys(share.CLUSConfigUserStore)
+	keys, err := cluster.GetStoreKeys(share.CLUSConfigUserStore)
+	if err != nil {
+		log.WithError(err).Warn("Failed to get user store keys")
+	}
 	for _, key := range keys {
 		if value, _, _ := m.get(key); value != nil {
 			var user share.CLUSUser
@@ -1962,7 +1980,10 @@ func (m clusterHelper) RecoverOrphanedCredits(controllerId string) error {
 func (m clusterHelper) GetAllComplianceProfiles(acc *access.AccessControl) []*share.CLUSComplianceProfile {
 	cps := make([]*share.CLUSComplianceProfile, 0)
 
-	keys, _ := cluster.GetStoreKeys(share.CLUSConfigComplianceProfileStore)
+	keys, err := cluster.GetStoreKeys(share.CLUSConfigComplianceProfileStore)
+	if err != nil {
+		log.WithError(err).Warn("Failed to get compliance profile store keys")
+	}
 	for _, key := range keys {
 		if value, _, _ := m.get(key); value != nil {
 			var cp share.CLUSComplianceProfile
@@ -2518,7 +2539,9 @@ func (m clusterHelper) DeleteFileMonitorTxn(txn *cluster.ClusterTransact, name s
 	key1 := share.CLUSFileMonitorKey(name)
 	key2 := share.CLUSFileMonitorNetworkKey(name)
 	if txn == nil {
-		_ = cluster.Delete(key1)
+		if err := cluster.Delete(key1); err != nil {
+			log.WithError(err).Warn("Failed to delete file monitor key")
+		}
 		return cluster.Delete(key2)
 	} else {
 		txn.Delete(key1)
@@ -2583,7 +2606,9 @@ func (m clusterHelper) PutFileAccessRuleTxn(txn *cluster.ClusterTransact, name s
 }
 
 func (m clusterHelper) DeleteFileAccessRule(name string) error {
-	_ = cluster.Delete(share.CLUSFileAccessRuleKey(name))
+	if err := cluster.Delete(share.CLUSFileAccessRuleKey(name)); err != nil {
+		log.WithError(err).Warn("Failed to delete file access rule key")
+	}
 	return cluster.Delete(share.CLUSFileAccessRuleNetworkKey(name))
 }
 
@@ -2644,8 +2669,11 @@ func (m clusterHelper) GetObjectCertRev(cn string) (*share.CLUSX509Cert, uint64,
 // returns pre-existing cert object in kv if it already in kv
 func (m clusterHelper) PutObjectCert(cn, keyPath, certPath string, cert *share.CLUSX509Cert) error {
 	key := share.CLUSObjectCertKey(cn)
-	value, _ := enc.Marshal(cert)
-	err := cluster.PutIfNotExist(key, value, true)
+	value, err := enc.Marshal(cert)
+	if err != nil {
+		return fmt.Errorf("failed to marshal cert %q: %w", cn, err)
+	}
+	err = cluster.PutIfNotExist(key, value, true)
 	if err == nil {
 		// don't know why: after rolling upgrade(replicas/maxSurge=3), there could be a short period that controller cannot get/put kv
 		// (GetRev returns "Key not found" error & Put/PutRev return "CAS put error" & PutIfNotExist returns nil : is it because kv is not syned yet?)
@@ -2690,8 +2718,11 @@ func (m clusterHelper) PutObjectCert(cn, keyPath, certPath string, cert *share.C
 // If index == 0, it will not overwrite the data. (PutIfNotExist)
 func (m clusterHelper) PutObjectCertMemory(cn string, in *share.CLUSX509Cert, out *share.CLUSX509Cert, index uint64) error {
 	key := share.CLUSObjectCertKey(cn)
-	value, _ := enc.Marshal(in)
-	err := cluster.PutRev(key, value, index)
+	value, err := enc.Marshal(in)
+	if err != nil {
+		return fmt.Errorf("failed to marshal cert %q: %w", cn, err)
+	}
+	err = cluster.PutRev(key, value, index)
 	if err != nil {
 		return err
 	}
@@ -2940,7 +2971,10 @@ func (m clusterHelper) GetFedMembership() *share.CLUSFedMembership {
 
 func (m clusterHelper) PutFedMembership(s *share.CLUSFedMembership) error {
 	key := share.CLUSFedKey(share.CLUSFedMembershipSubKey)
-	value, _ := enc.Marshal(s)
+	value, err := enc.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("failed to marshal fed membership: %w", err)
+	}
 	if err := cluster.Put(key, value); err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("")
 		return err
@@ -3018,7 +3052,9 @@ func (m clusterHelper) PutFedJointCluster(jointCluster *share.CLUSFedJointCluste
 
 func (m clusterHelper) DeleteFedJointCluster(id string) error {
 	key := share.CLUSFedJointClusterStatusKey(id)
-	_ = cluster.Delete(key)
+	if err := cluster.Delete(key); err != nil {
+		log.WithError(err).Warn("Failed to delete fed joint cluster status key")
+	}
 	key = share.CLUSFedJointClusterKey(id)
 	return cluster.Delete(key)
 }

--- a/db/vulassets.go
+++ b/db/vulassets.go
@@ -135,7 +135,10 @@ func FilterVulAssetsV2(allowed map[string]utils.Set, queryFilter *VulQueryFilter
 
 	columns := []interface{}{"id", "type", "assetid", "idns", "vulsb"}
 
-	statement, args, _ := dialect.From(Table_assetvuls).Select(columns...).Where(buildAssetFilterWhereClause(queryFilter.Filters)).Prepared(true).ToSQL()
+	statement, args, err := dialect.From(Table_assetvuls).Select(columns...).Where(buildAssetFilterWhereClause(queryFilter.Filters)).Prepared(true).ToSQL()
+	if err != nil {
+		return nil, 0, perf, CVEDBReady, fmt.Errorf("failed to build asset query: %w", err)
+	}
 	log.WithFields(log.Fields{"statement": statement, "args": args, "CVEDBReady": CVEDBReady}).Debug("GetVulAssetSessionV2, fetch assets")
 	rows, err := db.Query(statement, args...)
 	if err != nil {
@@ -319,7 +322,10 @@ func GetSessionMatchedVuls(allowed map[string]utils.Set, sessionToken string, La
 		"vectors", "score_v3", "vectors_v3", "published_timestamp", "last_modified_timestamp",
 		"workloads", "nodes", "images", "platforms"}
 
-	statement, args, _ := dialect.From(sessionTemp).Select(columns...).Prepared(true).ToSQL()
+	statement, args, err := dialect.From(sessionTemp).Select(columns...).Prepared(true).ToSQL()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build session vul query: %w", err)
+	}
 
 	queryStat, err := GetQueryStat(sessionToken)
 	if err != nil {
@@ -508,10 +514,14 @@ func GetVulAssetSessionV2(requesetQuery *VulQueryFilter) (*api.RESTVulnerability
 	dialect := goqu.Dialect("sqlite3")
 	var statement string
 	var args []interface{}
+	var sqlErr error
 	if row == -1 {
-		statement, args, _ = dialect.From(sessionTemp).Select(columns...).Where(quickFilterExp).Order(getOrderColumn(queryFilter.Filters)).Prepared(true).ToSQL() // select all
+		statement, args, sqlErr = dialect.From(sessionTemp).Select(columns...).Where(quickFilterExp).Order(getOrderColumn(queryFilter.Filters)).Prepared(true).ToSQL() // select all
 	} else {
-		statement, args, _ = dialect.From(sessionTemp).Select(columns...).Where(quickFilterExp).Order(getOrderColumn(queryFilter.Filters)).Limit(uint(row)).Offset(uint(start)).Prepared(true).ToSQL()
+		statement, args, sqlErr = dialect.From(sessionTemp).Select(columns...).Where(quickFilterExp).Order(getOrderColumn(queryFilter.Filters)).Limit(uint(row)).Offset(uint(start)).Prepared(true).ToSQL()
+	}
+	if sqlErr != nil {
+		return nil, nil, fmt.Errorf("failed to build session query: %w", sqlErr)
 	}
 
 	// if file db is ready, use it..

--- a/share/container/containerd.go
+++ b/share/container/containerd.go
@@ -89,7 +89,12 @@ func containerdConnect(endpoint string, sys *system.SystemTools) (Runtime, error
 			log.WithFields(log.Fields{"error": err}).Error("cri info")
 		}
 
-		id, _ = criGetSelfID(cri, ctx, id)
+		var criErr error
+		id, criErr = criGetSelfID(cri, ctx, id)
+		if criErr != nil {
+			// Suppress error: best-effort self ID detection via CRI
+			log.WithError(criErr).Debug("Failed to get self container ID via CRI")
+		}
 		sockPath, err = criGetContainerSocketPath(cri, ctx, id, endpoint)
 		if err == nil {
 			log.WithFields(log.Fields{"selfID": id, "sockPath": sockPath}).Info()

--- a/share/scan/scan_utils.go
+++ b/share/scan/scan_utils.go
@@ -248,7 +248,11 @@ func (s *ScanUtil) GetAppPackages(path string) ([]AppPackage, []byte, share.Scan
 	pkgs := apps.marshal()
 	files := make(tarutil.FilesMap)
 	files[AppFileName] = pkgs
-	buf, _ := utils.MakeTar(files)
+	buf, err := utils.MakeTar(files)
+	if err != nil {
+		log.WithError(err).Warn("Failed to create tar from app packages")
+		return nil, nil, share.ScanErrorCode_ScanErrFileSystem
+	}
 	appPkgs := apps.Data()[path]
 	return appPkgs, buf.Bytes(), share.ScanErrorCode_ScanErrNone
 }


### PR DESCRIPTION
## Description

Handle previously-ignored error returns across 13 files:
- agent/pipe/tc.go: log debug for non-fatal TC diagnostic commands
- agent/timer.go: log+continue/return for json.Marshal failures in loops
- controller/cache/{custom_role,domain,federation,group,learn,log,node}.go: log warn for unmarshal/kv errors
- controller/kv/helper.go: propagate cluster errors, log txn/delete failures
- db/vulassets.go: propagate ToSQL errors to callers
- share/container/containerd.go: log debug for best-effort CRI self-ID
- share/scan/scan_utils.go: early return on MakeTar failure to prevent nil deref

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

### Special notes for your reviewer

<!-- Please describe, if any special design or notes you want to share with your reviewer in this pull request -->

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
