### PR TITLE
revert dependencies download path

### DIFF
--- a/package/Dockerfile.enforcer
+++ b/package/Dockerfile.enforcer
@@ -48,8 +48,8 @@ RUN zypper refresh && zypper --installroot /chroot -n in --no-recommends \
     libnetfilter_queue-devel liburcu-devel libpcap-devel pcre2-devel libjansson-devel libmnl-devel jemalloc-devel
  
 # Install yq from isv:Rancher:dependencies
-RUN zypper addrepo -n rancher-deps https://download.opensuse.org/repositories/isv:Rancher:dependencies/packages/isv:Rancher:dependencies.repo && \
-    rpm --import https://download.opensuse.org/repositories/isv:/Rancher:/dependencies/packages/repodata/repomd.xml.key && \
+RUN zypper addrepo -n rancher-deps https://download.opensuse.org/repositories/isv:Rancher:dependencies/pkgs/isv:Rancher:dependencies.repo && \
+    rpm --import https://download.opensuse.org/repositories/isv:/Rancher:/dependencies/pkgs/repodata/repomd.xml.key && \
     zypper -n --gpg-auto-import-keys refresh && \
     zypper --installroot /chroot install -y --from rancher-deps yq
 


### PR DESCRIPTION
## Description

Revert `https://download.opensuse.org/repositories/isv:Rancher:dependencies/packages/` to `https://download.opensuse.org/repositories/isv:Rancher:dependencies/pkgs/` because the former is for OBS' testing.
Now OBS has changed back to `https://download.opensuse.org/repositories/isv:Rancher:dependencies/pkgs/`

## Test

## Additional Information

### Tradeoff

### Potential improvement

### Special notes for your reviewer

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

