### PR TITLE
fix(nvbench): check RKE2 kubelet TLS configuration K.4.2.9

### DIFF
--- a/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
@@ -489,7 +489,14 @@ groups:
                 warn "$check"
               fi
           else
-              warn "$check"
+              config_file="/var/lib/rancher/rke2/agent/etc/kubelet.conf.d/00-rke2-defaults.conf"
+              config_file=$(append_prefix "$CONFIG_PREFIX" "$config_file")
+              if grep -qF 'tlsCertFile: /var/lib/rancher/rke2/agent/serving-kubelet.crt' "$config_file" 2>/dev/null &&
+                 grep -qF 'tlsPrivateKeyFile: /var/lib/rancher/rke2/agent/serving-kubelet.key' "$config_file" 2>/dev/null; then
+                  pass "$check"
+              else
+                warn "$check"
+              fi
           fi
         remediation: |
           By default, RKE2 automatically provides the TLS certificate and private key for the Kubelet.


### PR DESCRIPTION
Restore PR #2690 with the missing TLS kubelet config check for RKE2.