### PR TITLE
issue 2597: Missing role and rolebinding when autoGenerateCert=false

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -613,6 +613,8 @@ func main() {
 				os.Exit(-2)
 			}
 		}
+	} else {
+		resource.AdjustRequiredRBAC(false)
 	}
 
 	err = cluster.ReloadInternalCert()

--- a/controller/resource/kubernetes_rbac.go
+++ b/controller/resource/kubernetes_rbac.go
@@ -2187,3 +2187,12 @@ func GetAllRiskyRolesByServiceAccount(saName, namespace string) ([]int, error) {
 	}
 	return riskyTags, nil
 }
+
+func AdjustRequiredRBAC(autoInternalCert bool) {
+	if !autoInternalCert {
+		delete(rbacRoleBindingsWanted, NvJobCreationRoleBinding)
+		delete(rbacRoleBindingsWanted, NvCertUpgraderRoleBinding)
+		delete(rbacRolesWanted, NvJobCreationRole)
+		delete(rbacRolesWanted, NvCertUpgraderRole)
+	}
+}


### PR DESCRIPTION
## Description

Fix [2597](https://github.com/neuvector/neuvector/issues/2597)

## Test

Specify `core.internal.autoGenerateCert=true` in helm command adds the following env var to controller deployment manifest:
```
           - name: AUTO_INTERNAL_CERT
             value: "1"
```

k8s RBAC role/rolebinding `neuvector-binding-job-creation`/`neuvector-binding-cert-upgrader` are checked only when `AUTO_INTERNAL_CERT` is set to `true` in controller deployment manifest, 

## Additional Information

### Tradeoff

### Checklist
