### PR TITLE
Agent/fix rke2 iptables util chains check K.4.2.6

### DIFF
--- a/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
@@ -402,10 +402,10 @@ groups:
         tags: {}
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_KUBELET_CMD" '--make-iptables-util-chains=true' >/dev/null 2>&1; then
-              pass "$check"
-          else
+          if check_argument "$CIS_KUBELET_CMD" '--make-iptables-util-chains=false' >/dev/null 2>&1; then
               warn "$check"
+          else
+              pass "$check"
           fi
         remediation: |
           Edit the RKE2 config file /etc/rancher/rke2/config.yaml, set the following parameter.

--- a/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
@@ -404,8 +404,16 @@ groups:
           check="$id  - $description"
           if check_argument "$CIS_KUBELET_CMD" '--make-iptables-util-chains=false' >/dev/null 2>&1; then
               warn "$check"
-          else
+          elif check_argument "$CIS_KUBELET_CMD" '--make-iptables-util-chains' >/dev/null 2>&1; then
               pass "$check"
+          else
+              config_file="/var/lib/rancher/rke2/agent/etc/kubelet.conf.d/00-rke2-defaults.conf"
+              config_file=$(append_prefix "$CONFIG_PREFIX" "$config_file")
+              if [ "$(yq e '.makeIPTablesUtilChains' "$config_file" 2>/dev/null)" = "false" ]; then
+                  warn "$check"
+              else
+                  pass "$check"
+              fi
           fi
         remediation: |
           Edit the RKE2 config file /etc/rancher/rke2/config.yaml, set the following parameter.


### PR DESCRIPTION
## Description

Fix the false warning produced by the RKE2 CIS check `K.4.2.6` when
`--make-iptables-util-chains` is not explicitly set.

The current audit only passes when the Kubelet command line contains:

```text
--make-iptables-util-chains=true
````

However, RKE2 allows the argument to be omitted and uses the Kubelet default value
of `true`. The existing remediation already documents this as a valid configuration.

This change is split into two logical commits:

1. Fix the command-line audit logic so that only an explicit
   `--make-iptables-util-chains=false` produces a warning.
2. Add an RKE2-specific fallback which checks
   `makeIPTablesUtilChains` in the RKE2-generated Kubelet configuration file:

   ```text
   /var/lib/rancher/rke2/agent/etc/kubelet.conf.d/00-rke2-defaults.conf
   ```

The check now reports:

* `PASS` when `--make-iptables-util-chains=true` is explicitly set;
* `WARN` when `--make-iptables-util-chains=false` is explicitly set;
* when the command-line argument is absent, `WARN` only if
  `makeIPTablesUtilChains: false` is configured;
* otherwise `PASS`, allowing the Kubelet default value of `true`.

Documentation:

* [[RKE2 Kubelet configuration](https://docs.rke2.io/install/configuration#kubelet-configuration)](https://docs.rke2.io/install/configuration#kubelet-configuration)
* [[RKE2 CIS Self-Assessment](https://docs.rke2.io/security/cis_self_assessment112)](https://docs.rke2.io/security/cis_self_assessment112)
* [[Kubernetes Kubelet reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/)](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/)

## Test

To test this pull request, run the following commands on an RKE2 worker node:

```shell
ps -ef | grep '[k]ubelet' | grep make-iptables-util-chains

grep -n 'makeIPTablesUtilChains' \
  /var/lib/rancher/rke2/agent/etc/kubelet.conf.d/00-rke2-defaults.conf
```

Verify the effective Kubelet configuration:

```shell
kubectl get --raw "/api/v1/nodes/<node-name>/proxy/configz" \
  | jq '.kubeletconfig.makeIPTablesUtilChains'
```

For the default RKE2 configuration, the expected result is:

```text
true
```

Run the NeuVector RKE2 compliance scan and verify that `K.4.2.6`:

* passes when the command-line argument is absent and the configuration does not
  set `makeIPTablesUtilChains` to `false`;
* passes when `--make-iptables-util-chains=true` is explicitly set;
* warns when `--make-iptables-util-chains=false` is explicitly set;
* warns when the RKE2 Kubelet configuration explicitly sets
  `makeIPTablesUtilChains: false`.

Validate the benchmark YAML:

```shell
yq eval '.' \
  agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml \
  >/dev/null
```

## Additional Information

### Tradeoff

This change intentionally uses the RKE2-defined Kubelet configuration path instead
of implementing generic Kubelet `--config` and `--config-dir` resolution.

This keeps the audit small and consistent with the existing RKE2-specific benchmark
checks and with the approach used in previously accepted NeuVector fixes.

The tradeoff is that custom Kubelet configuration paths are not resolved by this
check.

### Potential improvement

A future enhancement could provide reusable resolution of the effective Kubelet
configuration, including custom configuration files and configuration drop-ins.

That broader configuration-resolution logic is outside the scope of this fix.

### Special notes for your reviewer

The change is deliberately split into two logical commits:

1. correct the existing command-line audit logic;
2. add the RKE2-specific Kubelet configuration fallback.

The configuration fallback is intentionally limited to:

```text
/var/lib/rancher/rke2/agent/etc/kubelet.conf.d/00-rke2-defaults.conf
```

This is the path documented by RKE2 and avoids introducing generic configuration
resolution logic into this benchmark check.

### Checklist

* [x] squashed commits into logical changes
* [ ] includes documentation
* [ ] adds unit tests
* [ ] adds or updates e2e tests

```