### PR TITLE
Fix RKE2 kubelet client CA check K.4.2.3

### DIFF
--- a/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
@@ -325,9 +325,13 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
+          config=$(append_prefix "$CONFIG_PREFIX" "/var/lib/rancher/rke2/agent/etc/kubelet.conf.d/00-rke2-defaults.conf")
           if check_argument "$CIS_KUBELET_CMD" '--client-ca-file' >/dev/null 2>&1; then
               cafile=$(get_argument_value "$CIS_KUBELET_CMD" '--client-ca-file')
               cafile=$(append_prefix "$CONFIG_PREFIX" "$cafile")
+              pass "$check"
+              pass "      * client-ca-file: $cafile"
+          elif cafile=$(yq e '.authentication.x509.clientCAFile // ""' "$config" 2>/dev/null); [ -n "$cafile" ]; then
               pass "$check"
               pass "      * client-ca-file: $cafile"
           else


### PR DESCRIPTION
## Description

No linked issue.

Fix a false warning in RKE2 CIS check K.4.2.3 when the client CA is configured through RKE2's generated KubeletConfiguration instead of the `--client-ca-file` command-line argument.

The existing command-line check remains unchanged. If the argument is absent, the audit additionally checks whether `authentication.x509.clientCAFile` is set in:

`/var/lib/rancher/rke2/agent/etc/kubelet.conf.d/00-rke2-defaults.conf`

[[Official RKE2 documentation for check 4.2.3](https://docs.rke2.io/security/cis_self_assessment112#423-ensure-that-the---client-ca-file-argument-is-set-as-appropriate-automated)](https://docs.rke2.io/security/cis_self_assessment112#423-ensure-that-the---client-ca-file-argument-is-set-as-appropriate-automated)

## Test

The benchmark YAML and extracted audit block were validated for the following cases:

* `--client-ca-file` is present: PASS
* `authentication.x509.clientCAFile` is present in the RKE2 configuration: PASS
* Neither configuration is present: WARN
* Audit shell syntax validated with `sh -n`
* YAML parsing completed successfully
* `git diff --check` completed successfully

## Additional Information

### Tradeoff

The fallback uses the exact RKE2-generated configuration path documented by RKE2. It does not validate the referenced certificate itself because certificate permissions and ownership are covered by separate CIS checks.

### Potential improvement

None within the scope of this fix. Support for additional Kubelet configuration sources should be handled separately if documented by RKE2.

### Special notes for your reviewer

This is an additive four-line change. The existing CLI-based behavior is preserved for older RKE2 releases, while current releases using the generated KubeletConfiguration are handled by the fallback.

### Checklist

* [x] squashed commits into logical changes