### PR TITLE
fix: reduce noise from cancelling context

### DIFF
--- a/controller/resource/kubernetes_resource.go
+++ b/controller/resource/kubernetes_resource.go
@@ -1346,7 +1346,7 @@ exit_watcher:
 					d.lock.Lock()
 					for rt, rtWatcher := range d.watchers {
 						if rtWatcher != nil && rtWatcher.cancel != nil {
-							log.WithFields(log.Fields{"resource": rt}).Info("Cancel context")
+							log.WithFields(log.Fields{"resource": rt}).Debug("Canceling context")
 							rtWatcher.tokenRenewed = true
 							rtWatcher.cancel()
 							// 1. watchResource() is notified. It sends an error(ex: context.Canceled) to errCh channel and returns
@@ -1699,7 +1699,7 @@ func (d *kubernetes) startWatchResource(rt, ns string, wcb orchAPI.WatchCallback
 					tokenRenewed = rtWatcher.tokenRenewed
 				}
 				d.lock.RUnlock()
-				log.WithFields(log.Fields{"resource": rt, "tokenRenewed": tokenRenewed}).Info("Context cancelled")
+				log.WithFields(log.Fields{"resource": rt, "tokenRenewed": tokenRenewed}).Debug("Context cancelled")
 				if !tokenRenewed {
 					// The context is cancelled not because of k8s token renewal
 					// It means this go routine should be exiting now.


### PR DESCRIPTION
## Description

We're getting some info-level logs every hour.  This PR changes them to `Debug`.

```
│ neuvector-controller-pod 2026-06-29T19:56:56.721|INFO|CTL|resource.(*kubernetes).monitorK8sTokenFile: Cancel context - resource=persistentvolumeclaim                                                    │
│ neuvector-controller-pod 2026-06-29T19:56:56.721|INFO|CTL|resource.(*kubernetes).monitorK8sTokenFile: Cancel context - resource=secret                                                                   │
│ neuvector-controller-pod 2026-06-29T19:56:56.721|INFO|CTL|resource.(*kubernetes).monitorK8sTokenFile: Cancel context - resource=pod                                                                      │
│ neuvector-controller-pod 2026-06-29T19:56:56.721|INFO|CTL|resource.(*kubernetes).monitorK8sTokenFile: Cancel context - resource=k8s-role                                                                 │
│ neuvector-controller-pod 2026-06-29T19:56:56.721|INFO|CTL|resource.(*kubernetes).monitorK8sTokenFile: Cancel context - resource=k8s-role-binding                                                         │
│ neuvector-controller-pod 2026-06-29T19:56:56.721|INFO|CTL|resource.(*kubernetes).monitorK8sTokenFile: Cancel context - resource=service                                                                  │
│ neuvector-controller-pod 2026-06-29T19:56:56.721|INFO|CTL|resource.(*kubernetes).monitorK8sTokenFile: Cancel context - resource=customresourcedefinition                                                 │
│ neuvector-controller-pod 2026-06-29T19:56:56.722|INFO|CTL|resource.(*kubernetes).monitorK8sTokenFile: Cancel context - resource=k8s-cluster-role                                                         │
│ neuvector-controller-pod 2026-06-29T19:56:56.722|INFO|CTL|resource.(*kubernetes).monitorK8sTokenFile: Cancel context - resource=node                                                                     │
│ neuvector-controller-pod 2026-06-29T19:56:56.722|INFO|CTL|resource.(*kubernetes).monitorK8sTokenFile: Cancel context - resource=validatingwebhookconfiguration                                           │
│ neuvector-controller-pod 2026-06-29T19:56:56.722|INFO|CTL|resource.(*kubernetes).monitorK8sTokenFile: Cancel context - resource=configmap                                                                │
│ neuvector-controller-pod 2026-06-29T19:56:56.722|INFO|CTL|resource.(*kubernetes).monitorK8sTokenFile: Cancel context - resource=deployment                                                               │
│ neuvector-controller-pod 2026-06-29T19:56:56.722|INFO|CTL|resource.(*kubernetes).monitorK8sTokenFile: Cancel context - resource=namespace                                                                │
│ neuvector-controller-pod 2026-06-29T19:56:56.722|INFO|CTL|resource.(*kubernetes).monitorK8sTokenFile: Cancel context - resource=k8s-cluster-role-binding                                                 │
│ neuvector-controller-pod 2026-06-29T19:56:56.722|INFO|CTL|resource.(*kubernetes).startWatchResource.func1: Context cancelled - resource=k8s-role tokenRenewed=true                                       │
│ neuvector-controller-pod 2026-06-29T19:56:56.722|INFO|CTL|resource.(*kubernetes).startWatchResource.func1: Context cancelled - resource=k8s-role-binding tokenRenewed=true                               │
│ neuvector-controller-pod 2026-06-29T19:56:56.722|INFO|CTL|resource.(*kubernetes).startWatchResource.func1: Context cancelled - resource=service tokenRenewed=true                                        │
│ neuvector-controller-pod 2026-06-29T19:56:56.722|INFO|CTL|resource.(*kubernetes).startWatchResource.func1: Context cancelled - resource=customresourcedefinition tokenRenewed=true                       │
│ neuvector-controller-pod 2026-06-29T19:56:56.728|INFO|CTL|resource.(*kubernetes).startWatchResource.func1: Context cancelled - resource=deployment tokenRenewed=true                                     │
│ neuvector-controller-pod 2026-06-29T19:56:56.728|INFO|CTL|resource.(*kubernetes).startWatchResource.func1: Context cancelled - resource=k8s-cluster-role-binding tokenRenewed=true                       │
│ neuvector-controller-pod 2026-06-29T19:56:56.728|INFO|CTL|resource.(*kubernetes).startWatchResource.func1: Context cancelled - resource=persistentvolumeclaim tokenRenewed=true                          │
│ neuvector-controller-pod 2026-06-29T19:56:56.728|INFO|CTL|resource.(*kubernetes).startWatchResource.func1: Context cancelled - resource=secret tokenRenewed=true                                         │
│ neuvector-controller-pod 2026-06-29T19:56:56.728|INFO|CTL|resource.(*kubernetes).startWatchResource.func1: Context cancelled - resource=pod tokenRenewed=true                                            │
│ neuvector-controller-pod 2026-06-29T19:56:56.728|INFO|CTL|resource.(*kubernetes).startWatchResource.func1: Context cancelled - resource=node tokenRenewed=true                                           │
│ neuvector-controller-pod 2026-06-29T19:56:56.728|INFO|CTL|resource.(*kubernetes).startWatchResource.func1: Context cancelled - resource=k8s-cluster-role tokenRenewed=true                               │
│ neuvector-controller-pod 2026-06-29T19:56:56.728|INFO|CTL|resource.(*kubernetes).startWatchResource.func1: Context cancelled - resource=validatingwebhookconfiguration tokenRenewed=true                 │
│ neuvector-controller-pod 2026-06-29T19:56:56.728|INFO|CTL|resource.(*kubernetes).startWatchResource.func1: Context cancelled - resource=configmap tokenRenewed=true
```

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

### Special notes for your reviewer

<!-- Please describe, if any special design or notes you want to share with your reviewer in this pull request -->

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
