### PR TITLE
nvbench: resolve RKE2 worker paths from process arguments

### DIFF
--- a/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
@@ -56,10 +56,9 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          file="/var/lib/rancher/rke2/agent/kubeproxy.kubeconfig"
-          file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -e "$file" ]; then
-            permissions=$(stat -c %a $file)
+          file=$(resolve_argument_path "$CIS_PROXY_CMD" '--kubeconfig')
+          if [ -n "$file" ] && [ -e "$file" ]; then
+            permissions=$(stat -c %a "$file")
             if [ "$permissions" -le 600 ]; then
               pass "$check"
             else
@@ -86,8 +85,9 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -e "$file" ]; then
-            ownership=$(stat -c %u%g $file)
+          file=$(resolve_argument_path "$CIS_PROXY_CMD" '--kubeconfig')
+          if [ -n "$file" ] && [ -e "$file" ]; then
+            ownership=$(stat -c %u%g "$file")
             if [ "$ownership" = "00" ]; then
               pass "$check"
             else
@@ -114,11 +114,10 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          file="/var/lib/rancher/rke2/agent/kubelet.kubeconfig"
-          file=$(append_prefix "$CONFIG_PREFIX" "$file")
+          file=$(resolve_argument_path "$CIS_KUBELET_CMD" '--kubeconfig')
 
-          if [ -e "$file" ]; then
-            permissions=$(stat -c %a $file)
+          if [ -n "$file" ] && [ -e "$file" ]; then
+            permissions=$(stat -c %a "$file")
             if [ "$permissions" -le 600 ]; then
               pass "$check"
             else
@@ -145,8 +144,9 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          if [ -e "$file" ]; then
-            ownership=$(stat -c %u%g $file)
+          file=$(resolve_argument_path "$CIS_KUBELET_CMD" '--kubeconfig')
+          if [ -n "$file" ] && [ -e "$file" ]; then
+            ownership=$(stat -c %u%g "$file")
             if [ "$ownership" = "00" ]; then
               pass "$check"
             else
@@ -173,10 +173,9 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          file="/var/lib/rancher/rke2/agent/client-ca.crt"
-          file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -e "$file" ]; then
-            permissions=$(stat -c %a $file)
+          file=$(resolve_argument_path "$CIS_KUBELET_CMD" '--client-ca-file')
+          if [ -n "$file" ] && [ -e "$file" ]; then
+            permissions=$(stat -c %a "$file")
             if [ "$permissions" -le 600 ]; then
               pass "$check"
               pass "      * client-ca-file: $file"
@@ -204,10 +203,9 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          file="/var/lib/rancher/rke2/agent/client-ca.crt"
-          file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          if [ -e "$file" ]; then
-            ownership=$(stat -c %u%g $file)
+          file=$(resolve_argument_path "$CIS_KUBELET_CMD" '--client-ca-file')
+          if [ -n "$file" ] && [ -e "$file" ]; then
+            ownership=$(stat -c %u%g "$file")
             if [ "$ownership" = "00" ]; then
               pass "$check"
               pass "      * client-ca-file: $file"
@@ -536,14 +534,18 @@ groups:
           GDPR: []
         audit: |
           check="$id  - $description"
-          file="/var/lib/rancher/rke2/agent/kubelet.kubeconfig"
-          file=$(append_prefix "$CONFIG_PREFIX" "$file")
-          found=$(sed -rn '/--feature-gates=RotateKubeletServerCertificate=false/p' $file)
-          if [ "$found" ]; then
-              warn "$check"
-              warn "      * RotateKubeletServerCertificate should be: true, but is: false"
+          file=$(resolve_argument_path "$CIS_KUBELET_CMD" '--kubeconfig')
+          if [ -n "$file" ] && [ -e "$file" ]; then
+              found=$(sed -rn '/--feature-gates=RotateKubeletServerCertificate=false/p' "$file")
+              if [ "$found" ]; then
+                  warn "$check"
+                  warn "      * RotateKubeletServerCertificate should be: true, but is: false"
+              else
+                  pass "$check"
+              fi
           else
-              pass "$check"
+              warn "$check"
+              warn "      * kubeconfig file not found, $file"
           fi
         remediation: |
           By default, RKE2 does not set the RotateKubeletServerCertificate feature gate.

--- a/agent/nvbench/utils/utils.sh
+++ b/agent/nvbench/utils/utils.sh
@@ -54,6 +54,24 @@ append_prefix() {
   echo "$prefix/$file"
 }
 
+#resolve a path from a process command line argument
+resolve_argument_path() {
+  local cmd="$1"
+  local option="$2"
+  local path
+
+  if ! check_argument "$cmd" "$option" >/dev/null 2>&1; then
+    return 1
+  fi
+
+  path=$(get_argument_value "$cmd" "$option" | sed -n '1p')
+  if [ -z "$path" ]; then
+    return 1
+  fi
+
+  append_prefix "${CONFIG_PREFIX:-}" "$path"
+}
+
 #get an argument value from command line
 get_argument_value_from_journal() {
     CMD="$1"


### PR DESCRIPTION
## Description

No associated GitHub issue.

The RKE2 CIS 1.8 worker checks currently use fixed paths for the kube-proxy kubeconfig, kubelet kubeconfig, and kubelet client CA files. This can produce incorrect results when RKE2 uses a non-default data directory or passes a different path to the component at runtime.

This change adds a reusable `resolve_argument_path` helper following the existing `check_argument` and `get_argument_value` pattern. The helper:

1. verifies that the requested command-line argument exists;
2. extracts the configured path;
3. applies `CONFIG_PREFIX` so the file is accessed through the host filesystem; and
4. returns an error when the argument is missing or has no value.

The following checks now resolve their paths from the corresponding process arguments instead of using paths embedded in the benchmark YAML:

* `K.4.1.3` and `K.4.1.4`: kube-proxy `--kubeconfig`
* `K.4.1.5` and `K.4.1.6`: kubelet `--kubeconfig`
* `K.4.1.7` and `K.4.1.8`: kubelet `--client-ca-file`
* `K.4.2.11`: kubelet `--kubeconfig`

The ownership checks now resolve their own paths instead of depending on the `$file` variable set by a previous check.

`K.4.2.11` also reports a warning when the kubeconfig argument cannot be resolved or the referenced file does not exist. Previously, a missing file could cause the check to pass because the `sed` result was empty.

The remediation examples remain unchanged because they document the standard RKE2 locations.

## Test

Validate the shell syntax:

```shell
bash -n agent/nvbench/utils/utils.sh
sh -n agent/nvbench/utils/utils.sh
```

Validate the benchmark YAML:

```shell
yq eval '.' \
  agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml \
  >/dev/null
```

Validate the final diff:

```shell
git diff --check
```

The embedded audit scripts were also extracted from the YAML and checked with `sh -n`.

The resolver was tested with custom paths for:

* kube-proxy `--kubeconfig`
* kubelet `--kubeconfig`
* kubelet `--client-ca-file`

The affected audit checks were tested to confirm that they use the resolved paths after applying `CONFIG_PREFIX`.

The missing-argument case was tested to confirm that the checks do not silently fall back to the previous static paths.

On an RKE2 worker node, the effective arguments can be inspected with:

```shell
ps -ef | grep '[k]ubelet'
ps -ef | grep '[k]ube-proxy'
```

Run the NeuVector RKE2 compliance scan and verify that:

* `K.4.1.3` and `K.4.1.4` inspect the kube-proxy kubeconfig supplied through `--kubeconfig`;
* `K.4.1.5`, `K.4.1.6`, and `K.4.2.11` inspect the kubelet kubeconfig supplied through `--kubeconfig`;
* `K.4.1.7` and `K.4.1.8` inspect the client CA supplied through `--client-ca-file`;
* custom absolute paths are prefixed with `CONFIG_PREFIX`; and
* a missing argument or missing referenced file results in a warning.

## Additional Information

### Tradeoff

The resolver only handles file locations exposed through process command-line arguments. It does not currently parse RKE2 configuration files, KubeletConfiguration files, or configuration drop-in directories.

When a setting is provided only through a configuration file and the equivalent command-line argument is absent, the affected check reports a warning rather than using the previous fixed path.

This behavior avoids silently auditing an unrelated default file, but it means configuration-file-only values require additional resolution logic.

### Potential improvement

A future change could resolve values from the effective kubelet configuration by supporting:

* kubelet `--config`;
* kubelet `--config-dir`;
* RKE2 configuration drop-ins;
* later configuration files that override earlier values; and
* custom RKE2 data directories when the effective path is not present in a process argument.

Repository-level shell tests could also be added for the shared benchmark utility functions.

### Special notes for your reviewer

This change is limited to the `cis-rke2-1.8.0` worker profile and the shared nvbench shell utilities.

The new resolver intentionally reuses the existing command-line parsing functions so argument matching remains consistent with the other benchmark checks.

Each affected check resolves its required path independently. This removes ordering dependencies between adjacent YAML checks and makes individual checks safe to execute in isolation.

### Checklist

* [x] squashed commits into logical changes
* [ ] includes documentation
* [ ] adds unit tests
* [ ] adds or updates e2e tests
