### PR TITLE
fix(scanner): force CVE DB re-upload when store data is missing

### DIFF
--- a/controller/grpc.go
+++ b/controller/grpc.go
@@ -438,6 +438,17 @@ func (ss *ScanService) ScannerRegisterV3(stream share.ControllerScanService_Scan
 		upToDate = s.CVEDBVersion == req.CVEDBVersion
 	}
 
+	// Even when the version matches, verify the store data is actually present.
+	// If the slots were lost (e.g. after a partial upgrade or cluster disruption)
+	// while the version marker survived, force a full re-upload to recover.
+	if upToDate {
+		storePrefix := fmt.Sprintf("%s%s/", share.CLUSScannerDBStore, req.CVEDBVersion)
+		if keys, _ := cluster.GetStoreKeys(storePrefix); len(keys) == 0 {
+			upToDate = false
+			log.WithFields(log.Fields{"scanner": req.ID, "version": req.CVEDBVersion}).Warn("CVEDB store data missing despite up-to-date version marker; forcing re-upload")
+		}
+	}
+
 	if upToDate {
 		log.WithFields(log.Fields{"scanner": req.ID, "version": req.CVEDBVersion}).Info("CVEDB up-to-date, registering scanner without upload")
 		totalEntries := int(s.CVEDBEntries)


### PR DESCRIPTION
## Problem

When the consul version marker `scan/scanner/NeuVectorCVEDBVersion` exists
for a given CVE DB version but the corresponding data slots at
`scan/database/<version>/` have been lost — e.g. after a partial upgrade or
cluster disruption — `ScannerRegisterV3` considers the database up-to-date
and skips the re-upload. This leaves the controller's SQLite CVE database
empty, and the Vulnerabilities page shows:

> "The data is being prepared during controller is restarting, please click
> refresh button a moment later"

<img width="1621" height="1261" alt="image" src="https://github.com/user-attachments/assets/df6bd441-aa9c-4c94-8fe9-2e0bd68e42b3" />

indefinitely, even after restarting all pods and running the updater job.
The only recovery is to manually delete the stale consul key and restart
the scanner pods.

## Fix

Add a store existence check in the `upToDate` fast path: before skipping
the upload, verify that the consul slots for the current version are
actually present. If they are missing, set `upToDate = false` so the
controller requests a full re-upload from the scanner on the next
registration.