### PR TITLE
fix(nvbench): check RKE2 anonymous auth in kubelet config K.4.2.1

### DIFF
--- a/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
@@ -273,7 +273,11 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_KUBELET_CMD" '--anonymous-auth=false' >/dev/null 2>&1; then
+          file="/var/lib/rancher/rke2/agent/etc/kubelet.conf.d/00-rke2-defaults.conf"
+          file=$(append_prefix "$CONFIG_PREFIX" "$file")
+
+          if grep -A2 '^authentication:' "$file" 2>/dev/null |
+              grep -qE '^[[:space:]]+enabled:[[:space:]]+false[[:space:]]*$'; then
               pass "$check"
           else
               warn "$check"


### PR DESCRIPTION
## Description

No associated GitHub issue.

Fix the false warning produced by RKE2 CIS check `K.4.2.1` on current RKE2 versions.

The existing check searches the kubelet command line for `--anonymous-auth=false`. Current RKE2 versions configure this value in:

`/var/lib/rancher/rke2/agent/etc/kubelet.conf.d/00-rke2-defaults.conf`

This change follows the RKE2 CIS Self-Assessment procedure and verifies that `authentication.anonymous.enabled` is set to `false` in that file.

Documentation:

* [[RKE2 CIS 1.8 – Control 4.2.1](https://docs.rke2.io/security/cis_self_assessment18#421-ensure-that-the---anonymous-auth-argument-is-set-to-false-automated)](https://docs.rke2.io/security/cis_self_assessment18#421-ensure-that-the---anonymous-auth-argument-is-set-to-false-automated)
* [[Related NeuVector PR #2585](https://github.com/neuvector/neuvector/pull/2585)](https://github.com/neuvector/neuvector/pull/2585)

## Test

On an RKE2 worker node, run:

```shell
ps -ef | grep '[k]ubelet'

grep -A2 '^authentication:' \
  /var/lib/rancher/rke2/agent/etc/kubelet.conf.d/00-rke2-defaults.conf
```

Verify that:

* the kubelet command line uses `--config-dir`;
* the configuration contains `authentication.anonymous.enabled: false`;
* the NeuVector RKE2 compliance scan reports `K.4.2.1` as passed.

## Additional Information

### Tradeoff

The check validates the fixed RKE2 configuration path specified by the RKE2 CIS Self-Assessment Guide. It does not implement generic kubelet configuration or drop-in resolution.

This keeps the change limited to `K.4.2.1` and follows the approach established in #2585.

### Potential improvement

A separate enhancement could resolve the effective kubelet configuration across arbitrary drop-in files if support for custom RKE2 kubelet configurations is required.

### Special notes for your reviewer

This change is limited to `K.4.2.1` in the existing `cis-rke2-1.8.0` profile. It replaces the obsolete command-line check with the audit path documented by RKE2.

### Checklist

* [x] squashed commits into logical changes
* [ ] includes documentation
* [ ] adds unit tests
* [ ] adds or updates e2e tests