### PR TITLE
fix(nvbench): check rke2 client ca ownership by path

### DIFF
--- a/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
@@ -204,25 +204,20 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
-            file=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
-            file=$(append_prefix "$CONFIG_PREFIX" "$file")
-            if [ -e "$file" ]; then
-              ownership=$(stat -c %u%g $file)
-              if [ "$ownership" = "00" ]; then
-                pass "$check"
-                pass "      * client-ca-file: $file"
-              else
-                warn "$check"
-                warn "      * Wrong ownership for $file, expected root:root, but is $ownership"
-              fi
+          file="/var/lib/rancher/rke2/agent/client-ca.crt"
+          file=$(append_prefix "$CONFIG_PREFIX" "$file")
+          if [ -e "$file" ]; then
+            ownership=$(stat -c %u%g $file)
+            if [ "$ownership" = "00" ]; then
+              pass "$check"
+              pass "      * client-ca-file: $file"
             else
               warn "$check"
-              warn "      * File not found, $file"
+              warn "      * Wrong ownership for $file, expected root:root, but is $ownership"
             fi
           else
             warn "$check"
-            warn "      * --client-ca-file not set"
+            warn "      * File not found, $file"
           fi
         remediation: Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
No associated GitHub issue.

Fix the false warning produced by RKE2 CIS check K.4.1.8 when the deprecated kubelet flag `--client-ca-file` is not present.

The current check extracts `--client-ca-file` from `$CIS_KUBELET_CMD`. Current RKE2 versions configure the client CA through the kubelet configuration instead, so the check incorrectly reports:

`--client-ca-file not set`

This change checks the ownership of the RKE2 client CA file directly at `/var/lib/rancher/rke2/agent/client-ca.crt`, as specified by the RKE2 CIS Self-Assessment Guides.

<!-- Please provide the link to the documentation related to your change, if applicable -->
- [RKE2 CIS 1.8 – Control 4.1.8](https://docs.rke2.io/security/cis_self_assessment18#418-ensure-that-the-client-certificate-authorities-file-ownership-is-set-to-rootroot-automated)
- [RKE2 CIS 1.12 – Control 4.1.8](https://docs.rke2.io/security/cis_self_assessment112#418-ensure-that-the-client-certificate-authorities-file-ownership-is-set-to-rootroot-automated)
- [Kubernetes kubelet command-line reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/)

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands on an RKE2 worker node:

```shell
ps -ef | grep '[k]ubelet'
stat -c '%U:%G %n' /var/lib/rancher/rke2/agent/client-ca.crt
```

Verify that the kubelet command line does not contain `--client-ca-file` and that the client CA file is owned by `root:root`.

Run the NeuVector RKE2 compliance scan and verify that K.4.1.8:

- passes when `/var/lib/rancher/rke2/agent/client-ca.crt` exists and is owned by `root:root`;
- warns when the file is not owned by `root:root`; and
- warns when the file does not exist.

## Additional Information

### Tradeoff

Two approaches were considered:

1. Extend the existing `$CIS_KUBELET_CMD` logic to fall back from the deprecated `--client-ca-file` flag to `clientCAFile` in the kubelet configuration.
2. Follow the RKE2 CIS audit procedure and check the RKE2 client CA file directly.

This pull request uses the second approach. It avoids adding kubelet configuration and drop-in file resolution logic to a check for which the RKE2 CIS Self-Assessment Guides specify a fixed path.

The tradeoff is that the check validates the RKE2-defined path rather than an arbitrary custom kubelet client CA configuration.

### Potential improvement

Add and select a dedicated RKE2 CIS 1.12 benchmark profile for RKE2 v1.33 and newer. This is outside the scope of this change.

A separate, more general enhancement could resolve `clientCAFile` from the effective kubelet configuration, including configuration drop-in files, if support for custom RKE2 client CA paths is required.

### Special notes

Although `$CIS_KUBELET_CMD` is used by other controls in this benchmark file, K.4.1.8 verifies file ownership, and both the RKE2 CIS 1.8 and 1.12 Self-Assessment Guides explicitly audit:

`/var/lib/rancher/rke2/agent/client-ca.crt`

The existing `$CIS_KUBELET_CMD` lookup is therefore replaced for this control rather than extended with configuration-file parsing.

This change is limited to K.4.1.8 in the existing `cis-rke2-1.8.0` profile. It does not add or claim full RKE2 CIS 1.12 support.

### Checklist

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests