### PR TITLE
issue 2614: Revert  for Processes to NOT be the default

### DIFF
--- a/controller/common/common.go
+++ b/controller/common/common.go
@@ -106,7 +106,7 @@ const RegistryFedRepoScanName string = "fed._repo_scan"
 var DefaultSystemConfig = share.CLUSSystemConfig{
 	NewServicePolicyMode:      share.PolicyModeLearn,
 	NewServiceProfileMode:     share.PolicyModeLearn,
-	NewServiceProfileBaseline: share.ProfileZeroDrift,
+	NewServiceProfileBaseline: share.ProfileBasic,
 	UnusedGroupAging:          share.UnusedGroupAgingDefault,
 	CLUSSyslogConfig: share.CLUSSyslogConfig{
 		SyslogIP:         nil,


### PR DESCRIPTION
## Description ( Cherry-pick https://github.com/neuvector/neuvector/pull/2615 from branch `main` to branch `release/v5.6` )

Fix [#2614](https://github.com/neuvector/neuvector/issues/2614)

Use `basic` by default for "new service profile baseline" in fresh NV deployment.

Need to update the
[Documentation](https://open-docs.neuvector.com/policy/processrules#policy---groups---process-profile-rules)
about this change.

## Test

This PR only affects fresh deployment.
To test this pull request, you can run the following commands:

```
curl -k -H "Content-Type: application/json" -H "X-Auth-Token: $TOKEN" "https://$ControllerIP:$ControllerPORT/v1/system/config" | jq -r '.config.new_service_profile_baseline'
```

It should get `basic` after this PR is merged.

## Additional Information

### Tradeoff

