### PR TITLE
rest: keep IPv6 client addresses intact in auth audit events

### DIFF
--- a/controller/rest/auth.go
+++ b/controller/rest/auth.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math"
 	mathRand "math/rand"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -2357,6 +2358,16 @@ func isPasswordExpired(localAuthed bool, userName string, pwdResetTime time.Time
 	return pwdDaysUntilExpire, pwdHoursUntilExpire, false
 }
 
+// remoteHost returns the host part of an address that may carry a port, such
+// as "1.2.3.4:5678" or "[::1]:5678" from http.Request.RemoteAddr. A value
+// without a port, bare IPv6 addresses included, is returned unchanged.
+func remoteHost(remote string) string {
+	if host, _, err := net.SplitHostPort(remote); err == nil {
+		return host
+	}
+	return remote
+}
+
 func handlerAuthLogin(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	log.WithFields(log.Fields{"URL": r.URL.String()}).Debug()
 	defer r.Body.Close()
@@ -2455,9 +2466,7 @@ func handlerAuthLogin(w http.ResponseWriter, r *http.Request, ps httprouter.Para
 		if remote == "" {
 			remote = r.RemoteAddr
 		}
-		if i := strings.Index(remote, ":"); i > 0 {
-			remote = remote[:i]
-		}
+		remote = remoteHost(remote)
 
 		var errLocalAuth error
 		var localAuthEnabled bool
@@ -2711,9 +2720,7 @@ func handlerFedAuthLogin(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	if remote == "" {
 		remote = r.RemoteAddr
 	}
-	if i := strings.Index(remote, ":"); i > 0 {
-		remote = remote[:i]
-	}
+	remote = remoteHost(remote)
 
 	userName := auth.JointUsername
 	if auth.JointUsername == common.DefaultAdminUser {
@@ -2780,9 +2787,7 @@ func handlerAuthLoginServer(w http.ResponseWriter, r *http.Request, ps httproute
 	if remote == "" {
 		remote = r.RemoteAddr
 	}
-	if i := strings.Index(remote, ":"); i > 0 {
-		remote = remote[:i]
-	}
+	remote = remoteHost(remote)
 
 	accReadAll := access.NewReaderAccessControl()
 

--- a/controller/rest/auth_test.go
+++ b/controller/rest/auth_test.go
@@ -1084,3 +1084,21 @@ func TestGroupMapping(t *testing.T) {
 
 	postTest()
 }
+
+func TestRemoteHost(t *testing.T) {
+	cases := map[string]string{
+		"1.2.3.4:5678":         "1.2.3.4",
+		"[::1]:5678":           "::1",
+		"[2001:db8::17]:443":   "2001:db8::17",
+		"1.2.3.4":              "1.2.3.4",
+		"::1":                  "::1",
+		"2001:db8::17":         "2001:db8::17",
+		"proxy.example.com:80": "proxy.example.com",
+		"":                     "",
+	}
+	for in, expected := range cases {
+		if out := remoteHost(in); out != expected {
+			t.Errorf("remoteHost(%q) = %q, expected %q", in, out, expected)
+		}
+	}
+}

--- a/controller/rest/ibmsa.go
+++ b/controller/rest/ibmsa.go
@@ -369,10 +369,7 @@ func handlerGetIBMSAEpSetupToken(w http.ResponseWriter, r *http.Request, ps http
 		}
 	}
 	if user != nil {
-		remote := r.RemoteAddr
-		if i := strings.Index(remote, ":"); i > 0 {
-			remote = remote[:i]
-		}
+		remote := remoteHost(r.RemoteAddr)
 		if s, rc := loginUser(user, nil, nil, remote, _interactiveSessionID, "", api.FedRoleNone, nil); rc == userOK {
 			resp := api.RESTIBMSASetupToken{
 				AccessToken: s.token,

--- a/controller/rest/user.go
+++ b/controller/rest/user.go
@@ -1010,10 +1010,7 @@ func handlerUserPwdConfig(w http.ResponseWriter, r *http.Request, ps httprouter.
 		restRespErrorMessage(w, http.StatusInternalServerError, api.RESTErrFailWriteCluster, "Failed to write to the cluster")
 		return
 	} else {
-		remote := r.RemoteAddr
-		if i := strings.Index(remote, ":"); i > 0 {
-			remote = remote[:i]
-		}
+		remote := remoteHost(r.RemoteAddr)
 		if unblockUser {
 			msg := fmt.Sprintf("User %s is unblocked from login by %s", fullname, login.fullname)
 			authLog(share.CLUSEvAuthLoginUnblocked, fullname, remote, "", nil, msg)


### PR DESCRIPTION
### Related Issue

None filed upstream that I could find.

### What happens

Login, login-failure and password-reset audit events record the client address in `user_addr`. When the connection reaches the controller over IPv6, the recorded value is a single `[` character. Reproduced on a stock 5.6.0 just now: connect to the controller REST port over IPv6 loopback from inside the pod's network namespace, fail one login, read the event:

```
curl -6 -k -X POST "https://[::1]:10443/v1/auth" -H "Content-Type: application/json" \
     -d '{"password":{"username":"ipv6-addr-probe2","password":"wrong"}}'
```
```
2026-08-07 12:01:22   User.Login.Failed   user=ipv6-addr-probe2   user_addr=[
```

Where this bites in practice: on some CRI implementations `kubectl port-forward` dials the pod over `::1`, so every port-forwarded console or REST session lands in the audit log as `user_addr=[`. We first noticed while triaging a burst of console auth events during a pentest window, which is precisely the moment you want the audit trail to tell you where logins are coming from, and it could not.

### What is actually going on

Five call sites strip the port from the client address the same way:

```go
if i := strings.Index(remote, ":"); i > 0 {
    remote = remote[:i]
}
```

`http.Request.RemoteAddr` is host:port, so for IPv4 this yields the IP. Any IPv6 form is cut at the first colon instead: `[::1]:54321` becomes `[`, and a bare `2001:db8::17` arriving through the `client_ip` field of the auth request would become `2001`.

The sites are the password login, the federation master-token login and the login-via-auth-server handlers in `auth.go`, the unblock / admin password reset events in `user.go`, and the IBM SA setup-token login in `ibmsa.go`.

### The fix

One `remoteHost()` helper built on `net.SplitHostPort`. If the value parses as host:port, take the host, which comes back with the brackets already removed. Anything else, bare IPv4, bare IPv6, hostname, empty string, is returned unchanged. For IPv4 the results are byte for byte what the old code produced, so nothing changes on existing deployments except that IPv6 addresses stop being destroyed.

With the fix, the event above records `user_addr=::1`.

### Test

`TestRemoteHost` in `auth_test.go` covers the bracketed-with-port, bare IPv4, bare IPv6, hostname and empty forms. The live repro above is the before; the after is the `"[::1]:5678"` to `"::1"` row of that table, since I have no built image to swap onto a cluster.

`go build ./controller/...`, `go vet ./controller/rest/`, `gofmt` and the full `go test ./controller/rest/` suite are clean.

### Notes for reviewer

Two nearby call sites never stripped the port at all and record the full `RemoteAddr`: the apikey login session and the Rancher SSO login. Whether those should record host only is a behaviour question rather than a bug, so I left them alone; happy to follow up if you want them consistent.

I also checked for consumers of the current value before changing it: nothing downstream parses `user_addr`, it is display and export only.
