### PR TITLE
probe: size the netlink dump buffer for kernels with pages over 4K

### DIFF
--- a/agent/probe/socket_linux.go
+++ b/agent/probe/socket_linux.go
@@ -10,7 +10,14 @@ import (
 	"github.com/neuvector/neuvector/share/utils"
 )
 
-const inetMonitorSocketSize uint = 1024 * 5
+// Has to be at least NLMSG_GOODSIZE, which the kernel defines as
+// SKB_WITH_OVERHEAD(PAGE_SIZE) capped at SKB_WITH_OVERHEAD(8192), so roughly
+// 7872 bytes on any kernel with PAGE_SIZE >= 8192 (arm64 built with 16K or 64K
+// pages). netlink_dump() only shrinks a dump datagram to the reader's buffer
+// when that buffer is the larger of the two, so anything below NLMSG_GOODSIZE
+// truncates every datagram, which abandons the dump and leaves the socket
+// returning EBUSY for the rest of its life.
+const inetMonitorSocketSize uint = 1024 * 32
 const INET_DIAG_INFO = 2
 
 /* removed by go-lint


### PR DESCRIPTION
### Related Issue

Related to #1260 and #1622.

### What happens

On an arm64 node with a 64KB-page kernel the enforcer logs this about once a second, forever, and never succeeds:

```
probe.(*Probe).getNewConnections: Failed to read sockets - error=Error in netlink message
```

We had 49,545 of them in the log window we still had. Connection reporting for that node is dead for the lifetime of the pod.

### What is actually going on

`getNewConnections()` reads INET_DIAG dumps into a 5120 byte buffer. The kernel picks the datagram size in `netlink_dump()`:

```c
#if PAGE_SIZE < 8192UL
#define NLMSG_GOODSIZE  SKB_WITH_OVERHEAD(PAGE_SIZE)
#else
#define NLMSG_GOODSIZE  SKB_WITH_OVERHEAD(8192UL)
#endif
```

and only shrinks to the reader's buffer when the reader's buffer is the bigger of the two. On a 4K page kernel `NLMSG_GOODSIZE` works out around 3776, which is under 5120, so the kernel adapts down and everything fits. On a kernel with `PAGE_SIZE` of 8192 or more it is around 7872, the adaptation never engages, and every datagram is too big to read.

Measured on the affected host, asking for the dump with the same 5120 buffer and using `MSG_TRUNC` to see the real datagram size:

```
PAGE_SIZE = 65536

buffer 5120:
    dgram#1  real=7812   copied=5120   <-- TRUNCATED
    dgram#2  real=7812   copied=5120   <-- TRUNCATED
    ...
    13 of 15 datagrams truncated, 578 sockets read

buffer 8192:   0 truncated, 889 sockets
buffer 32768:  0 truncated, 889 sockets
```

Truncation makes `ParseNetlinkMessage` fail, `getAllSockets()` gives up part way through the dump, and nothing reopens the socket, so the kernel keeps `cb_running` set on it and refuses every later dump with EBUSY. EBUSY comes back as an `NLMSG_ERROR`, which is where the message in the log comes from. The first failures look different from the steady state, which is worth knowing if you go looking: the early ones are parse errors, and once the socket is wedged it is EBUSY from then on.

### The fix

One constant, 5120 to 32768. `NLMSG_GOODSIZE` is capped at `SKB_WITH_OVERHEAD(8192)` for any page size, so 8192 would be enough on every kernel that exists; 32768 also cuts the number of reads on a busy host and the kernel's adaptive sizing tops out below it.

### Test

On the affected host, before and after, same code path as the agent:

```
buffer 5120:   13/15 datagrams truncated, 578 sockets
buffer 32768:  0 truncated, 889 sockets
```

`go build ./agent/...`, `go vet ./agent/probe/` and `gofmt` all clean.

### Notes for reviewer

#1260 and #1622 report this same error on arm64. I cannot confirm either reporter's page size, since neither states one, so I am not claiming this closes them; a maintainer is better placed to judge. What I can say is that the trigger is the page size rather than the architecture, which would explain why arm64 in general looks unaffected: plain 4K-page arm64 never crosses the threshold. `getconf PAGESIZE` on the affected node settles it either way.

There is a comment on #1622 suggesting `inetMonitorSocketSize` be adjusted on aarch64, which is the right instinct. It never landed, and it does not need to be conditional on architecture, since 32K is safe everywhere.

Three related things I have deliberately left out to keep this reviewable, happy to send them separately if wanted:

- `NLMSG_ERROR` is collapsed into a bare string and the errno is thrown away. That is the reason this went undiagnosed for two years.
- nothing checks `MSG_TRUNC`, so truncation is silent.
- `getAllSockets()` failing should close and reopen the socket, otherwise one bad read wedges the probe permanently, which is what turns a recoverable condition into a dead pod.
