### PR TITLE
dp: size the AF_PACKET ring blocks from the runtime page size

### DIFF
--- a/dp/ring.c
+++ b/dp/ring.c
@@ -34,6 +34,39 @@ static uint8_t g_tso_packet[MAX_TSO_SIZE];
 #define FRAME_SIZE_V3 (1024 * 2)
 #define BLOCK_SIZE_V3 (1024 * 64)
 
+/*
+ * The kernel requires tp_block_size to be a multiple of PAGE_SIZE. The block
+ * sizes above are multiples of 4096, so they are fine on a 4K-page kernel but
+ * rejected with EINVAL on a 16K or 64K page kernel (arm64 builds with
+ * CONFIG_ARM64_16K_PAGES / CONFIG_ARM64_64K_PAGES).
+ *
+ * Round the block size up to the page size and divide the block count by the
+ * same factor, so the total ring size, and with it the MAP_LOCKED footprint,
+ * is unchanged. Every block size, frame size and block count here is a power
+ * of two, so the factor divides both exactly: block_size stays a multiple of
+ * frame_size, and ring->size stays a power of two, which dp_rx_v1() and
+ * dp_tx_v1() depend on for their "& (ring->size - 1)" wraparound.
+ *
+ * On a 4K-page kernel this is a no-op.
+ */
+static void dp_ring_fit_page_size(unsigned int *block_size, uint *blocks)
+{
+    long page_size = sysconf(_SC_PAGESIZE);
+
+    if (page_size <= 0 || *block_size == 0 || (*block_size % (unsigned int)page_size) == 0) {
+        return;
+    }
+
+    unsigned int aligned = (((*block_size) + (unsigned int)page_size - 1) /
+                            (unsigned int)page_size) * (unsigned int)page_size;
+    unsigned int factor = aligned / *block_size;
+
+    *block_size = aligned;
+    *blocks = (*blocks > factor) ? (*blocks / factor) : 1;
+
+    DEBUG_INIT("page_size=%ld block_size=%u blocks=%u\n", page_size, *block_size, *blocks);
+}
+
 static int dp_ring_bind(int fd, const char *iface)
 {
     struct sockaddr_ll ll;
@@ -201,13 +234,16 @@ static int dp_ring_v1(int fd, const char *iface, dp_ring_t *ring, bool tap, bool
      * Following comments are quoted from 
      * https://www.kernel.org/doc/Documentation/networking/packet_mmap.txt
      *
-     * Block size needs to be PAGE_SIZE << MAX_ORDER, PAGE_SIZE is 4096 bytes
+     * Block size needs to be a multiple of PAGE_SIZE. PAGE_SIZE is 4096 bytes
+     * on x86_64 and on most arm64 builds, but it is 16384 or 65536 on an arm64
+     * kernel built with CONFIG_ARM64_16K_PAGES or CONFIG_ARM64_64K_PAGES, so it
+     * has to be read at runtime rather than assumed. See dp_ring_fit_page_size().
      *
-     * As stated earlier, each block is a contiguous physical region of memory. 
+     * As stated earlier, each block is a contiguous physical region of memory.
      * These memory regions are allocated with calls to the __get_free_pages() function.
-     * As the name indicates, this function allocates pages of memory, and the second 
+     * As the name indicates, this function allocates pages of memory, and the second
      * argument is "order" or a power of two number of pages, that is (for PAGE_SIZE == 4096)
-     * order=0 ==> 4096 bytes, order=1 ==> 8192 bytes, order=2 ==> 16384 bytes, etc. 
+     * order=0 ==> 4096 bytes, order=1 ==> 8192 bytes, order=2 ==> 16384 bytes, etc.
      *
      */
     if (!tap && jumboframe){
@@ -217,6 +253,7 @@ static int dp_ring_v1(int fd, const char *iface, dp_ring_t *ring, bool tap, bool
         req->tp_block_size = BLOCK_SIZE_V1;
         req->tp_frame_size = FRAME_SIZE_V1;
     }
+    dp_ring_fit_page_size(&req->tp_block_size, &blocks);
     req->tp_block_nr = blocks;
     req->tp_frame_nr = (req->tp_block_size * blocks) / req->tp_frame_size;
     ring->size = req->tp_block_size * blocks;
@@ -227,15 +264,26 @@ static int dp_ring_v1(int fd, const char *iface, dp_ring_t *ring, bool tap, bool
     }
     ring->batch = batch;
 
-    setsockopt(fd, SOL_PACKET, PACKET_RX_RING, req, sizeof(*req));
+    if (setsockopt(fd, SOL_PACKET, PACKET_RX_RING, req, sizeof(*req)) < 0) {
+        DEBUG_ERROR(DBG_CTRL, "fail to set rx ring: %s, block_size=%u frame_size=%u "
+                    "block_nr=%u frame_nr=%u page_size=%ld\n", strerror(errno),
+                    req->tp_block_size, req->tp_frame_size, req->tp_block_nr,
+                    req->tp_frame_nr, sysconf(_SC_PAGESIZE));
+        return -1;
+    }
     if (!tap) {
-        setsockopt(fd, SOL_PACKET, PACKET_TX_RING, req, sizeof(*req));
+        if (setsockopt(fd, SOL_PACKET, PACKET_TX_RING, req, sizeof(*req)) < 0) {
+            DEBUG_ERROR(DBG_CTRL, "fail to set tx ring: %s, block_size=%u frame_size=%u "
+                        "block_nr=%u frame_nr=%u page_size=%ld\n", strerror(errno),
+                        req->tp_block_size, req->tp_frame_size, req->tp_block_nr,
+                        req->tp_frame_nr, sysconf(_SC_PAGESIZE));
+            return -1;
+        }
     }
 
     ring->rx_map = mmap(NULL, ring->map_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_LOCKED, fd, 0);
     if (ring->rx_map == MAP_FAILED) {
-        DEBUG_ERROR(DBG_CTRL, "fail to mmap (size=0x%x).\n", ring->map_size);
-        close(fd);
+        DEBUG_ERROR(DBG_CTRL, "fail to mmap (size=0x%x): %s.\n", ring->map_size, strerror(errno));
         return -1;
     }
 


### PR DESCRIPTION
### Related Issue

https://github.com/neuvector/neuvector/issues/2673

### What happens

On an arm64 node with a 64KB-page kernel the enforcer runs, reports healthy and connected, and captures no traffic whatsoever. The only symptom is this, on every interface event:

```
dp_ring_v1: fail to mmap (size=0x400000).
dp_alloc_context: fail to open dp socket, iface=eth0
```

`tp_block_size` has to be a multiple of `PAGE_SIZE`. `BLOCK_SIZE_V1` is 8192 and `BLOCK_SIZE_JUMBO_V1` is 32768, both fine against 4096 and both rejected with EINVAL against 65536. The `setsockopt` return value is dropped, so the first thing anyone sees is the `mmap` failing further down with no errno, which sends you looking at memory limits instead.

### The fix

Round the block size up to the runtime page size, and divide the block count by the same factor. The total ring size stays exactly what it was, which matters because these are mapped `MAP_LOCKED` and there is one per monitored interface. Rounding the block size alone would have taken the standard V1 ring from 8K to 64K per block and multiplied the locked footprint by eight.

Everything involved is a power of two, so the factor divides cleanly, `block_size` stays a multiple of `frame_size`, and `ring->size` stays a power of two, which `dp_rx_v1()` and `dp_tx_v1()` need for their `& (ring->size - 1)` wraparound.

On a 4K page kernel every value comes out unchanged, so x86_64 behaviour is untouched.

Also checks the two `setsockopt` calls and prints what the kernel actually said, along with the geometry and the page size. Without that this class of failure is close to undiagnosable from the logs.

### Test

Built with the standard `-Werror` flags:

```
cd dp && make
```

Ring geometry before and after, on an arm64 host with a 64KB-page kernel. These numbers come from a standalone program asking the kernel for the same geometries `dp_ring_v1()` builds, before and after the scaling this patch adds, rather than from the patched binary in place:

```
PAGE_SIZE = 65536

as shipped:
  tap     bs=8192   fs=2048   bn=512   total=0x400000   | setsockopt=Invalid argument
  inline  bs=8192   fs=2048   bn=2048  total=0x1000000  | setsockopt=Invalid argument
  jumbo   bs=32768  fs=16384  bn=2048  total=0x4000000  | setsockopt=Invalid argument

patched:
  tap     bs=65536  fs=2048   bn=64    total=0x400000   | setsockopt=ok | mmap=ok
  inline  bs=65536  fs=2048   bn=256   total=0x1000000  | setsockopt=ok | mmap=ok
  jumbo   bs=65536  fs=16384  bn=1024  total=0x4000000  | setsockopt=ok | mmap=ok
```

Same totals, so no extra locked memory.

### Notes for reviewer

There is no test suite under `dp/`, and no CI runner has a page size other than 4K, so this cannot be covered by a unit test or reproduced in CI. The before and after above is from real hardware and is the best evidence I can offer. On a 4K host the new code path is a no-op by construction, so the risk to existing platforms is the `setsockopt` return check rather than the geometry.

One thing to note on the helper: if the block count were ever smaller than the scaling factor it clamps to one block, and that is the single case where the ring would grow rather than stay the same size. It cannot happen with the current constants, since the smallest count is 512 and the largest factor is 16 on a 64K page, but it is worth knowing if those numbers ever change.
