### PR TITLE
fix: reduce noisy logs

### DIFF
--- a/controller/cache/admission.go
+++ b/controller/cache/admission.go
@@ -179,9 +179,14 @@ func initCache() {
 	ruleCaches := [4]*share.CLUSAdmissionRules{&admValidateExceptCache, &admValidateDenyCache, &admFedValidateExceptionCache, &admFedValidateDenyCache}
 	for idx, ruleType := range ruleTypes {
 		arhs, err := clusHelper.GetAdmissionRuleList(admission.NvAdmValidateType, ruleType)
-		if err != nil && err.Error() == cluster.ErrKeyNotFound.Error() {
-			if putErr := clusHelper.PutAdmissionRuleList(admission.NvAdmValidateType, ruleType, arhs); putErr != nil {
-				log.WithFields(log.Fields{"ruleType": ruleType, "err": putErr}).Warn("failed to init admission rule list")
+		if err != nil {
+			if errors.Is(err, common.ErrObjectNotFound) {
+				if putErr := clusHelper.PutAdmissionRuleList(admission.NvAdmValidateType, ruleType, arhs); putErr != nil {
+					log.WithFields(log.Fields{"ruleType": ruleType, "err": putErr}).Warn("failed to init admission rule list")
+				}
+			} else {
+				log.WithFields(log.Fields{"ruleType": ruleType, "err": err}).Error("failed to get admission rule list")
+				continue
 			}
 		}
 		ruleCaches[idx].RuleMap = make(map[uint32]*share.CLUSAdmissionRule, len(arhs)) // key is ruleID

--- a/controller/grpc.go
+++ b/controller/grpc.go
@@ -21,6 +21,7 @@ import (
 	"github.com/neuvector/neuvector/controller/access"
 	"github.com/neuvector/neuvector/controller/api"
 	"github.com/neuvector/neuvector/controller/cache"
+	"github.com/neuvector/neuvector/controller/common"
 	"github.com/neuvector/neuvector/controller/kv"
 	"github.com/neuvector/neuvector/controller/rest"
 	"github.com/neuvector/neuvector/controller/rpc"
@@ -186,7 +187,7 @@ func (ss *ScanService) HealthCheck(ctx context.Context, data *share.ScannerRegis
 
 	clusHelper := kv.GetClusterHelper()
 	s, err := clusHelper.GetScanner(scannerID, access.NewReaderAccessControl())
-	if err != nil && !errors.Is(err, cluster.ErrKeyNotFound) {
+	if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 		log.WithFields(log.Fields{"error": err, "scanner": scannerID}).Warn("Failed to get scanner during health check")
 		return nil, fmt.Errorf("failed to get scanner %s: %w", scannerID, err)
 	}
@@ -242,7 +243,7 @@ func (ss *ScanService) scannerRegister(data *share.ScannerRegisterData) error {
 
 	// Check if the database is newer.
 	s, err := clusHelper.GetScanner(share.CLUSScannerDBVersionID, access.NewReaderAccessControl())
-	if err != nil && !errors.Is(err, cluster.ErrKeyNotFound) {
+	if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 		log.WithFields(log.Fields{"error": err, "version": data.CVEDBVersion}).Warn("Failed to get scanner DB version record")
 		return fmt.Errorf("failed to get scanner DB version record: %w", err)
 	}

--- a/controller/kv/certmanager.go
+++ b/controller/kv/certmanager.go
@@ -11,6 +11,7 @@ import (
 
 	"errors"
 
+	"github.com/neuvector/neuvector/controller/common"
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/cluster"
 	log "github.com/sirupsen/logrus"
@@ -125,7 +126,7 @@ func (c *CertManager) checkAndRotateCert(cn string, callback *CertManagerCallbac
 		var x509Cert *x509.Certificate
 		shouldrenew := false
 		data, index, err := clusHelper.GetObjectCertRev(cn)
-		if err != nil && err != cluster.ErrKeyNotFound {
+		if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 			// This function assumes the previous certificate should be there.  If not, return an error.
 			return fmt.Errorf("failed to get certificate: %w", err)
 		}
@@ -291,7 +292,7 @@ func (c *CertManager) UpdateCerts(cn string) error {
 
 	return RetryOnCASError(DefaultRetryNumber, func() error {
 		data, index, err := clusHelper.GetObjectCertRev(cn)
-		if err != nil && err != cluster.ErrKeyNotFound {
+		if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 			// This function assumes the previous certificate should be there.  If not, return an error.
 			return fmt.Errorf("failed to get certificate: %w", err)
 		}

--- a/controller/kv/endpoint.go
+++ b/controller/kv/endpoint.go
@@ -3,6 +3,7 @@ package kv
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -613,7 +614,7 @@ func (ep cfgEndpoint) write(writer *bufio.Writer, fedRole string) error {
 	}
 
 	if ep.isStore {
-		if kvPairs, err := cluster.List(ep.key); err == nil || err == cluster.ErrEmptyStore {
+		if kvPairs, err := cluster.List(ep.key); err == nil || errors.Is(err, cluster.ErrEmptyStore) {
 			for _, kvPair := range kvPairs {
 				key := kvPair.Key
 				skip := false
@@ -671,7 +672,7 @@ func (ep cfgEndpoint) write(writer *bufio.Writer, fedRole string) error {
 			return err
 		}
 	} else {
-		if value, err := cluster.Get(ep.key); err == nil || err == cluster.ErrKeyNotFound {
+		if value, err := cluster.Get(ep.key); err == nil || errors.Is(err, cluster.ErrKeyNotFound) {
 			line := fmt.Sprintf("%s\n%s\n", ep.key, value)
 			if _, err = writer.WriteString(line); err != nil {
 				return err

--- a/controller/kv/helper.go
+++ b/controller/kv/helper.go
@@ -569,10 +569,17 @@ func (m clusterHelper) ReleaseLock(lock cluster.LockInterface) {
 	}
 }
 
+func translateErr(err error) error {
+	if errors.Is(err, cluster.ErrKeyNotFound) || errors.Is(err, cluster.ErrEmptyStore) {
+		return common.ErrObjectNotFound
+	}
+	return err
+}
+
 func (m clusterHelper) get(key string) ([]byte, uint64, error) {
 	value, rev, err := cluster.GetRev(key)
 	if err != nil || value == nil {
-		return nil, rev, err
+		return nil, rev, translateErr(err)
 	} else {
 		var wrt bool
 		if value, err, wrt = UpgradeAndConvert(key, value); wrt {
@@ -681,7 +688,7 @@ func (m clusterHelper) GetOrCreateInstallationID() (string, error) {
 
 		key := share.CLUSCtrlInstallationKey
 		value, index, err = m.get(key)
-		if err != nil && err != cluster.ErrKeyNotFound {
+		if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 			return err
 		}
 		id = string(value)
@@ -698,7 +705,7 @@ func (m clusterHelper) GetOrCreateInstallationID() (string, error) {
 		}
 
 		value, err = cluster.Get(share.CLUSNextKeyRotationTSKey)
-		if err != nil {
+		if err != nil && !errors.Is(err, cluster.ErrKeyNotFound) {
 			log.WithError(err).Warn("Failed to get key rotation timestamp")
 		}
 		if len(value) == 0 {
@@ -775,7 +782,7 @@ func (m clusterHelper) GetAllControllers() ([]*share.CLUSController, error) {
 	all := make([]*share.CLUSController, 0)
 	if err != nil {
 		log.WithFields(log.Fields{"err": err}).Error()
-		return all, err
+		return all, translateErr(err)
 	}
 	for _, key := range keys {
 		if value, err := cluster.Get(key); err == nil {
@@ -816,7 +823,7 @@ func (m clusterHelper) GetSystemConfigRev(acc *access.AccessControl) (*share.CLU
 
 	key := share.CLUSConfigSystemKey
 	value, rev, err := m.get(key)
-	if err != nil {
+	if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 		log.WithError(err).Warn("Failed to get system config")
 	}
 	if value != nil {
@@ -859,7 +866,7 @@ func (m clusterHelper) GetScanConfigRev(acc *access.AccessControl) (*share.CLUSS
 
 	key := share.CLUSConfigScanKey
 	value, rev, err := m.get(key)
-	if err != nil {
+	if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 		log.WithError(err).Warn("Failed to get scan config")
 	}
 	if value != nil {
@@ -891,7 +898,7 @@ func (m clusterHelper) GetFedSystemConfigRev(acc *access.AccessControl) (*share.
 
 	key := share.CLUSFedKey(share.CFGEndpointSystem)
 	value, rev, err := m.get(key)
-	if err != nil {
+	if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 		log.WithError(err).Warn("Failed to get fed system config")
 	}
 	if value != nil {
@@ -922,7 +929,7 @@ func (m clusterHelper) PutFedSystemConfigRev(conf *share.CLUSSystemConfig, rev u
 func (m clusterHelper) GetDomain(name string, acc *access.AccessControl) (*share.CLUSDomain, uint64, error) {
 	key := share.CLUSDomainKey(name)
 	value, rev, err := m.get(key)
-	if err != nil {
+	if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 		log.WithError(err).Warn("Failed to get domain")
 	}
 	if value != nil {
@@ -1195,7 +1202,7 @@ func (m clusterHelper) PutPolicyRuleListZip(key string, array []byte) error {
 func (m clusterHelper) GetPolicyRule(id uint32) (*share.CLUSPolicyRule, uint64) {
 	key := share.CLUSPolicyRuleKey(share.DefaultPolicyName, id)
 	value, rev, err := m.get(key)
-	if err != nil {
+	if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 		log.WithError(err).Warn("failed to get policy rule")
 	}
 	if value != nil {
@@ -1289,7 +1296,7 @@ func (m clusterHelper) GetResponseRuleList(policyName string) []*share.CLUSRuleH
 	crhs := make([]*share.CLUSRuleHead, 0)
 	key := share.CLUSResponseRuleListKey(policyName)
 	value, _, err := m.get(key)
-	if err != nil {
+	if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 		log.WithError(err).Warn("failed to get response rule list")
 	}
 	if value != nil {
@@ -1305,7 +1312,7 @@ func (m clusterHelper) GetResponseRuleList(policyName string) []*share.CLUSRuleH
 func (m clusterHelper) GetResponseRule(policyName string, id uint32) (*share.CLUSResponseRule, uint64) {
 	key := share.CLUSResponseRuleKey(policyName, id)
 	value, rev, err := m.get(key)
-	if err != nil {
+	if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 		log.WithError(err).Warn("failed to get response rule")
 	}
 	if value != nil {
@@ -1410,7 +1417,7 @@ func (m clusterHelper) GetAllServers(acc *access.AccessControl) map[string]*shar
 func (m clusterHelper) GetServerRev(name string, acc *access.AccessControl) (*share.CLUSServer, uint64, error) {
 	key := share.CLUSServerKey(name)
 	value, rev, err := m.get(key)
-	if err != nil {
+	if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 		log.WithError(err).Warn("Failed to get server rev from cluster")
 	}
 	if value != nil {
@@ -1509,7 +1516,7 @@ func (m clusterHelper) GetAllUsersNoAuth() map[string]*share.CLUSUser {
 func (m clusterHelper) GetUserRev(fullname string, acc *access.AccessControl) (*share.CLUSUser, uint64, error) {
 	key := share.CLUSUserKey(url.QueryEscape(fullname))
 	value, rev, err := m.get(key)
-	if err != nil {
+	if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 		log.WithError(err).Warn("failed to get user rev")
 	}
 	if value != nil {
@@ -1692,7 +1699,7 @@ func (m clusterHelper) GetScannerStats(id string) (*share.CLUSScannerStats, erro
 		log.WithError(err).Warn("failed to get scanner stats")
 	}
 	if value == nil {
-		return nil, cluster.ErrKeyNotFound
+		return nil, common.ErrObjectNotFound
 	}
 
 	if err := nvJsonUnmarshal(key, value, &s); err != nil {
@@ -1795,16 +1802,18 @@ func (m clusterHelper) GetScanner(id string, acc *access.AccessControl) (*share.
 
 		return &s, nil
 	}
-	return nil, cluster.ErrKeyNotFound
+	return nil, common.ErrObjectNotFound
 }
 
 // GetScannerRev gets scanner with revision for internal operations (no auth check)
 func (m clusterHelper) GetScannerRev(id string) (*share.CLUSScanner, uint64, error) {
 	key := share.CLUSScannerKey(id)
 	value, rev, err := m.get(key)
-	if err != nil || value == nil {
-		// Use cluster.ErrKeyNotFound to stay consistent with the KV store layer abstraction.
-		return nil, 0, cluster.ErrKeyNotFound
+	if err != nil {
+		return nil, 0, err
+	}
+	if value == nil {
+		return nil, 0, common.ErrObjectNotFound
 	}
 
 	var s share.CLUSScanner
@@ -1941,7 +1950,7 @@ func (m clusterHelper) ReleaseScanCredit(scannerId string, releaseCredit int) er
 		scanner, rev, err := m.GetScannerRev(scannerId)
 		if err != nil {
 			// Check if scanner was deleted (object not found)
-			if errors.Is(err, cluster.ErrKeyNotFound) {
+			if errors.Is(err, common.ErrObjectNotFound) {
 				// Scanner has been deleted - credit is implicitly released with the scanner
 				log.WithFields(log.Fields{"scanner": scannerId}).Debug("Scanner not found during credit release, likely deleted")
 				return nil
@@ -1996,7 +2005,7 @@ func (m clusterHelper) TrackCreditAcquisition(controllerID, scannerID string, ma
 	for i := 0; i < m.maxScanCreditRetries; i++ {
 		scanners := make(map[string]int)
 		value, rev, err := m.get(key)
-		if err != nil && !errors.Is(err, cluster.ErrKeyNotFound) {
+		if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 			return err
 		}
 
@@ -3885,7 +3894,7 @@ func (m clusterHelper) PutCrdEventQueue(record *share.CLUSCrdEventRecord) error 
 func (m clusterHelper) GetCrdEventQueueCount() int {
 	key := share.CLUSCrdContentCountKey()
 	value, err := cluster.Get(key)
-	if err != nil && err != cluster.ErrKeyNotFound {
+	if err != nil && !errors.Is(err, cluster.ErrKeyNotFound) {
 		log.WithError(err).Warn("Failed to get CRD event queue count")
 	}
 	if value != nil {

--- a/controller/kv/mock.go
+++ b/controller/kv/mock.go
@@ -546,7 +546,7 @@ func (m *MockCluster) GetScanner(id string, acc *access.AccessControl) (*share.C
 		}
 		return &clone, nil
 	}
-	return nil, cluster.ErrKeyNotFound
+	return nil, common.ErrObjectNotFound
 }
 
 func (m *MockCluster) PickLeastLoadedScanner() (*share.CLUSScanner, error) {
@@ -739,7 +739,7 @@ func (m *MockCluster) GetObjectCertRev(cn string) (*share.CLUSX509Cert, uint64, 
 	out := share.CLUSX509Cert{}
 	v, ok := m.kv[cn]
 	if !ok {
-		return nil, 0, cluster.ErrKeyNotFound
+		return nil, 0, common.ErrObjectNotFound
 	}
 	err := json.Unmarshal([]byte(v), &out)
 	if err != nil {

--- a/controller/kv/upgrade.go
+++ b/controller/kv/upgrade.go
@@ -1894,7 +1894,7 @@ func resetRegistryCfgType() {
 
 func initFedScanRevKey() {
 	if m := clusHelper.GetFedMembership(); m != nil && (m.FedRole == api.FedRoleMaster || m.FedRole == api.FedRoleJoint) {
-		if _, _, err := clusHelper.GetFedScanRevisions(); err == cluster.ErrKeyNotFound {
+		if _, _, err := clusHelper.GetFedScanRevisions(); errors.Is(err, common.ErrObjectNotFound) {
 			var currName string
 			var currRev uint64
 			var regConfigRev uint64

--- a/controller/rest/group.go
+++ b/controller/rest/group.go
@@ -640,8 +640,8 @@ func handlerGroupCreate(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 		log.WithFields(log.Fields{"name": rg.Name}).Error(e)
 		restRespErrorMessage(w, http.StatusBadRequest, api.RESTErrDuplicateName, e)
 		return
-	} else if err != common.ErrObjectNotFound {
-		if err == common.ErrObjectAccessDenied {
+	} else if !errors.Is(err, common.ErrObjectNotFound) {
+		if errors.Is(err, common.ErrObjectAccessDenied) {
 			restRespAccessDenied(w, login)
 		} else {
 			restRespErrorMessage(w, http.StatusInternalServerError, 0, err.Error())

--- a/controller/rest/scanner.go
+++ b/controller/rest/scanner.go
@@ -256,7 +256,7 @@ func handlerScanWorkloadReport(w http.ResponseWriter, r *http.Request, ps httpro
 	var resp *api.RESTScanReportData
 
 	vuls, modules, err := cacher.GetVulnerabilityReport(id, showTag)
-	if err != nil && err != common.ErrObjectNotFound {
+	if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 		log.WithError(err).Warn("failed to get vulnerability report")
 	}
 	if vuls == nil {
@@ -447,7 +447,7 @@ func handlerAssetsScanReportInternal(
 outer:
 	for _, asset = range cachedAssets {
 		vuls, _, vulErr := cacheInterface.GetVulnerabilityReport(asset.GetID(), showTag)
-		if vulErr != nil && vulErr != common.ErrObjectNotFound {
+		if vulErr != nil && !errors.Is(vulErr, common.ErrObjectNotFound) {
 			log.WithError(vulErr).Warn("failed to get vulnerability report")
 		}
 
@@ -743,7 +743,7 @@ func handlerScanHostReport(w http.ResponseWriter, r *http.Request, ps httprouter
 	var resp *api.RESTScanReportData
 
 	vuls, _, err := cacher.GetVulnerabilityReport(id, showTag)
-	if err != nil && err != common.ErrObjectNotFound {
+	if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 		log.WithError(err).Warn("failed to get vulnerability report")
 	}
 	if vuls == nil {
@@ -989,7 +989,7 @@ func getAllVulnerabilities(acc *access.AccessControl) (map[string]*vulAsset, *ap
 	if acc.HasGlobalPermissions(share.PERMS_RUNTIME_SCAN, 0) {
 		platform, _, _ := cacher.GetPlatform()
 		vuls, _, err := cacher.GetVulnerabilityReport(common.ScanPlatformID, "")
-		if err != nil && err != common.ErrObjectNotFound {
+		if err != nil && !errors.Is(err, common.ErrObjectNotFound) {
 			log.WithError(err).Warn("failed to get platform vulnerability report")
 		}
 		if vuls != nil {

--- a/controller/rest/sigstore.go
+++ b/controller/rest/sigstore.go
@@ -107,7 +107,7 @@ func handlerSigstoreRootOfTrustGetByName(w http.ResponseWriter, r *http.Request,
 
 	rootName := ps.ByName("root_name")
 	rootOfTrust, _, err := clusHelper.GetSigstoreRootOfTrust(rootName)
-	if err == common.ErrObjectNotFound || rootOfTrust == nil {
+	if errors.Is(err, common.ErrObjectNotFound) || rootOfTrust == nil {
 		restRespError(w, http.StatusNotFound, api.RESTErrObjectNotFound)
 		return
 	} else if err != nil {
@@ -143,7 +143,7 @@ func handlerSigstoreRootOfTrustPatchByName(w http.ResponseWriter, r *http.Reques
 
 	rootName := ps.ByName("root_name")
 	clusRootOfTrust, rev, err := clusHelper.GetSigstoreRootOfTrust(rootName)
-	if err == common.ErrObjectNotFound || clusRootOfTrust == nil {
+	if errors.Is(err, common.ErrObjectNotFound) || clusRootOfTrust == nil {
 		restRespError(w, http.StatusNotFound, api.RESTErrObjectNotFound)
 		return
 	} else if err != nil {
@@ -203,7 +203,7 @@ func handlerSigstoreRootOfTrustDeleteByName(w http.ResponseWriter, r *http.Reque
 	rootName := ps.ByName("root_name")
 	err := clusHelper.DeleteSigstoreRootOfTrust(rootName)
 	if err != nil {
-		if err == common.ErrObjectNotFound {
+		if errors.Is(err, common.ErrObjectNotFound) {
 			restRespError(w, http.StatusNotFound, api.RESTErrObjectNotFound)
 		} else {
 			msg := fmt.Sprintf("Could not delete root of trust \"%s\" from kv store: %s", rootName, err.Error())
@@ -296,7 +296,7 @@ func handlerSigstoreVerifierPost(w http.ResponseWriter, r *http.Request, ps http
 		// check if root of trust type allows keyless verifiers
 		rootName := ps.ByName("root_name")
 		rootOfTrust, _, err := clusHelper.GetSigstoreRootOfTrust(rootName)
-		if err == common.ErrObjectNotFound || rootOfTrust == nil {
+		if errors.Is(err, common.ErrObjectNotFound) || rootOfTrust == nil {
 			restRespErrorMessage(w, http.StatusNotFound, api.RESTErrObjectNotFound, fmt.Sprintf("could not find root of trust %s", rootName))
 			return
 		} else if err != nil {
@@ -370,7 +370,7 @@ func handlerSigstoreVerifierGetByName(w http.ResponseWriter, r *http.Request, ps
 	rootName := ps.ByName("root_name")
 	verifierName := ps.ByName("verifier_name")
 	verifier, _, err := clusHelper.GetSigstoreVerifier(rootName, verifierName)
-	if err == common.ErrObjectNotFound || verifier == nil {
+	if errors.Is(err, common.ErrObjectNotFound) || verifier == nil {
 		restRespError(w, http.StatusNotFound, api.RESTErrObjectNotFound)
 		return
 	} else if err != nil {
@@ -396,7 +396,7 @@ func handlerSigstoreVerifierPatchByName(w http.ResponseWriter, r *http.Request, 
 	rootName := ps.ByName("root_name")
 	verifierName := ps.ByName("verifier_name")
 	clusVerifier, rev, err := clusHelper.GetSigstoreVerifier(rootName, verifierName)
-	if err == common.ErrObjectNotFound || clusVerifier == nil {
+	if errors.Is(err, common.ErrObjectNotFound) || clusVerifier == nil {
 		restRespError(w, http.StatusNotFound, api.RESTErrObjectNotFound)
 		return
 	} else if err != nil {
@@ -422,7 +422,7 @@ func handlerSigstoreVerifierPatchByName(w http.ResponseWriter, r *http.Request, 
 		// check if root of trust type allows keyless verifiers
 		rootName := ps.ByName("root_name")
 		rootOfTrust, _, err := clusHelper.GetSigstoreRootOfTrust(rootName)
-		if err == common.ErrObjectNotFound || rootOfTrust == nil {
+		if errors.Is(err, common.ErrObjectNotFound) || rootOfTrust == nil {
 			restRespErrorMessage(w, http.StatusNotFound, api.RESTErrObjectNotFound, fmt.Sprintf("could not find root of trust %s", rootName))
 			return
 		} else if err != nil {
@@ -476,7 +476,7 @@ func handlerSigstoreVerifierDeleteByName(w http.ResponseWriter, r *http.Request,
 	verifierName := ps.ByName("verifier_name")
 	err := clusHelper.DeleteSigstoreVerifier(rootName, verifierName)
 	if err != nil {
-		if err == common.ErrObjectNotFound {
+		if errors.Is(err, common.ErrObjectNotFound) {
 			restRespError(w, http.StatusNotFound, api.RESTErrObjectNotFound)
 		} else {
 			msg := fmt.Sprintf("Could not delete verifier \"%s/%s\" from kv store: %s", rootName, verifierName, err.Error())

--- a/controller/rest/sniffer.go
+++ b/controller/rest/sniffer.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -164,7 +165,7 @@ func handlerSnifferShow(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 			restRespError(w, http.StatusNotFound, api.RESTErrObjectNotFound)
 		}
 	} else {
-		if err == common.ErrObjectNotFound || err == common.ErrObjectAccessDenied {
+		if errors.Is(err, common.ErrObjectNotFound) || errors.Is(err, common.ErrObjectAccessDenied) {
 			restRespNotFoundLogAccessDenied(w, login, err)
 		} else {
 			restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailWriteCluster, "Error in rpc")


### PR DESCRIPTION
## Description

This PR addresses two issues:

1. Previously, clusterHelper could return `cluster.ErrEmptyStore`, `cluster.ErrKeyNotFound` and `common.ErrObjectNotFound`.  This PR makes clusterHelper only returns `common.ErrObjectNotFound` by translating the error internally.
2. In the previous changes, more errors are handled, but not all logic ignores `common.ErrObjectNotFound` and other errors.  In this PR, those issues are addressed. 

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

### Special notes for your reviewer

<!-- Please describe, if any special design or notes you want to share with your reviewer in this pull request -->

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
