### PR TITLE
fix(lint): resolve errcheck in controller/cache and controller/rest

### DIFF
--- a/controller/cache/automode.go
+++ b/controller/cache/automode.go
@@ -247,13 +247,18 @@ func automode_decision_func(mover int, group string, err error) error {
 
 	modeType, theGroup := atmoHelper.GetTheGroupType(group)
 	if isLeader() {
-		_ = automode_promote_mode(theGroup, targetMode, modeType)
+		if err := automode_promote_mode(theGroup, targetMode, modeType); err != nil {
+			log.WithError(err).Warn("failed to promote automode")
+		}
 	} else {
 		go func() {
 			r1 := rand.New(rand.NewSource(time.Now().UnixNano()))
 			wait_sec := 3*60 + r1.Intn(100) // separating controller actions. no promoting when it has been already promoted
 			time.Sleep(time.Second * time.Duration(wait_sec))
-			_ = automode_promote_mode(theGroup, targetMode, modeType)
+			// Log error: this is the top of goroutine
+			if err := automode_promote_mode(theGroup, targetMode, modeType); err != nil {
+				log.WithError(err).Warn("failed to promote automode in goroutine")
+			}
 		}()
 	}
 

--- a/controller/cache/cache.go
+++ b/controller/cache/cache.go
@@ -1712,7 +1712,9 @@ func startWorkerThread(ctx *Context) {
 			select {
 			case <-usageReportTicker.C:
 				if isLeader() {
-					_ = writeUsageReport()
+					if err := writeUsageReport(); err != nil {
+						log.WithError(err).Warn("failed to write usage report")
+					}
 				}
 			case <-groupMetricCheckTicker.C:
 				if isLeader() {

--- a/controller/cache/federation.go
+++ b/controller/cache/federation.go
@@ -317,7 +317,9 @@ func fedConfigUpdate(nType cluster.ClusterNotifyType, key string, value []byte) 
 			fedSystemConfigCache = cfg
 		case share.CLUSFedSettingsSubKey:
 			var cfg share.CLUSFedSettings
-			_ = json.Unmarshal(value, &cfg)
+			if err := json.Unmarshal(value, &cfg); err != nil {
+				log.WithError(err).Warn("failed to unmarshal fed settings")
+			}
 			fedSettingsCache = cfg
 		}
 	case cluster.ClusterNotifyDelete:

--- a/controller/cache/group.go
+++ b/controller/cache/group.go
@@ -379,7 +379,9 @@ func groupConfigUpdate(nType cluster.ClusterNotifyType, key string, value []byte
 	switch nType {
 	case cluster.ClusterNotifyAdd, cluster.ClusterNotifyModify:
 		var group share.CLUSGroup
-		_ = json.Unmarshal(value, &group)
+		if err := json.Unmarshal(value, &group); err != nil {
+			log.WithError(err).Warn("failed to unmarshal group")
+		}
 
 		// post-3.2.2 enforcer report nv containers to controller, if the controller happens to be pre-3.2.2,
 		// for example, in upgrade case, the group will be created. This is to remove the group as we see it.

--- a/controller/cache/log.go
+++ b/controller/cache/log.go
@@ -835,7 +835,9 @@ func threatLogUpdate(nType cluster.ClusterNotifyType, key string, value []byte, 
 		}
 
 		var thrts []share.CLUSThreatLog
-		_ = json.Unmarshal(uzb, &thrts)
+		if err := json.Unmarshal(uzb, &thrts); err != nil {
+			log.WithError(err).Warn("failed to unmarshal threat logs")
+		}
 
 		syncLock(syncCatgThreatIdx)
 		defer syncUnlock(syncCatgThreatIdx)
@@ -1251,7 +1253,10 @@ func syncEventTx() *syncDataMsg {
 	syncLock(syncCatgEventIdx)
 	if curEventIndex > 0 {
 		events := eventCache[0:curEventIndex]
-		msg.Data, _ = json.Marshal(events)
+		var err error
+		if msg.Data, err = json.Marshal(events); err != nil {
+			log.WithError(err).Warn("failed to marshal events")
+		}
 	}
 	msg.ModifyIdx = getModifyIdx(syncCatgEventIdx)
 	syncUnlock(syncCatgEventIdx)
@@ -1263,7 +1268,10 @@ func syncThreatTx() *syncDataMsg {
 	syncLock(syncCatgThreatIdx)
 	if curThrtIndex > 0 {
 		threats := thrtCache[0:curThrtIndex]
-		msg.Data, _ = json.Marshal(threats)
+		var err error
+		if msg.Data, err = json.Marshal(threats); err != nil {
+			log.WithError(err).Warn("failed to marshal threats")
+		}
 	}
 	msg.ModifyIdx = getModifyIdx(syncCatgThreatIdx)
 	syncUnlock(syncCatgThreatIdx)
@@ -1275,7 +1283,10 @@ func syncIncidentTx() *syncDataMsg {
 	syncLock(syncCatgIncidentIdx)
 	if curIncidentIndex > 0 {
 		incidents := incidentCache[0:curIncidentIndex]
-		msg.Data, _ = json.Marshal(incidents)
+		var err error
+		if msg.Data, err = json.Marshal(incidents); err != nil {
+			log.WithError(err).Warn("failed to marshal incidents")
+		}
 	}
 	msg.ModifyIdx = getModifyIdx(syncCatgIncidentIdx)
 	syncUnlock(syncCatgIncidentIdx)

--- a/controller/cache/node.go
+++ b/controller/cache/node.go
@@ -408,7 +408,9 @@ func deleteAgentFromCluster(hostID string, agentID string) {
 	log.WithFields(log.Fields{"hostID": hostID, "enforcer": agentID}).Info()
 
 	key := share.CLUSAgentKey(hostID, agentID)
-	_ = cluster.Delete(key)
+	if err := cluster.Delete(key); err != nil {
+		log.WithError(err).Warn("failed to delete agent from cluster")
+	}
 }
 
 func deleteControllerFromCluster(hostID string, ctrlID string, clusterIP string) {

--- a/controller/cache/object.go
+++ b/controller/cache/object.go
@@ -856,7 +856,9 @@ func controllerUpdate(nType cluster.ClusterNotifyType, key string, value []byte)
 			for _, cc = range ctrlCacheMap {
 				if cc.ctrl.ID != ctrl.ID && cc.ctrl.ClusterIP == ctrl.ClusterIP {
 					log.WithFields(log.Fields{"controller": cc.ctrl}).Info("duplicated controller")
-					_ = cluster.Delete(cc.clusKey)
+					if err := cluster.Delete(cc.clusKey); err != nil {
+						log.WithError(err).Warn("failed to delete duplicated controller")
+					}
 				}
 			}
 

--- a/controller/cache/policy.go
+++ b/controller/cache/policy.go
@@ -2062,10 +2062,16 @@ func policyIPRulesCleanup(ruleKeys []string) {
 func policyIPRulesCleanupNode(rule_key, verstr, newCommonRuleKey string, tmpNid map[string]string) {
 	for tnid := range tmpNid {
 		tmpNewNodeKey := fmt.Sprintf("%s%s/%s/", rule_key, tnid, verstr)
-		tmpNewNodeKeys, _ := cluster.GetStoreKeys(tmpNewNodeKey)
+		tmpNewNodeKeys, err := cluster.GetStoreKeys(tmpNewNodeKey)
+		if err != nil {
+			log.WithError(err).Warn("failed to get store keys for node cleanup")
+		}
 		policyIPRulesCleanup(tmpNewNodeKeys)
 	}
-	newCommonKeys, _ := cluster.GetStoreKeys(newCommonRuleKey)
+	newCommonKeys, err := cluster.GetStoreKeys(newCommonRuleKey)
+	if err != nil {
+		log.WithError(err).Warn("failed to get common rule store keys")
+	}
 	policyIPRulesCleanup(newCommonKeys)
 }
 
@@ -2075,7 +2081,10 @@ func putPolicyIPRulesToClusterScaleNode(rules []share.CLUSGroupIPPolicy) {
 	//change key from "network/GroupIPRules/" to "recalculate/policy/GroupIPRules/"
 	//rule_key := fmt.Sprintf("%s/", share.CLUSPolicyIPRulesKey(share.PolicyIPRulesDefaultName))
 	rule_key := fmt.Sprintf("%s/", share.CLUSRecalPolicyIPRulesKey(share.PolicyIPRulesDefaultName))
-	oldKeys, _ := cluster.GetStoreKeys(rule_key)
+	oldKeys, err := cluster.GetStoreKeys(rule_key)
+	if err != nil {
+		log.WithError(err).Warn("failed to get old policy IP rule store keys")
+	}
 
 	verstr := fmt.Sprintf("ver.%d.%d", time.Now().UTC().UnixNano(), time.Now().UTC().UnixNano())
 	newCommonRuleKey := fmt.Sprintf("%s%s/", rule_key, verstr)

--- a/controller/cache/usage.go
+++ b/controller/cache/usage.go
@@ -52,7 +52,9 @@ func writeUsageReport() error {
 
 		for i := usageReportHistory; i < len(all); i++ {
 			key := share.CLUSCtrlUsageReportKey(all[i])
-			_ = cluster.Delete(key)
+			if err := cluster.Delete(key); err != nil {
+				log.WithError(err).Warn("failed to delete usage report")
+			}
 		}
 	}
 

--- a/controller/kv/helper.go
+++ b/controller/kv/helper.go
@@ -1163,7 +1163,11 @@ func (m clusterHelper) PutPolicyRuleListZip(key string, array []byte) error {
 
 func (m clusterHelper) GetPolicyRule(id uint32) (*share.CLUSPolicyRule, uint64) {
 	key := share.CLUSPolicyRuleKey(share.DefaultPolicyName, id)
-	if value, rev, _ := m.get(key); value != nil {
+	value, rev, err := m.get(key)
+	if err != nil {
+		log.WithError(err).Warn("failed to get policy rule")
+	}
+	if value != nil {
 		var rule share.CLUSPolicyRule
 		_ = nvJsonUnmarshal(key, value, &rule)
 		return &rule, rev
@@ -1242,7 +1246,11 @@ func (m clusterHelper) PutDlpVer(s *share.CLUSDlpRuleVer) error {
 func (m clusterHelper) GetResponseRuleList(policyName string) []*share.CLUSRuleHead {
 	crhs := make([]*share.CLUSRuleHead, 0)
 	key := share.CLUSResponseRuleListKey(policyName)
-	if value, _, _ := m.get(key); value != nil {
+	value, _, err := m.get(key)
+	if err != nil {
+		log.WithError(err).Warn("failed to get response rule list")
+	}
+	if value != nil {
 		_ = nvJsonUnmarshal(key, value, &crhs)
 		return crhs
 	}
@@ -1252,7 +1260,11 @@ func (m clusterHelper) GetResponseRuleList(policyName string) []*share.CLUSRuleH
 
 func (m clusterHelper) GetResponseRule(policyName string, id uint32) (*share.CLUSResponseRule, uint64) {
 	key := share.CLUSResponseRuleKey(policyName, id)
-	if value, rev, _ := m.get(key); value != nil {
+	value, rev, err := m.get(key)
+	if err != nil {
+		log.WithError(err).Warn("failed to get response rule")
+	}
+	if value != nil {
 		var rule share.CLUSResponseRule
 		_ = nvJsonUnmarshal(key, value, &rule)
 		return &rule, rev
@@ -3041,7 +3053,10 @@ func (m clusterHelper) GetFedJointCluster(id string) *share.CLUSFedJointClusterI
 }
 
 func (m clusterHelper) PutFedJointCluster(jointCluster *share.CLUSFedJointClusterInfo) error {
-	value, _ := enc.Marshal(jointCluster)
+	value, err := enc.Marshal(jointCluster)
+	if err != nil {
+		return fmt.Errorf("failed to marshal joint cluster: %w", err)
+	}
 	key := share.CLUSFedJointClusterKey(jointCluster.ID)
 	if err := cluster.Put(key, value); err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("")
@@ -3549,7 +3564,10 @@ func (m clusterHelper) GetAwsProjectCfg(projectName string, acc *access.AccessCo
 
 func (m clusterHelper) PutAwsProjectCfg(projectName string, record *share.CLUSAwsProjectCfg) error {
 	key := share.CLUSCloudCfgKey(share.CloudAws, projectName)
-	value, _ := enc.Marshal(record)
+	value, err := enc.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("failed to marshal project config: %w", err)
+	}
 	return cluster.Put(key, value)
 }
 
@@ -3566,7 +3584,10 @@ func (m clusterHelper) GetAwsCloudResource(projectName string) (*share.CLUSAwsRe
 
 func (m clusterHelper) PutAwsCloudResource(project *share.CLUSAwsResource) error {
 	key := share.CLUSCloudKey(share.CloudAws, project.ProjectName)
-	value, _ := enc.Marshal(project)
+	value, err := enc.Marshal(project)
+	if err != nil {
+		return fmt.Errorf("failed to marshal cloud resource: %w", err)
+	}
 	return cluster.Put(key, value)
 }
 

--- a/controller/rest/admission.go
+++ b/controller/rest/admission.go
@@ -1711,8 +1711,13 @@ func handlerPromoteAdmissionRules(w http.ResponseWriter, r *http.Request, ps htt
 	}
 
 	var promoteData api.RESTAdmCtrlPromoteRequestData
-	body, _ := io.ReadAll(r.Body)
-	err := json.Unmarshal(body, &promoteData)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.WithError(err).Warn("failed to read request body")
+		restRespError(w, http.StatusBadRequest, api.RESTErrInvalidRequest)
+		return
+	}
+	err = json.Unmarshal(body, &promoteData)
 	if err != nil || promoteData.Request == nil || len(promoteData.Request.IDs) == 0 {
 		log.WithFields(log.Fields{"error": err}).Error("Request error")
 		restRespError(w, http.StatusBadRequest, api.RESTErrInvalidRequest)
@@ -1733,7 +1738,10 @@ func handlerPromoteAdmissionRules(w http.ResponseWriter, r *http.Request, ps htt
 	defer clusHelper.ReleaseLock(lock)
 
 	for _, ruleType := range []string{api.ValidatingExceptRuleType, api.ValidatingDenyRuleType, share.FedAdmCtrlExceptRulesType, share.FedAdmCtrlDenyRulesType} {
-		arhs, _ := clusHelper.GetAdmissionRuleList(admission.NvAdmValidateType, ruleType)
+		arhs, err := clusHelper.GetAdmissionRuleList(admission.NvAdmValidateType, ruleType)
+		if err != nil {
+			log.WithError(err).Warn("failed to get admission rule list")
+		}
 		for _, arh := range arhs {
 			switch ruleType {
 			case share.FedAdmCtrlExceptRulesType, share.FedAdmCtrlDenyRulesType:

--- a/controller/rest/assessment.go
+++ b/controller/rest/assessment.go
@@ -60,7 +60,10 @@ func handlerAssessAdmCtrlRules(w http.ResponseWriter, r *http.Request, ps httpro
 	var whsvr WebhookServer
 	var stamps api.AdmCtlTimeStamps
 
-	body, _ := io.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.WithError(err).Warn("failed to read request body")
+	}
 	body = _preprocessImportBody(body)
 	yamlParts := strings.Split(string(body), "\n---\n")
 

--- a/controller/rest/auth.go
+++ b/controller/rest/auth.go
@@ -2282,7 +2282,10 @@ func fedMasterTokenAuth(userName, masterToken, secret string) (*share.CLUSUser, 
 			if err := cluster.PutIfNotExist(key, value, false); err != nil {
 				log.WithFields(log.Fields{"error": err}).Error("PutIfNotExist")
 			}
-			user, _, _ = clusHelper.GetUserRev(userName, acc)
+			user, _, err = clusHelper.GetUserRev(userName, acc)
+			if err != nil {
+				log.WithError(err).Warn("failed to get user rev")
+			}
 		}
 	}
 	if user == nil || user.Server != "" {
@@ -2409,7 +2412,11 @@ func handlerAuthLogin(w http.ResponseWriter, r *http.Request, ps httprouter.Para
 			return
 		}
 		if role == api.UserRoleAdmin || role == api.UserRoleFedAdmin {
-			if u, _, _ := clusHelper.GetUserRev(common.DefaultAdminUser, accReadAll); u != nil {
+			u, _, err := clusHelper.GetUserRev(common.DefaultAdminUser, accReadAll)
+			if err != nil {
+				log.WithError(err).Warn("failed to get default admin user rev")
+			}
+			if u != nil {
 				if !common.IsSaltedPasswordHash(u.PasswordHash) {
 					if hash := utils.HashPassword(common.DefaultAdminPass); hash == u.PasswordHash {
 						defaultPW = true
@@ -2426,9 +2433,11 @@ func handlerAuthLogin(w http.ResponseWriter, r *http.Request, ps httprouter.Para
 		mainSessionUser = user.Fullname
 	} else {
 		// Read body
-		body, _ := io.ReadAll(r.Body)
-
-		err := json.Unmarshal(body, &auth)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			log.WithError(err).Warn("failed to read request body")
+		}
+		err = json.Unmarshal(body, &auth)
 		if err != nil || auth.Password == nil {
 			log.WithFields(log.Fields{"error": err}).Error("Request error")
 			restRespError(w, http.StatusBadRequest, api.RESTErrInvalidRequest)
@@ -2524,7 +2533,11 @@ func handlerAuthLogin(w http.ResponseWriter, r *http.Request, ps httprouter.Para
 				// user password passes remote auth but not local auth(user found in local). do not increase local user's FailedLoginCount
 				retry := 0
 				for retry < retryClusterMax {
-					if user, rev, _ := clusHelper.GetUserRev(auth.Password.Username, accReadAll); user != nil {
+					user, rev, err := clusHelper.GetUserRev(auth.Password.Username, accReadAll)
+					if err != nil {
+						log.WithError(err).Warn("failed to get user rev")
+					}
+					if user != nil {
 						if user.FailedLoginCount > 0 {
 							user.FailedLoginCount--
 							if user.FailedLoginCount < uint32(localAuthResult.blockAfterFailedCount) {

--- a/controller/rest/compliance.go
+++ b/controller/rest/compliance.go
@@ -616,7 +616,10 @@ func importCompProfile(scope string, loginDomainRoles access.DomainRole, importT
 
 	importTask.Percentage = int(progress)
 	importTask.Status = share.IMPORT_RUNNING
-	_ = clusHelper.PutImportTask(&importTask) // Ignore error because progress update is non-critical
+	if err := clusHelper.PutImportTask(&importTask); err != nil {
+		// Suppress error: progress update is non-critical
+		log.WithError(err).Debug("failed to update import task progress")
+	}
 
 	var crdHandler nvCrdHandler
 	crdHandler.Init(share.CLUSLockCompKey, importCallerRest)
@@ -632,13 +635,19 @@ func importCompProfile(scope string, loginDomainRoles access.DomainRole, importT
 				cmpProfilesCfg = append(cmpProfilesCfg, cpCfgRet)
 				progress += inc
 				importTask.Percentage = int(progress)
-				_ = clusHelper.PutImportTask(&importTask) // Ignore error because progress update is non-critical
+				if err := clusHelper.PutImportTask(&importTask); err != nil {
+					// Suppress error: progress update is non-critical
+					log.WithError(err).Debug("failed to update import task progress")
+				}
 			}
 		}
 
 		progress += inc
 		importTask.Percentage = int(progress)
-		_ = clusHelper.PutImportTask(&importTask) // Ignore error because progress update is non-critical
+		if err := clusHelper.PutImportTask(&importTask); err != nil {
+			// Suppress error: progress update is non-critical
+			log.WithError(err).Debug("failed to update import task progress")
+		}
 
 		if err == nil {
 			// [2]: import compliance profile defined in the yaml file
@@ -649,11 +658,17 @@ func importCompProfile(scope string, loginDomainRoles access.DomainRole, importT
 				}
 				progress += inc
 				importTask.Percentage = int(progress)
-				_ = clusHelper.PutImportTask(&importTask) // Ignore error because progress update is non-critical
+				if err := clusHelper.PutImportTask(&importTask); err != nil {
+					// Suppress error: progress update is non-critical
+					log.WithError(err).Debug("failed to update import task progress")
+				}
 			}
 		}
 		importTask.Percentage = 90
-		_ = clusHelper.PutImportTask(&importTask) // Ignore error because progress update is non-critical
+		if err := clusHelper.PutImportTask(&importTask); err != nil {
+			// Suppress error: progress update is non-critical
+			log.WithError(err).Debug("failed to update import task progress")
+		}
 	}
 
 	postImportOp(err, importTask, loginDomainRoles, "", share.IMPORT_TYPE_COMP_PROFILE)

--- a/controller/rest/configmap.go
+++ b/controller/rest/configmap.go
@@ -75,7 +75,10 @@ func handleldapcfg(yaml_data []byte, load bool, skip *bool, context *configMapHa
 		context.gotAllCustomRoles = true
 	}
 
-	cs, _, _ := clusHelper.GetServerRev(name, accAdmin)
+	cs, _, err := clusHelper.GetServerRev(name, accAdmin)
+	if err != nil {
+		log.WithError(err).Warn("failed to get LDAP server rev")
+	}
 	if cs == nil {
 		cldap := &share.CLUSServerLDAP{
 			Port: DefaultLDAPServerPort,
@@ -135,7 +138,10 @@ func handlesamlcfg(yaml_data []byte, load bool, skip *bool, context *configMapHa
 		context.gotAllCustomRoles = true
 	}
 
-	cs, _, _ := clusHelper.GetServerRev(name, accAdmin)
+	cs, _, err := clusHelper.GetServerRev(name, accAdmin)
+	if err != nil {
+		log.WithError(err).Warn("failed to get SAML server rev")
+	}
 	if cs == nil {
 		csaml := &share.CLUSServerSAML{
 			CLUSServerAuth: share.CLUSServerAuth{
@@ -198,7 +204,10 @@ func handleoidccfg(yaml_data []byte, load bool, skip *bool, context *configMapHa
 		remoteAuther = auth.NewRemoteAuther(nil)
 	}
 
-	cs, _, _ := clusHelper.GetServerRev(name, accAdmin)
+	cs, _, err := clusHelper.GetServerRev(name, accAdmin)
+	if err != nil {
+		log.WithError(err).Warn("failed to get OIDC server rev")
+	}
 	if cs == nil {
 		coidc := &share.CLUSServerOIDC{
 			Scopes: auth.DefaultOIDCScopes,

--- a/controller/rest/crdsecurityrule.go
+++ b/controller/rest/crdsecurityrule.go
@@ -305,7 +305,10 @@ func (h *nvCrdHandler) crdHandleGroupsAdd(groups []v1.GroupConfig, targetGroup s
 		}
 
 		isNvIpGroup := strings.HasPrefix(group.Name, api.LearnedSvcGroupPrefix)
-		cg, _, _ := clusHelper.GetGroup(group.Name, h.acc)
+		cg, _, err := clusHelper.GetGroup(group.Name, h.acc)
+		if err != nil {
+			log.WithError(err).Warn("failed to get group")
+		}
 		if cg != nil {
 			// group update case
 			updateKV := false
@@ -489,7 +492,9 @@ func (h *nvCrdHandler) crdDeleteNetworkRules(delRules map[string]uint32) {
 		delRuleIDs.Add(id)
 		// This function cannot return an error, as there is no possibility for one to occur.
 		// However, we retain the error return type to accommodate the mock dependency.
-		_ = clusHelper.DeletePolicyRuleTxn(txn, id)
+		if err := clusHelper.DeletePolicyRuleTxn(txn, id); err != nil {
+			log.WithError(err).Warn("failed to delete policy rule in txn")
+		}
 	}
 	for _, crh := range crhs {
 		if crh.CfgType != share.GroundCfg || !delRuleIDs.Contains(crh.ID) {
@@ -613,7 +618,11 @@ func findAbsentGroups(cacheRecord *share.CLUSCrdSecurityRule, groupNew []string)
 func (h *nvCrdHandler) crdDeleteGroup(delGroups []string) {
 	names := make([]string, 0, len(delGroups))
 	for _, name := range delGroups {
-		if cg, _, _ := clusHelper.GetGroup(name, h.acc); cg == nil {
+		cg, _, err := clusHelper.GetGroup(name, h.acc)
+		if err != nil {
+			log.WithError(err).Warn("failed to get group for deletion")
+		}
+		if cg == nil {
 			log.WithFields(log.Fields{"name": name}).Error("Group doesn't exist")
 			continue
 		}
@@ -650,7 +659,10 @@ func (h *nvCrdHandler) crdUpdateGroup(updateGroup []string) {
 
 	var lastTxnError error
 	for _, name := range updateGroup {
-		cg, _, _ := clusHelper.GetGroup(name, h.acc)
+		cg, _, err := clusHelper.GetGroup(name, h.acc)
+		if err != nil {
+			log.WithError(err).Warn("failed to get group for update")
+		}
 		if cg == nil {
 			log.WithFields(log.Fields{"name": name}).Error("Group doesn't exist")
 			continue
@@ -918,7 +930,10 @@ LOOPALLDEL:
 		if kvOnly {
 			groupsToUpdate = append(groupsToUpdate, cur)
 		} else {
-			group, _ := cacher.GetGroup(cur, "", false, h.acc)
+			group, err := cacher.GetGroup(cur, "", false, h.acc)
+			if err != nil {
+				log.WithError(err).Warn("failed to get group from cache")
+			}
 			if group != nil {
 				// if group exist before crd apply when delete we should not touch it
 				if group.CfgType != api.CfgTypeGround {
@@ -1427,7 +1442,9 @@ func (h *nvCrdHandler) crdHandleNetworkRules(rules []api.RESTPolicyRuleConfig, c
 		if newId, ok := newRules[cacheName]; ok && newId == cacheId {
 			continue
 		}
-		_ = clusHelper.DeletePolicyRuleTxn(txn, cacheId)
+		if err := clusHelper.DeletePolicyRuleTxn(txn, cacheId); err != nil {
+			log.WithError(err).Warn("failed to delete policy rule in txn")
+		}
 		delete(ruleHead, cacheId)
 	}
 
@@ -1489,7 +1506,10 @@ func (h *nvCrdHandler) crdHandleAdmCtrlRules(cfgType share.TCfgType, allAdmCtrlR
 		ruleTypeKeys = append(ruleTypeKeys, api.ValidatingExceptRuleType, api.ValidatingDenyRuleType)
 	}
 	for _, ruleType := range ruleTypeKeys {
-		arhs, _ := clusHelper.GetAdmissionRuleList(admission.NvAdmValidateType, ruleType)
+		arhs, err := clusHelper.GetAdmissionRuleList(admission.NvAdmValidateType, ruleType)
+		if err != nil {
+			log.WithError(err).Warn("failed to get admission rule list")
+		}
 		clusArhsNew[ruleType] = arhs
 		for _, arh := range arhs {
 			ids.Add(arh.ID)
@@ -1557,7 +1577,10 @@ func (h *nvCrdHandler) crdHandleAdmCtrlRules(cfgType share.TCfgType, allAdmCtrlR
 					}
 				} else {
 					// it's non-default rule
-					cr.Criteria, _ = cache.AdmCriteria2CLUS(ruleConf.Criteria)
+					var err error
+					if cr.Criteria, err = cache.AdmCriteria2CLUS(ruleConf.Criteria); err != nil {
+						log.WithError(err).Warn("failed to convert admission criteria")
+					}
 					cr.Comment = ruleConf.Comment
 					cr.Disable = ruleConf.Disabled
 				}
@@ -1996,7 +2019,10 @@ func (h *nvCrdHandler) crdHandleVulnProfile(vulnProfileCfg *resource.NvCrdVulnPr
 
 	var err error
 	if vulnProfileCfg.Profile != nil {
-		cvp, _, _ := clusHelper.GetVulnerabilityProfile(vulnProfileCfg.Profile.Name, h.acc)
+		cvp, _, cvpErr := clusHelper.GetVulnerabilityProfile(vulnProfileCfg.Profile.Name, h.acc)
+		if cvpErr != nil {
+			log.WithError(cvpErr).Warn("failed to get vulnerability profile")
+		}
 		if cvp == nil {
 			cvp = &share.CLUSVulnerabilityProfile{
 				Name:    vulnProfileCfg.Profile.Name,
@@ -2026,7 +2052,10 @@ func (h *nvCrdHandler) crdHandleCompProfile(compProfileCfg *resource.NvCrdCompPr
 
 	var err error
 	if compProfileCfg.Templates != nil {
-		ccp, _, _ := clusHelper.GetComplianceProfile(compProfileCfg.Templates.Name, h.acc)
+		ccp, _, ccpErr := clusHelper.GetComplianceProfile(compProfileCfg.Templates.Name, h.acc)
+		if ccpErr != nil {
+			log.WithError(ccpErr).Warn("failed to get compliance profile")
+		}
 		if ccp != nil && ccp.CfgType != cfgType && ccp.CfgType == share.GroundCfg {
 			log.WithFields(log.Fields{"name": compProfileCfg.Templates.Name}).Error("profile is managed by CRD")
 			return errors.New(restErrMessage[api.RESTErrOpNotAllowed])
@@ -3398,7 +3427,11 @@ func (h *nvCrdHandler) parseCurCrdDlpContent(dlpSecRule *resource.NvDlpSecurityR
 			errMsg := fmt.Sprintf("%s:   cannot create sensor with reserved name %s", errMsgSubject, name)
 			return nil, 1, errMsg, recordName
 		}
-		if cs, _ := cacher.GetDlpSensor(sensor.Name, h.acc); cs != nil && cs.Predefine {
+		cs, csErr := cacher.GetDlpSensor(sensor.Name, h.acc)
+		if csErr != nil {
+			log.WithError(csErr).Warn("failed to get DLP sensor")
+		}
+		if cs != nil && cs.Predefine {
 			errMsg := fmt.Sprintf("%s:   cannot modify predefined sensor %s", errMsgSubject, name)
 			return nil, 1, errMsg, recordName
 		}
@@ -3470,7 +3503,11 @@ func (h *nvCrdHandler) parseCurCrdWafContent(wafSecRule *resource.NvWafSecurityR
 			errMsg := fmt.Sprintf("%s:   cannot create sensor with reserved name %s", errMsgSubject, name)
 			return nil, 1, errMsg, recordName
 		}
-		if cs, _ := cacher.GetWafSensor(sensor.Name, h.acc); cs != nil && cs.Predefine {
+		cs, csErr := cacher.GetWafSensor(sensor.Name, h.acc)
+		if csErr != nil {
+			log.WithError(csErr).Warn("failed to get WAF sensor")
+		}
+		if cs != nil && cs.Predefine {
 			errMsg := fmt.Sprintf("%s:   cannot modify predefined sensor %s", errMsgSubject, name)
 			return nil, 1, errMsg, recordName
 		}
@@ -4030,7 +4067,10 @@ func isExportSkipGroupName(name, owner string, alwaysAllowNsUser bool, acc *acce
 		group, err := cacher.GetGroup(name, "", false, acc)
 		if group == nil {
 			if owner != "target" && err == common.ErrObjectAccessDenied && alwaysAllowNsUser {
-				group, _ = cacher.GetGroup(name, "", false, acc)
+				group, err = cacher.GetGroup(name, "", false, acc)
+				if err != nil {
+					log.WithError(err).Warn("failed to get group with ns user access")
+				}
 			}
 		}
 		if group == nil {
@@ -4330,7 +4370,10 @@ func handlerGroupCfgExport(w http.ResponseWriter, r *http.Request, ps httprouter
 				continue
 			}
 			policy_ids.Add(idx)
-			rule, _ := cacher.GetPolicyRule(idx, acc)
+			rule, err := cacher.GetPolicyRule(idx, acc)
+			if err != nil {
+				log.WithError(err).Warn("failed to get policy rule")
+			}
 			if rule != nil {
 				nvGrpDefItem := resource.NvGroupDefinition{
 					TypeMeta: metav1.TypeMeta{
@@ -4384,11 +4427,23 @@ func handlerGroupCfgExport(w http.ResponseWriter, r *http.Request, ps httprouter
 	// We don't know the default policy mode in other system so in current system just export
 
 	if rconf.UseNameReferral {
-		json_data1, _ := json.MarshalIndent(respGroupDefs, "", "  ")
-		data, _ := yaml.JSONToYAML(json_data1)
+		json_data1, err := json.MarshalIndent(respGroupDefs, "", "  ")
+		if err != nil {
+			log.WithError(err).Warn("failed to marshal group defs")
+		}
+		data, err := yaml.JSONToYAML(json_data1)
+		if err != nil {
+			log.WithError(err).Warn("failed to convert group defs to YAML")
+		}
 		data = append(data, []byte("\n---\n\n")...)
-		json_data2, _ := json.MarshalIndent(resp, "", "  ")
-		data2, _ := yaml.JSONToYAML(json_data2)
+		json_data2, err := json.MarshalIndent(resp, "", "  ")
+		if err != nil {
+			log.WithError(err).Warn("failed to marshal export response")
+		}
+		data2, err := yaml.JSONToYAML(json_data2)
+		if err != nil {
+			log.WithError(err).Warn("failed to convert export response to YAML")
+		}
 		data = append(data, data2...)
 		doExport(exportFileName, exportType, rconf.RemoteExportOptions, data, w, r, acc, login)
 	} else {


### PR DESCRIPTION

## Description

Replace blank-identifier error discards (`_ = f()`, `x, _ = f()`) with proper error handling across controller/cache, controller/kv, and controller/rest packages. Errors are logged at Warn level (or Debug for non-critical progress updates), preserving original code flow without adding early returns.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

### Special notes for your reviewer

<!-- Please describe, if any special design or notes you want to share with your reviewer in this pull request -->

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
