### PR TITLE
pathWalker: an empty Dirs filter should not skip the whole tree

### DIFF
--- a/agent/workerlet/pathWalker/pathWalker.go
+++ b/agent/workerlet/pathWalker/pathWalker.go
@@ -226,7 +226,9 @@ func (tm *taskMain) WalkPathTask(req workerlet.WalkPathRequest) {
 					return filepath.SkipDir
 				}
 
-				bSkip := true
+				// An empty Dirs means "no directory filter": walk the whole tree.
+				// Only callers that opt into a scope get their traversal limited.
+				bSkip := len(req.Dirs) > 0
 				ldir := path[rootPathLen:]
 				for _, rdir := range req.Dirs {
 					if strings.HasPrefix(ldir, rdir) {

--- a/agent/workerlet/pathWalker/pathWalker_dirs_test.go
+++ b/agent/workerlet/pathWalker/pathWalker_dirs_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/neuvector/neuvector/agent/workerlet"
+	"github.com/neuvector/neuvector/share/system"
+)
+
+// walkTree runs WalkPathTask over dir and returns the relative paths it reported.
+//
+// WalkPathTask always resolves its root as /proc/<Pid>/root + Path, so the test
+// passes its own pid: /proc/self/root is the caller's root filesystem, which
+// makes an ordinary temp directory reachable without root privileges or a
+// running container.
+func walkTree(t *testing.T, dir string, dirs []string) []string {
+	t.Helper()
+
+	done := make(chan error, 1)
+	tm := InitTaskMain(t.TempDir(), done, system.NewSystemTools())
+
+	go tm.WalkPathTask(workerlet.WalkPathRequest{
+		Pid:      os.Getpid(),
+		Path:     dir,
+		ExecOnly: false,
+		Dirs:     dirs,
+	})
+
+	if err := <-done; err != nil {
+		t.Fatalf("WalkPathTask: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tm.workPath, workerlet.ResultJson))
+	if err != nil {
+		t.Fatalf("read result: %v", err)
+	}
+
+	var res workerlet.WalkPathResult
+	if err := json.Unmarshal(data, &res); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	found := make([]string, 0, len(res.Files))
+	for _, f := range res.Files {
+		found = append(found, f.File)
+	}
+	return found
+}
+
+func contains(list []string, want string) bool {
+	for _, got := range list {
+		if got == want {
+			return true
+		}
+	}
+	return false
+}
+
+// A request that sets no Dirs asks for no directory filter, so the whole tree
+// below the root must be reported. Before the fix every sub-directory was
+// skipped and only files sitting directly in the root were returned.
+func TestWalkPathEmptyDirsWalksWholeTree(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "usr", "bin"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "top"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "usr", "bin", "nested"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	found := walkTree(t, root, nil)
+
+	if !contains(found, "/top") {
+		t.Errorf("file in the root was not reported, got %v", found)
+	}
+	if !contains(found, "/usr/bin/nested") {
+		t.Errorf("nested file was not reported, got %v", found)
+	}
+}
+
+// A request that does set Dirs keeps its scope: directories outside the listed
+// prefixes stay pruned.
+func TestWalkPathDirsLimitsScope(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "keep"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "prune"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "keep", "wanted"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "prune", "unwanted"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	found := walkTree(t, root, []string{"/keep"})
+
+	if !contains(found, "/keep/wanted") {
+		t.Errorf("file under the requested directory was not reported, got %v", found)
+	}
+	if contains(found, "/prune/unwanted") {
+		t.Errorf("file outside the requested directories was reported, got %v", found)
+	}
+}


### PR DESCRIPTION
### The bug

`WalkPathTask` prunes any directory that does not prefix-match an entry in `req.Dirs`:

```go
bSkip := true
ldir := path[rootPathLen:]
for _, rdir := range req.Dirs {
    if strings.HasPrefix(ldir, rdir) { bSkip = false; break }
}
if bSkip { return filepath.SkipDir }
```

The loop starts from `bSkip = true`, so when a caller sends **no** `Dirs` nothing can ever clear the flag and **every** directory below the root is skipped. `filepath.Walk` still visits the root itself, so the request returns only the files sitting directly in it — and returns *success*, so the caller cannot tell.

### Which callers this affects

The filter arrived with NVSHAS-9756 (4bcaf6b), which added `Dirs` and updated `share/fsmon/monitor.go` to pass it. The other callers of the same shared walker were not updated, and none of them sets `Dirs`:

| call site | intent |
|---|---|
| `agent/probe/faccess_linux.go:129` | `enumExecutables`, walks `/` to build the fanotify mark set for process protection |
| `agent/probe/fsn.go:131` | `enumFiles` — its own comment reads *"Add all sub-directories from the top layers"* |
| `agent/probe/fsn.go:694` | container layer enumeration |

All three ask for a full walk and have been receiving only the root directory's own files since that change.

### Why I went looking: process protection is fail-open

`enumExecutables` builds `root.whlst` from the returned executables, defaulted to `rule_not_defined`, so that `whiteListCheck` denies anything not explicitly allowed. With the walk returning nothing, `whlst` ends up holding **only** the allow entries merged in afterwards, and any path missing from it falls through to `whiteListCheck`'s initialiser `res := rule_allowed`.

So at the fanotify layer, process protection permits every unlisted binary instead of denying it. Observed on a container with 787 executables:

```
FA: done      - dirs=0 execs=0 path=/proc/<pid>/root
FA: add marks - exec_cnt=11 marks=5 total_marks=6
```

The `exec_cnt=11` is entirely the profile's own allow rules. In the same window there were zero `FA: denied` events, while unlisted binaries were still being killed after the fact by the process-monitor path — which is asynchronous, so short-lived processes finish first. Measured over 20 trials each: `uname` survived 35% of attempts, `sleep 0.2` and `sleep 3` 0%.

### The change

Start `bSkip` from `len(req.Dirs) > 0`, so an absent filter means *no restriction* rather than *exclude everything*. Callers that do pass `Dirs` keep the scoping NVSHAS-9756 introduced, and the existing mount-point pruning is untouched.

### Tests

Both halves are covered. They resolve the walk root through `/proc/<self>/root`, so a temp directory can stand in for a container root without privileges or a running container.

- `TestWalkPathEmptyDirsWalksWholeTree` — **fails before this change**, reporting only the root-level file (`got [/top]`)
- `TestWalkPathDirsLimitsScope` — passes before and after, pinning the scoping behaviour

`gofmt`, `go vet ./agent/workerlet/...` and `go build ./agent/...` all clean.

### One trade-off worth flagging

`getRootFs` derives `dirs` from the profile's filters, so a profile with no filters at all now produces a full walk where it previously produced none. That result is only consumed inside the per-filter loops in `getCoreFile`, so with zero filters it is discarded either way — bounded wasted work in a degenerate configuration, capped by `rootIterTimeout` and `walkerLimiter`, and not a behavioural change.

If you would rather not take even that, the alternative is to leave the walker alone and set `Dirs` explicitly at the three call sites above. I went with the shared fix because an optional filter reading as "exclude everything when unset" seems like the more surprising of the two, but I am happy to switch it round.