### PR TITLE
nvbench: k3s CIS check OOM-kills the enforcer on nodes with a large journal

### DIFF
--- a/agent/nvbench/journal.tmpl
+++ b/agent/nvbench/journal.tmpl
@@ -11,7 +11,11 @@ fetch_kube_cmd() {
     echo "$JOURNAL_LOG" |  grep "Running $1" | tail -n1   | sed "s/[\"']//g"
 }
 
-JOURNAL_LOG=$(journalctl -D /var/log/journal -u k3s)
+# Only the "Running <component>" lines are used below (see fetch_kube_cmd), so
+# filter them out here instead of buffering the entire k3s journal into this
+# variable. On a control-plane node with a large journal that slurp can reach
+# several GB of shell memory and OOM-kill the enforcer.
+JOURNAL_LOG=$(journalctl -D /var/log/journal -u k3s | grep 'Running')
 
 # Read logs for each component
 kube_apiserver_cmd=$(fetch_kube_cmd "$CIS_APISERVER_CMD")


### PR DESCRIPTION
### Related Issue
https://github.com/neuvector/neuvector/issues/2570

### What happens

On our k3s clusters the enforcer pod sits in CrashLoopBackOff, getting OOM-killed and restarting every few minutes. It's node-specific: it hits the k3s control-plane node and not the quieter worker.

### What's actually using the memory

The Go agent looked fine, so I checked the kernel OOM log, and the process getting killed isn't the agent, it's a shell:

```
Memory cgroup out of memory: Killed process ... (sh) total-vm:4975296kB, anon-rss:3994112kB
```

~3.8 GB of anon memory in a `sh` process. At the same moment the `agent` was ~36 MB, and a heap profile of the agent showed only ~35 MB in use, which is why this is easy to miss: the memory isn't in the Go process at all.

Tracing the shell, it's `agent/nvbench/journal.tmpl` (run via `nstools` for the k3s CIS check). The line that blows up is:

```sh
JOURNAL_LOG=$(journalctl -D /var/log/journal -u k3s)
```

That command substitution buffers the entire k3s journal into a shell variable. On a control-plane node the journal is large (ours is ~3.8 GB), so `JOURNAL_LOG` grows to match and the cgroup OOMs.

### The fix

The only use of `JOURNAL_LOG` is `fetch_kube_cmd`, which greps it for the `Running <component>` lines, so there's no need to hold the whole journal:

```sh
JOURNAL_LOG=$(journalctl -D /var/log/journal -u k3s | grep 'Running')
```

I ran the original and the patched script head-to-head on the same node against the real ~3.8 GB journal:

- peak RSS: **~3.9 GB -> ~227 MB**
- final output: **byte-identical** (all components still detected: kube-apiserver, controller-manager, scheduler, kube-proxy, kubelet)

So it changes nothing but the memory, and the OOM is gone.

This is separate from #1260 (that's the arm64 sock_diag netlink noise); this one is the memory blow-up in the k3s CIS journal check.
