### PR TITLE
fix: pod-service traffic is denied

### DIFF
--- a/dp/dpi/dpi_policy.c
+++ b/dp/dpi/dpi_policy.c
@@ -1061,7 +1061,11 @@ static int dpi_policy_lookup_by_key(dpi_policy_hdl_t *hdl, uint32_t sip, uint32_
         //egress traffic is to host ip
         if (is_internal && !(hdl->apply_dir & DP_POLICY_APPLY_EGRESS) && !ipv4_ent &&
             iptype != DP_IPTYPE_HOSTIP && iptype != DP_IPTYPE_UWLIP && !is_nbe && !check_sgm) {
-            // east-west egress traffic is always allowed
+            // internal (pod-to-pod) east-west egress traffic is always allowed.
+            // Note: pod->ClusterIP (a service-VIP, not a peer workload) also
+            // reaches here whenever check_sgm is false; only under strict group
+            // mode + Protect is it handled by the dedicated service-VIP block
+            // below.
             desc->id = 0;
             desc->action = DP_POLICY_ACTION_OPEN;
             desc->flags = POLICY_DESC_INTERNAL;
@@ -1076,6 +1080,26 @@ static int dpi_policy_lookup_by_key(dpi_policy_hdl_t *hdl, uint32_t sip, uint32_
             }
             if (is_nbe && iptype == DP_IPTYPE_SVCIP) {
                 //no check for cross namespace for svc ip traffic
+                desc->id = 0;
+                desc->action = DP_POLICY_ACTION_OPEN;
+                desc->flags = POLICY_DESC_INTERNAL;
+                goto exit;
+            }
+            // Strict group mode + Protect on ingress-apply platforms (k8s): a
+            // Service ClusterIP is a virtual service IP, not a peer workload.
+            // This is NOT pod-to-pod east-west traffic - the ClusterIP maps to
+            // nv.ip.<svc>, has no workload identity, and can never match a
+            // destination rule here. kube-proxy DNATs it to a backend pod, and
+            // the real endpoint-to-endpoint hop is enforced post-DNAT at the
+            // backend's ingress. Without this, check_sgm forces the egress
+            // lookup, which finds no rule and drops the packet. So bypass the
+            // lookup (mirror of the !check_sgm fast-path above) instead of
+            // dropping a VIP connection that can never match; ingress
+            // enforcement still applies.
+            //
+            // This will ignore nv.ip explicit deny rules on service ClusterIP by design.
+            if (check_sgm && iptype == DP_IPTYPE_SVCIP &&
+                !(hdl->apply_dir & DP_POLICY_APPLY_EGRESS)) {
                 desc->id = 0;
                 desc->action = DP_POLICY_ACTION_OPEN;
                 desc->flags = POLICY_DESC_INTERNAL;


### PR DESCRIPTION

## Description

When group contention mode is set as `restrict`, the pod-service traffic is blocked unintentionally until a special group is added.  This commit fixes the issue.

Fix #2704

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

### Special notes for your reviewer

<!-- Please describe, if any special design or notes you want to share with your reviewer in this pull request -->

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
