### PR TITLE
feat: NVSHAS-10316 improve error message for image scan

### DIFF
--- a/controller/rest/repository.go
+++ b/controller/rest/repository.go
@@ -140,8 +140,9 @@ func (r *repoScanTask) Run(arg interface{}) (interface{}, *JobError) {
 			"errMsg":   rsr.errMsg,
 		}).Error("RPC request fail")
 	} else if result.Error != share.ScanErrorCode_ScanErrNone {
-		// Include the error code in Detail to enable ShouldRetry logic
-		scanErr = NewJobError(api.RESTErrFailRepoScan, err, result.Error)
+		// Include the error code in Detail to enable ShouldRetry logic.
+		// Use the human-readable string as Err so it surfaces in the API response body.
+		scanErr = NewJobError(api.RESTErrFailRepoScan, errors.New(scanUtils.ScanErrorToStr(result.Error)), result.Error)
 		log.WithFields(log.Fields{
 			"registry":   req.Registry,
 			"image":      getImageName(req),

--- a/share/scan/registry.go
+++ b/share/scan/registry.go
@@ -181,7 +181,8 @@ func (rc *RegClient) GetImageInfo(ctx context.Context, name, tag string, manifes
 		}
 	}
 
-	var v2SchemaError error = nil
+	var v2SchemaError error
+	var manifestConnErr error
 	if !isQuaySpecialCase {
 		if manifestReqType == registry.ManifestRequest_CosignSignature {
 			log.WithFields(log.Fields{"name": name, "tag": tag}).Debug("not quay special case, trying v2")
@@ -211,8 +212,12 @@ func (rc *RegClient) GetImageInfo(ctx context.Context, name, tag string, manifes
 				log.WithFields(log.Fields{"os": ml.Manifests[0].Platform.OS, "arch": ml.Manifests[0].Platform.Architecture, "tag": tag}).Debug("manifest list")
 
 				_, body, err = rc.ManifestRequest(ctx, name, tag, 2, manifestReqType)
+				if err != nil {
+					manifestConnErr = err
+				}
 			}
 		} else {
+			manifestConnErr = err
 			v2SchemaError = fmt.Errorf("error when requesting v2 manifest, will try v1: %s", err.Error())
 		}
 
@@ -305,7 +310,7 @@ func (rc *RegClient) GetImageInfo(ctx context.Context, name, tag string, manifes
 		log.WithFields(log.Fields{"imageInfo": imageInfo}).Error("Get metadata fail")
 
 		if imageInfo.ID == "" {
-			return imageInfo, share.ScanErrorCode_ScanErrImageNotFound
+			return imageInfo, classifyManifestErr(manifestConnErr)
 		} else {
 			return imageInfo, share.ScanErrorCode_ScanErrRegistryAPI
 		}
@@ -350,6 +355,24 @@ func (rc *RegClient) getSchemaV1Id(manV1 *manifestV1.SignedManifest) string {
 
 func (rc *RegClient) Alive() (uint, error) {
 	return rc.Ping()
+}
+
+// classifyManifestErr maps a manifest-request transport error to the appropriate
+// ScanErrorCode, distinguishing TLS/network failures from genuine missing-image errors.
+func classifyManifestErr(err error) share.ScanErrorCode {
+	if err == nil {
+		return share.ScanErrorCode_ScanErrImageNotFound
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "x509:") || strings.Contains(msg, "tls:") {
+		return share.ScanErrorCode_ScanErrCertificate
+	}
+	if strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "no such host") ||
+		strings.Contains(msg, "dial tcp") {
+		return share.ScanErrorCode_ScanErrNetwork
+	}
+	return share.ScanErrorCode_ScanErrImageNotFound
 }
 
 // GetCosignSignatureTagFromDigest takes an image digest and returns the default tag

--- a/share/scan/registry_test.go
+++ b/share/scan/registry_test.go
@@ -1,13 +1,66 @@
 package scan
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
 	"github.com/docker/distribution"
 	manifestV2 "github.com/docker/distribution/manifest/schema2"
+	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/scan/registry"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestClassifyManifestErr(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		expected share.ScanErrorCode
+	}{
+		{
+			name:     "nil error returns ImageNotFound",
+			err:      nil,
+			expected: share.ScanErrorCode_ScanErrImageNotFound,
+		},
+		{
+			name:     "x509 certificate error returns Certificate",
+			err:      errors.New(`Get "https://registry.example.com/v2/": tls: failed to verify certificate: x509: certificate signed by unknown authority`),
+			expected: share.ScanErrorCode_ScanErrCertificate,
+		},
+		{
+			name:     "tls handshake error returns Certificate",
+			err:      errors.New(`tls: no supported versions satisfy MinVersion and MaxVersion`),
+			expected: share.ScanErrorCode_ScanErrCertificate,
+		},
+		{
+			name:     "connection refused returns Network",
+			err:      errors.New(`dial tcp 10.0.0.1:443: connect: connection refused`),
+			expected: share.ScanErrorCode_ScanErrNetwork,
+		},
+		{
+			name:     "no such host returns Network",
+			err:      errors.New(`dial tcp: lookup registry.example.com on 8.8.8.8:53: no such host`),
+			expected: share.ScanErrorCode_ScanErrNetwork,
+		},
+		{
+			name:     "dial tcp timeout returns Network",
+			err:      errors.New(`dial tcp 10.0.0.1:443: i/o timeout`),
+			expected: share.ScanErrorCode_ScanErrNetwork,
+		},
+		{
+			name:     "404 not found returns ImageNotFound",
+			err:      errors.New(`manifest unknown: manifest unknown`),
+			expected: share.ScanErrorCode_ScanErrImageNotFound,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expected, classifyManifestErr(c.err))
+		})
+	}
+}
 
 func printLayers(t *testing.T, imageInfo *ImageInfo) {
 	for i := 0; i < len(imageInfo.Layers); i++ {


### PR DESCRIPTION
## Description

https://github.com/neuvector/neuvector/issues/2618

This PR makes sure that when controller `/v1/scan/repository` API is called to trigger an image scan, the error can be populated correctly from scanner when the issue is TLS certificate error.  

Before the change:

```
{"code":26,"error":"Fail to scan repository","message":"ScanErrImageNotFound"}
```

After the change:

```
{"code":26,"error":"Fail to scan repository","message":"certificate error"}
```

This PR is controller side and scanner needs another one to update neuvector/neuvector dependency. 

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

### Special notes for your reviewer

<!-- Please describe, if any special design or notes you want to share with your reviewer in this pull request -->

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
