### PR TITLE
Modify NeuVector release checklist in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/neuvector_release.md
+++ b/.github/ISSUE_TEMPLATE/neuvector_release.md
@@ -14,6 +14,12 @@ This issue tracks the release of a new version of NeuVector. Please
 follow the checklist below to ensure a smooth release process.
 (ref: https://confluence.suse.com/spaces/NeuVector/pages/1335722612/NeuVector+Release+Check+List)
 
+- [ ] Is documentation ready to be published?
+  - [ ] CVEs (if applicable)
+  - [ ] Release note
+  - [ ] New version
+  - [ ] Matrix
+  - [ ] Tech Writer notified
 - [ ] Images are updated and available
 - [ ] No cve is found scanned by trivy, ms and our scanner tool on released images.
 - [ ] Pass the release test suites.
@@ -27,6 +33,6 @@ follow the checklist below to ensure a smooth release process.
 - [ ] Publish UBI. (Esther)
 - [ ] Announce neuvector-updates email list. (William)
 - [ ] CRD changes document.
-- [ ] Documentation. (need to update support matrix and features.)
+- [ ] Publish Documentation. (need to update support matrix and features.)
 - [ ] Verify https://open-docs.neuvector.com/releasenotes/5x/ is up-to-date
 


### PR DESCRIPTION
Update release checklist to ensure that documentation is ready to be published by the time we start working on a new release with the goal to publish it once the release is over.