### PR TITLE
fix(nvbench): check RKE2 kubelet TLS configuration K.4.2.9

### DIFF
--- a/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
@@ -489,7 +489,14 @@ groups:
                 warn "$check"
               fi
           else
-              warn "$check"
+              config_file="/var/lib/rancher/rke2/agent/etc/kubelet.conf.d/00-rke2-defaults.conf"
+              config_file=$(append_prefix "$CONFIG_PREFIX" "$config_file")
+              if grep -qF 'tlsCertFile: /var/lib/rancher/rke2/agent/serving-kubelet.crt' "$config_file" 2>/dev/null &&
+                 grep -qF 'tlsPrivateKeyFile: /var/lib/rancher/rke2/agent/serving-kubelet.key' "$config_file" 2>/dev/null; then
+                  pass "$check"
+              else
+                  warn "$check"
+              fi
           fi
         remediation: |
           By default, RKE2 automatically provides the TLS certificate and private key for the Kubelet.


### PR DESCRIPTION
## Description

Follow-up to #2585.

Fix the false warning produced by the RKE2 CIS check `K.4.2.9` when the Kubelet flags `--tls-cert-file` and `--tls-private-key-file` are not present.

RKE2 v1.32 and newer provide these settings through the generated Kubelet configuration:

`/var/lib/rancher/rke2/agent/etc/kubelet.conf.d/00-rke2-defaults.conf`

The current check only inspects `$CIS_KUBELET_CMD`. This change preserves the existing command-line check and adds a minimal fallback that verifies the RKE2 default configuration contains:

```yaml
tlsCertFile: /var/lib/rancher/rke2/agent/serving-kubelet.crt
tlsPrivateKeyFile: /var/lib/rancher/rke2/agent/serving-kubelet.key
```

This follows the RKE2-specific approach accepted in #2585 and aligns the check more closely with CIS Kubernetes Benchmark control 4.2.9, which requires checking the Kubelet configuration when the equivalent command-line arguments are absent.

References:

* https://docs.rke2.io/install/configuration#kubelet-configuration
* https://docs.rke2.io/security/cis_self_assessment111
* https://github.com/neuvector/neuvector/pull/2585

## Test

To test this pull request, you can run the following commands on an RKE2 v1.32 or newer worker node:

```shell
ps -ef | grep '[k]ubelet'

grep -E '^(tlsCertFile|tlsPrivateKeyFile):' \
  /var/lib/rancher/rke2/agent/etc/kubelet.conf.d/00-rke2-defaults.conf

test -f /var/lib/rancher/rke2/agent/serving-kubelet.crt
test -f /var/lib/rancher/rke2/agent/serving-kubelet.key
```

Verify that:

* the Kubelet command line does not contain `--tls-cert-file` or `--tls-private-key-file`;
* `00-rke2-defaults.conf` contains both expected RKE2 TLS settings;
* the NeuVector RKE2 compliance scan reports `PASS` for `K.4.2.9`;
* the check still reports `WARN` when either expected setting is missing; and
* the existing command-line argument path continues to report `PASS` when both flags are present.

Validate the benchmark YAML:

```shell
yq eval '.' \
  agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml \
  >/dev/null
```

## Additional Information

### Tradeoff

This change checks the RKE2-defined default configuration file instead of implementing generic Kubelet `--config` and `--config-dir` resolution.

This keeps the change small and consistent with #2585, but it validates the standard RKE2 paths rather than arbitrary custom Kubelet TLS configuration.

### Potential improvement

A future enhancement could resolve the effective Kubelet configuration, including:

* custom `--config` files;
* configuration drop-in directories;
* custom RKE2 data directories; and
* later drop-ins that override the RKE2 defaults.

That broader configuration-resolution logic is outside the scope of this fix.

### Special notes for your reviewer

The existing command-line argument logic is unchanged. Only the final `else` branch is extended with an RKE2-specific fallback.

The paths and values used by the check are documented in the official RKE2 configuration and CIS self-assessment documentation.

This change is limited to `K.4.2.9` in the existing `cis-rke2-1.8.0` profile. It does not claim general Kubelet configuration resolution or full support for a newer RKE2 CIS profile.

### Checklist

* [ ] squashed commits into logical changes
* [ ] includes documentation
* [ ] adds unit tests
* [ ] adds or updates e2e tests
