### PR TITLE
crd: allow dry-run admission requests instead of denying them

### DIFF
--- a/controller/rest/crdvalidatewebhook.go
+++ b/controller/rest/crdvalidatewebhook.go
@@ -533,8 +533,15 @@ func (whsvr *WebhookServer) crdserveK8s(w http.ResponseWriter, r *http.Request, 
 			resultMsg = fmt.Sprintf(" %s denied: %s", reqOp, sizeErrMsg)
 		} else {
 			if ar.Request.DryRun != nil && *ar.Request.DryRun {
+				// The webhook is registered with sideEffects=NoneOnDryRun, so a
+				// dry-run request must not be processed. It must not be denied
+				// either: a real request passing the same checks above is always
+				// allowed, with validation happening asynchronously after
+				// admission. Answer what the real request would get and skip the
+				// processing.
 				skip = true
-				resultMsg = fmt.Sprintf(" %s denied in dry-run", reqOp)
+				allowed = true
+				resultMsg = fmt.Sprintf(" %s allowed in dry-run, not processed", reqOp)
 			} else {
 				allowed = true
 				if reqOp != "DELETE" && reqOp != "CREATE" && reqOp != "UPDATE" {

--- a/controller/rest/crdvalidatewebhook_test.go
+++ b/controller/rest/crdvalidatewebhook_test.go
@@ -1,0 +1,99 @@
+package rest
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/neuvector/neuvector/controller/resource"
+)
+
+func serveCrdRequest(t *testing.T, req *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+	t.Helper()
+
+	ar := admissionv1beta1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AdmissionReview",
+			APIVersion: "admission.k8s.io/v1beta1",
+		},
+		Request: req,
+	}
+	body, err := json.Marshal(&ar)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	whsvr := &WebhookServer{}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/", nil)
+	whsvr.crdserveK8s(w, r, body)
+
+	var resp admissionv1beta1.AdmissionReview
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v (body: %q)", err, w.Body.String())
+	}
+	if resp.Response == nil {
+		t.Fatalf("no response in AdmissionReview (body: %q)", w.Body.String())
+	}
+	return resp.Response
+}
+
+func TestCrdValidateDryRunAllowed(t *testing.T) {
+	preTest()
+
+	dryRun := true
+	raw := []byte(`{"apiVersion":"neuvector.com/v1","kind":"NvSecurityRule","metadata":{"name":"nv.test.default","namespace":"default"}}`)
+
+	for _, op := range []admissionv1beta1.Operation{admissionv1beta1.Create, admissionv1beta1.Update, admissionv1beta1.Delete} {
+		req := &admissionv1beta1.AdmissionRequest{
+			UID:       types.UID("dry-run-test"),
+			Kind:      metav1.GroupVersionKind{Group: "neuvector.com", Version: "v1", Kind: resource.NvSecurityRuleKind},
+			Name:      "nv.test.default",
+			Namespace: "default",
+			Operation: op,
+			DryRun:    &dryRun,
+		}
+		if op == admissionv1beta1.Delete {
+			req.OldObject = runtime.RawExtension{Raw: raw}
+		} else {
+			req.Object = runtime.RawExtension{Raw: raw}
+		}
+
+		resp := serveCrdRequest(t, req)
+		if !resp.Allowed {
+			t.Errorf("dry-run %s denied: %+v", op, resp.Result)
+		}
+	}
+
+	postTest()
+}
+
+func TestCrdValidateDryRunKeepsNameCheck(t *testing.T) {
+	preTest()
+
+	// A CREATE with a metadata name outside the allowed set for this kind is
+	// denied synchronously, and dry-run must give the same answer.
+	dryRun := true
+	raw := []byte(`{"apiVersion":"neuvector.com/v1","kind":"NvAdmissionControlSecurityRule","metadata":{"name":"bogus"}}`)
+
+	req := &admissionv1beta1.AdmissionRequest{
+		UID:       types.UID("dry-run-test"),
+		Kind:      metav1.GroupVersionKind{Group: "neuvector.com", Version: "v1", Kind: resource.NvAdmCtrlSecurityRuleKind},
+		Name:      "bogus",
+		Operation: admissionv1beta1.Create,
+		Object:    runtime.RawExtension{Raw: raw},
+		DryRun:    &dryRun,
+	}
+
+	resp := serveCrdRequest(t, req)
+	if resp.Allowed {
+		t.Errorf("dry-run CREATE with disallowed metadata name was allowed")
+	}
+
+	postTest()
+}


### PR DESCRIPTION
### Related Issue

Fix #649

### What happens

Any server-side dry-run against a NeuVector custom resource is denied by the CRD validating webhook:

```
admission webhook "neuvector-validating-crd-webhook.neuvector.svc" denied the request:  UPDATE denied in dry-run
```

`kubectl apply --dry-run=server` and `kubectl diff` fail on every NV CR. So does anything built on server-side dry-run. The way we hit it was ArgoCD's server-side diff: one NvSecurityRule in an application is enough to put the whole app into ComparisonError, and the workaround is to quarantine the NV rules in their own application with server-side diff switched off, which costs you drift detection on exactly the resources a security tool cares about.

Reproduced today on 5.6.0, and #649 reports the same from 2023.

### What is actually going on

The webhook's own registration promises this works. `nvvalidatewebhookcfg.go` registers the CRD webhook with `sideEffects: NoneOnDryRun` on any Kubernetes new enough for admissionregistration/v1, which is the explicit signal to the API server that dry-run requests are safe to send. The handler then denies every one of them:

```go
if ar.Request.DryRun != nil && *ar.Request.DryRun {
    skip = true
    resultMsg = fmt.Sprintf(" %s denied in dry-run", reqOp)
}
```

`skip` is right, that is the NoneOnDryRun contract. But `allowed` is left false, and that is what breaks the callers. The two have contradicted each other since the initial code drop, so I don't think this was ever a decision, just a default that stuck.

Deny is also not a conservative answer here. For every kind except NvGroupDefinition the webhook does not validate synchronously at all: a real request that passes the size and reserved-name checks is allowed at admission, queued, and validated in the background, with the CR deleted after the fact if it turns out bad. The dry-run answer for the same object should be what the real request would get, which is allow.

### The fix

Answer a dry-run with allow and keep skipping the processing. The synchronous checks above it (resource size, reserved metadata names) run before the dry-run branch, so they still deny, in dry-run and for real alike.

### Test

New unit tests in `crdvalidatewebhook_test.go`:

- dry-run CREATE, UPDATE and DELETE of an NvSecurityRule are allowed. All three fail on the current code with "denied in dry-run" and pass with the fix.
- a dry-run CREATE of an NvAdmissionControlSecurityRule with a metadata name outside the allowed set is still denied, so the fix does not blanket-allow dry-run ahead of the synchronous checks.

`go build ./controller/...`, `go vet ./controller/rest/`, `gofmt` and the full `go test ./controller/rest/` suite are clean.

### Notes for reviewer

The one kind the handler does validate synchronously is NvGroupDefinition, and that path writes through `crdSecRuleHandler`, so it cannot run on a dry-run without breaking NoneOnDryRun. A dry-run of an invalid NvGroupDefinition therefore now answers allow where the real request would answer deny. Its cheap checks (namespace, reserved names) could be pulled out and run on dry-run too; I left that out to keep this small, happy to follow up if wanted.

The pre-1.22 registration path declares `sideEffects: Some`, so those API servers reject dry-run themselves without calling the webhook. Nothing changes there.
