### PR TITLE
chore(renovate): update renovate.json to include release/v5.6 branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
   ],
   "baseBranchPatterns": [
     "main",
+    "release/v5.6",
     "release/v5.5",
     "release/v5.4"
   ],


### PR DESCRIPTION
## Description

Change the branch name specified in renovate.json to enable security-only update on release/v5.6 branch.

## Test

## Additional Information

### Tradeoff

### Potential improvement
