### PR TITLE
issue-2686: Duplicate response rules are created when importing(thru CRD) same-name response rules with changes

### DIFF
--- a/controller/rest/crdsecurityrule.go
+++ b/controller/rest/crdsecurityrule.go
@@ -1784,6 +1784,34 @@ func (h *nvCrdHandler) crdHandleGroupResponseRules(scope string, grpResponseCfg 
 	return newIDs, err
 }
 
+func (h *nvCrdHandler) deleteExistingResponseRules(policyName string, ids []uint32) {
+	dels := utils.NewSet()
+	for _, id := range ids {
+		dels.Add(id)
+	}
+
+	txn := cluster.Transact()
+	defer txn.Close()
+
+	crhs := clusHelper.GetResponseRuleList(policyName)
+	crhsNew := make([]*share.CLUSRuleHead, 0, len(crhs))
+	for _, crh := range crhs {
+		if !dels.Contains(crh.ID) {
+			crhsNew = append(crhsNew, crh)
+		}
+	}
+
+	if len(crhsNew) != len(crhs) {
+		if err := clusHelper.PutResponseRuleListTxn(policyName, txn, crhsNew); err != nil {
+			log.WithFields(log.Fields{"error": err}).Error()
+		}
+		deleteResponseRules(policyName, txn, dels)
+		if _, err := txn.Apply(); err != nil {
+			log.WithFields(log.Fields{"err": err, "dels": dels}).Error()
+		}
+	}
+}
+
 // caller must own CLUSLockPolicyKey lock
 // This function is for handling the response rules that are for all groups only.
 // Every such response rule is a CR
@@ -1791,8 +1819,14 @@ func (h *nvCrdHandler) crdHandleResponseRule(cfgType share.TCfgType, crdResponse
 	cacheRecord *share.CLUSCrdSecurityRule, reviewType share.TReviewType) error {
 	var err error
 	scope := share.ScopeLocal
+	policyName := share.DefaultPolicyName
 	if cfgType == share.FederalCfg {
 		scope = share.ScopeFed
+		policyName = share.ScopeFed
+	}
+
+	if reviewType == share.ReviewTypeCRD {
+		h.deleteExistingResponseRules(policyName, cacheRecord.ResponseRules.IDs)
 	}
 
 	responseCfgs := []*v1.NvCrdResponseRule{crdResponseCfg}
@@ -4957,7 +4991,6 @@ func CrossCheckCrd(kind, rscType, kvCrdKind, lockKey string, kvOnly bool) error 
 			log.WithFields(log.Fields{"kind": kind, "name": mdNameDisplay}).Warn("it is not supported to import federated policies through CRD")
 			continue
 		}
-
 		var getCrErr error
 		if crdHash, skip, getCrErr = crdHandler.getCrInfo(obj); getCrErr != nil {
 			log.WithError(getCrErr).Warn("Failed to get CRD info")

--- a/controller/rest/crdsecurityrule.go
+++ b/controller/rest/crdsecurityrule.go
@@ -1784,34 +1784,6 @@ func (h *nvCrdHandler) crdHandleGroupResponseRules(scope string, grpResponseCfg 
 	return newIDs, err
 }
 
-func (h *nvCrdHandler) deleteExistingResponseRules(policyName string, ids []uint32) {
-	dels := utils.NewSet()
-	for _, id := range ids {
-		dels.Add(id)
-	}
-
-	txn := cluster.Transact()
-	defer txn.Close()
-
-	crhs := clusHelper.GetResponseRuleList(policyName)
-	crhsNew := make([]*share.CLUSRuleHead, 0, len(crhs))
-	for _, crh := range crhs {
-		if !dels.Contains(crh.ID) {
-			crhsNew = append(crhsNew, crh)
-		}
-	}
-
-	if len(crhsNew) != len(crhs) {
-		if err := clusHelper.PutResponseRuleListTxn(policyName, txn, crhsNew); err != nil {
-			log.WithFields(log.Fields{"error": err}).Error()
-		}
-		deleteResponseRules(policyName, txn, dels)
-		if _, err := txn.Apply(); err != nil {
-			log.WithFields(log.Fields{"err": err, "dels": dels}).Error()
-		}
-	}
-}
-
 // caller must own CLUSLockPolicyKey lock
 // This function is for handling the response rules that are for all groups only.
 // Every such response rule is a CR
@@ -1819,14 +1791,12 @@ func (h *nvCrdHandler) crdHandleResponseRule(cfgType share.TCfgType, crdResponse
 	cacheRecord *share.CLUSCrdSecurityRule, reviewType share.TReviewType) error {
 	var err error
 	scope := share.ScopeLocal
-	policyName := share.DefaultPolicyName
 	if cfgType == share.FederalCfg {
 		scope = share.ScopeFed
-		policyName = share.ScopeFed
 	}
 
 	if reviewType == share.ReviewTypeCRD {
-		h.deleteExistingResponseRules(policyName, cacheRecord.ResponseRules.IDs)
+		h.crdDeleteResponseRules(cacheRecord.ResponseRules)
 	}
 
 	responseCfgs := []*v1.NvCrdResponseRule{crdResponseCfg}
@@ -3790,6 +3760,7 @@ func (h *nvCrdHandler) crdGFwRuleProcessRecord(crdCfgRet *resource.NvSecurityPar
 		grpResponseCfg := map[string][]*v1.NvCrdResponseRule{
 			crdCfgRet.TargetName: crdCfgRet.GroupResponseCfg,
 		}
+		h.crdDeleteResponseRules(crdRecord.ResponseRules)
 		ruleIDs, err := h.crdHandleGroupResponseRules(share.ScopeLocal, grpResponseCfg, crdCfgRet.CfgType)
 		if err != nil {
 			log.WithFields(log.Fields{"error": err}).Error("crdHandleGroupResponseRules")

--- a/controller/rest/response.go
+++ b/controller/rest/response.go
@@ -319,10 +319,14 @@ func validateResponseRule(r *api.RESTResponseRule, grpMustExist bool, acc *acces
 			cdTypeValue := fmt.Sprintf("%s:%s", cd.CondType, cd.CondValue)
 			valid := false
 			switch cd.CondType {
-			case "name":
+			case share.EventCondTypeName:
 				valid = allowedNameValues.Contains(cdTypeValue)
-			case "level":
+			case share.EventCondTypeLevel:
 				valid = allowedLevelValues.Contains(cdTypeValue)
+			case share.EventCondTypeProc:
+				if r.Event == share.EventRuntime {
+					valid = true
+				}
 			default:
 				if r.Event == share.EventCVEReport {
 					valid = true

--- a/controller/rest/response.go
+++ b/controller/rest/response.go
@@ -307,18 +307,32 @@ func validateResponseRule(r *api.RESTResponseRule, grpMustExist bool, acc *acces
 	if option, ok := options[r.Event]; !ok {
 		return fmt.Errorf("Unsupported event for response rule")
 	} else if len(r.Conditions) > 0 {
+		allowedCondTypes := utils.NewSetFromStringSlice(option.Types)   // ex: {name, level}
+		allowedNameValues := utils.NewSetFromStringSlice(option.Name)   // ex: {name:Admission.Control.Allowed, name:Admission.Control.Violation, name:Admission.Control.Denied}
+		allowedLevelValues := utils.NewSetFromStringSlice(option.Level) // ex: {level:Info, level:Critical, level:Warning}
 		cds := utils.NewSet()
 		for i, cd := range r.Conditions {
-			var found = false
-			for _, a := range option.Types {
-				if a == cd.CondType {
-					found = true
-					break
+			// ex: cd={CondType:name CondValue:Admission.Control.Denied}
+			if !allowedCondTypes.Contains(cd.CondType) {
+				return fmt.Errorf("Unsupported condition type for event %s", r.Event)
+			}
+			cdTypeValue := fmt.Sprintf("%s:%s", cd.CondType, cd.CondValue)
+			valid := false
+			switch cd.CondType {
+			case "name":
+				valid = allowedNameValues.Contains(cdTypeValue)
+			case "level":
+				valid = allowedLevelValues.Contains(cdTypeValue)
+			default:
+				if r.Event == share.EventCVEReport {
+					valid = true
 				}
 			}
-			if !found {
-				return fmt.Errorf("Unsupported condition type for event %s", r.Event)
-			} else if r.Event == share.EventCVEReport {
+			if !valid {
+				return fmt.Errorf("Unsupported condition type/value %s for event %s", cdTypeValue, r.Event)
+			}
+
+			if r.Event == share.EventCVEReport {
 				// value validation
 				switch cd.CondType {
 				case share.EventCondTypeCVECritical, share.EventCondTypeCVEHighOnly, share.EventCondTypeCVEHigh, share.EventCondTypeCVEMedium:
@@ -341,9 +355,7 @@ func validateResponseRule(r *api.RESTResponseRule, grpMustExist bool, acc *acces
 				case share.EventCondTypeCVEName:
 					r.Conditions[i].CondValue = strings.ToUpper(cd.CondValue)
 				}
-			} //else if r.Event == share.EventCompliance {
-			// value validation
-			// }
+			}
 			if !cds.Contains(cd.CondType) {
 				cds.Add(cd.CondType)
 			} else {


### PR DESCRIPTION
## Description

Fix https://github.com/neuvector/neuvector/issues/2686

Duplicate response rules are created when importing(thru CRD) same-name response rules with changes.
(For import thru UI/REST API, it's expected that duplicate response rules are created if the same yaml file is repeatedly imported)

## Test

1.  Import a new rule response rule as mentioned below thru CRD(like `kubectl apply -f neuvector-reponse-rule-1.yaml`),
```neuvector-reponse-rule-1.yaml
apiVersion: v1
items:
- apiVersion: neuvector.com/v1
  kind: NvResponseRuleSecurityRule
  metadata:
    creationTimestamp: null
    name: admission-control--33641b8c42d5b08f8743db142e9d2de17b0fe88afcb0116058fa764dbf6249ed
  spec:
    rule:
      actions:
      - webhook
      event: admission-control
      policy_name: default
      conditions:
      - type: name
        value: Admission.Control.Violation
      comment: test
kind: List
metadata: {}
```
2. On UI a response rule with CRD type is displayed
3. Changed the condition.value in neuvector-reponse-rule-1.yaml to `Admission.Control.Denied` and apply to k8s. (`metadata.name` doesn't change)
4. Before this PR, on UI two response rules with CRD type is displayed. One is for `Admission.Control.Violation` and one is for `Admission.Control.Denied`
After this PR, on UI the response rule with CRD type(created in step 1) is displayed with the updated event. No new CRD-type rule is created
5. Use `kubectl delete -f neuvector-reponse-rule-1.yaml` to delete the CRD-type response rule 
6. Changed the condition.value in neuvector-reponse-rule-1.yaml to `Admission.Control.Denied12345` (invalid value) and apply to k8s. 
7. On UI no new response rule with CRD type is created. In k8s the CR for nvresponserulesecurityrules.neuvector.com doesn't exist because NV deletes it for its invalid value

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

### Special notes for your reviewer

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
