### PR TITLE
issue-2727: NV doesn't prevent user from importing federated groups/policies thru CRD

### DIFF
--- a/controller/rest/crdsecurityrule.go
+++ b/controller/rest/crdsecurityrule.go
@@ -4953,13 +4953,14 @@ func CrossCheckCrd(kind, rscType, kvCrdKind, lockKey string, kvOnly bool) error 
 			mdNameDisplay = metaData.GetName()
 			recordName = fmt.Sprintf("%s-default-%s", kind, mdNameDisplay)
 		}
+		if isForNvFedCR(kind, metaData.GetName()) {
+			log.WithFields(log.Fields{"kind": kind, "name": mdNameDisplay}).Warn("it is not supported to import federated policies through CRD")
+			continue
+		}
+
 		var getCrErr error
 		if crdHash, skip, getCrErr = crdHandler.getCrInfo(obj); getCrErr != nil {
 			log.WithError(getCrErr).Warn("Failed to get CRD info")
-		}
-		if isForNvFedCR(kind, metaData.GetName()) {
-			log.WithFields(log.Fields{"kind": kind, "name": mdNameDisplay}).Warn("it is not supported to import federated policies through CRD")
-			skip = true
 		}
 		if skip {
 			continue


### PR DESCRIPTION
## Description

Fix https://github.com/neuvector/neuvector/issues/2727

## Test

1. Create and export federated policy from NV UI
2. Delete those exported federated policy from NV UI
3. Use `kubectl create -f abc.yaml` to create the CRs in k8s
4. Observe that those created CRs are ignored by NV (i.e. no new federated policy created)
5. Delete the NV (keep the CRs in k8s)
6. Create configmap `neuvector-init` for `fedinitcfg.yaml` that promote NV cluster to primary cluster
7. Deploy a new NV. With the configmap `neuvector-init` in step 6 created, the new NV cluster is automatically promoted to primary cluster
8. Observe that those pre-existing CRs are ignored by NV (i.e. no federated policy created)
9. Use `kubectl delete -f abc.yaml` to delete the CRs in k8s. NV allows the CR to be deleted.

## Additional Information

### Tradeoff

### Potential improvement

### Special notes for your reviewer

### Checklist


- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


