### PR TITLE
fix: resolve golangci-lint 1.13.1 issues

### DIFF
--- a/controller/cache/admission_test.go
+++ b/controller/cache/admission_test.go
@@ -543,12 +543,12 @@ func TestNormalizeImageValue(t *testing.T) {
 		"https://localhost:8080": "https://localhost:8080/",
 		"10.1.127.3:5000/neuvector/toolbox/selvam_coreos_http":        "https://10.1.127.3:5000/neuvector/toolbox/selvam_coreos_http",
 		"10.1.127.3:5000/neuvector/toolbox/selvam_coreos_http:latest": "https://10.1.127.3:5000/neuvector/toolbox/selvam_coreos_http:latest",
-		"docker.io/nvlab/iperf":                                       "https://docker.io/nvlab/iperf",
-		"docker.io/nvlab/iperf:RELEASE":                               "https://docker.io/nvlab/iperf:RELEASE",
-		"docker.io":                                                   "https://docker.io/",
-		"nvlab/iperf":                                                 "nvlab/iperf",
-		"iperfserver:latest":                                          "iperfserver:latest",
-		":latest":                                                     ":latest",
+		"docker.io/nvlab/iperf":         "https://docker.io/nvlab/iperf",
+		"docker.io/nvlab/iperf:RELEASE": "https://docker.io/nvlab/iperf:RELEASE",
+		"docker.io":                     "https://docker.io/",
+		"nvlab/iperf":                   "nvlab/iperf",
+		"iperfserver:latest":            "iperfserver:latest",
+		":latest":                       ":latest",
 	}
 	var output string
 	for k, v := range input {
@@ -565,12 +565,12 @@ func TestNormalizeImageValue(t *testing.T) {
 		"https://localhost:8080": "https://localhost:8080/",
 		"10.1.127.3:5000/neuvector/toolbox/selvam_coreos_http":        "https://10.1.127.3:5000/",
 		"10.1.127.3:5000/neuvector/toolbox/selvam_coreos_http:latest": "https://10.1.127.3:5000/",
-		"docker.io/nvlab/iperf":                                       "https://docker.io/",
-		"docker.io/nvlab/iperf:RELEASE":                               "https://docker.io/",
-		"docker.io":                                                   "https://docker.io/",
-		"nvlab/iperf":                                                 "",
-		"iperfserver:latest":                                          "",
-		":latest":                                                     "",
+		"docker.io/nvlab/iperf":         "https://docker.io/",
+		"docker.io/nvlab/iperf:RELEASE": "https://docker.io/",
+		"docker.io":                     "https://docker.io/",
+		"nvlab/iperf":                   "",
+		"iperfserver:latest":            "",
+		":latest":                       "",
 	}
 	for k, v := range input {
 		output = normalizeImageValue(k, true)

--- a/controller/cache/profile.go
+++ b/controller/cache/profile.go
@@ -44,16 +44,12 @@ func profileConfigUpdate(nType cluster.ClusterNotifyType, key string, value []by
 		cacheMutexLock()
 		profileGroups[group] = &profile
 		cacheMutexUnlock()
-		if procRuleHelper != nil {
-			procRuleHelper.AddProcesProfile(&profile)
-		}
+		procRuleHelper.AddProcesProfile(&profile)
 
 	case cluster.ClusterNotifyDelete:
 		cacheMutexLock()
 		if profile, ok := profileGroups[group]; ok {
-			if procRuleHelper != nil {
-				procRuleHelper.DeleteProcesProfile(profile)
-			}
+			procRuleHelper.DeleteProcesProfile(profile)
 			delete(profileGroups, group)
 		}
 		cacheMutexUnlock()

--- a/controller/rest/admwebhook.go
+++ b/controller/rest/admwebhook.go
@@ -1597,9 +1597,8 @@ func k8sWebhookRestServer(svcName string, port uint, clientAuth, debug bool) {
 		server: &http.Server{
 			Addr: listenPortTLS,
 			TLSConfig: &tls.Config{
-				Certificates:             []tls.Certificate{pair},
-				PreferServerCipherSuites: true,
-				MinVersion:               tls.VersionTLS13,
+				Certificates: []tls.Certificate{pair},
+				MinVersion:   tls.VersionTLS13,
 				CurvePreferences: []tls.CurveID{
 					tls.CurveP256,
 					tls.X25519,

--- a/controller/rest/process.go
+++ b/controller/rest/process.go
@@ -434,10 +434,6 @@ func handlerProcRuleShow(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	log.WithFields(log.Fields{"URL": r.URL.String()}).Debug("")
 	defer r.Body.Close()
 	procRuleHelper := ruleid.GetProcessRuleIDHelper()
-	if procRuleHelper == nil {
-		restRespError(w, http.StatusBadRequest, api.RESTErrInvalidRequest)
-		return
-	}
 
 	acc, login := getAccessControl(w, r, "")
 	if acc == nil {

--- a/controller/rest/rest.go
+++ b/controller/rest/rest.go
@@ -2019,9 +2019,8 @@ func StartRESTServer(isNewCluster, isLead bool, maxConcurrentRepoScanTasks, scan
 
 	addr := fmt.Sprintf(":%d", _restPort)
 	config := &tls.Config{
-		MinVersion:               tls.VersionTLS13,
-		PreferServerCipherSuites: true,
-		CipherSuites:             utils.GetSupportedTLSCipherSuites(),
+		MinVersion:   tls.VersionTLS13,
+		CipherSuites: utils.GetSupportedTLSCipherSuites(),
 	}
 
 	// tlsCertificate is only generated when default location has no files

--- a/controller/scan/aws_auth.go
+++ b/controller/scan/aws_auth.go
@@ -111,9 +111,7 @@ func getAwsEcrAuthTokenById(sess *session.Session, registryID, region string) (*
 	svc := ecr.New(sess, aws.NewConfig().WithRegion(region))
 
 	// this lets us handle multiple registries
-	params := &ecr.GetAuthorizationTokenInput{
-		RegistryIds: []*string{aws.String(registryID)},
-	}
+	params := &ecr.GetAuthorizationTokenInput{}
 
 	// request the token
 	resp, err := svc.GetAuthorizationToken(params)

--- a/share/auth/auth_test.go
+++ b/share/auth/auth_test.go
@@ -73,7 +73,7 @@ func TestOktaSAMLUnsignedAuthnRequest(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Verify if it's consistent with Authn request for Okta.
-	assert.Equal(t, "https://dev.okta.com/app/dev/xxxxx/sso/saml?SAMLRequest=jJJBb9swDIX%2FisC7LcdNFkOoA2QNhgXotqDJdtglYGVmEWpJnkhl2b8f4rZAd1gwHSk%2Bfg98vGX0%2FWCWWY7hgX5mYlFn3wc240cLOQUTkR2bgJ7YiDXb5ad7U5eVGVKUaGMPbyTXFchMSVwMoNarFvZkp3Oy86bA%2BWFaTGdNVzTvsCsODc0628zosUFQ3yixi6GFuqxAbV6o713oXPhxHfj43MTm4263KTZftjtQy1cTdzFw9pS2lE7O0teH%2BxaOIgMbremMfuiptNFriU8U9pjluGdKJ0qg1syZ1oEFg7RQV%2FVNMamKarqrJ6ZqzE31HdSKWFxAGa2%2Fzu3oVMYnwXEwDsOloM%2BXp5mjvqwQFmMqZmSkxX85utVvJS%2BpfkZP69Um9s7%2BVsu%2Bj7%2FuEqFQC5IygfoQk0f59wIn5WSsuK44jK0mBx7IuoOjDvTiGfr39Sz%2BBAAA%2F%2F8%3D", url)
+	assert.Equal(t, "https://dev.okta.com/app/dev/xxxxx/sso/saml?SAMLRequest=jJJBbxMxEIX%2FijX3XW%2B2CVlZ2UihESJSgagJHLhEU%2B%2BEWF3bi2ccwr9HWYqohKjqq%2BfN9%2FTeLBh9P5hVllO4p%2B%2BZWNTF94HN%2BNFCTsFEZMcmoCc2Ys1u9eHO1GVlhhQl2tjDM8nLCmSmJC4GUJt1Cwey0znZeVPg%2FDgtprOmK5o32BXHhmadbWb00CCoL5TYxdBCXVagtk%2FUty50Lnx7Gfjwe4jN%2B%2F1%2BW2w%2F7fagVn9M3MbA2VPaUTo7S5%2Fv71o4iQxstKYL%2BqGn0kavJT5SOGCW04EpnSmB2jBn2gQWDNJCXdU3xaQqqum%2BnpiqMTfVV1BrYnEBr6S%2Fezs6l%2FFRcFyMw6A7OuvL9WnmqK%2Bpw3JsxYyMtHyVo4V%2BLnlq9SN62qy3sXf2p1r1ffxxmwiFWpCUCdS7mDzK%2FwOclJOxddcVx3HU5MADWXd01IFeLvS%2F17P8NQA%3D", url)
 }
 
 // This test verifies signed Authn request.
@@ -166,7 +166,7 @@ ma7nkie3ORja96UTROAZ77o=
 	assert.Nil(t, err)
 
 	// Verify if it's consistent with Authn request for Okta.
-	assert.Equal(t, "https://dev.okta.com/app/dev/xxxxx/sso/saml?SAMLRequest=jJJBb9swDIX%2FisC7LcdNFkOoA2QNhgXotqDJdtglYGVmEWpJnkhl2b8f4rZAd1gwHSk%2Bfg98vGX0%2FWCWWY7hgX5mYlFn3wc240cLOQUTkR2bgJ7YiDXb5ad7U5eVGVKUaGMPbyTXFchMSVwMoNarFvZkp3Oy86bA%2BWFaTGdNVzTvsCsODc0628zosUFQ3yixi6GFuqxAbV6o713oXPhxHfj43MTm4263KTZftjtQy1cTdzFw9pS2lE7O0teH%2BxaOIgMbremMfuiptNFriU8U9pjluGdKJ0qg1syZ1oEFg7RQV%2FVNMamKarqrJ6ZqzE31HdSKWFxAGa2%2Fzu3oVMYnwXEwDsOloM%2BXp5mjvqwQFmMqZmSkxX85utVvJS%2BpfkZP69Um9s7%2BVsu%2Bj7%2FuEqFQC5IygfoQk0f59wIn5WSsuK44jK0mBx7IuoOjDvTiGfr39Sz%2BBAAA%2F%2F8%3D", url)
+	assert.Equal(t, "https://dev.okta.com/app/dev/xxxxx/sso/saml?SAMLRequest=jJJBbxMxEIX%2FijX3XW%2B2CVlZ2UihESJSgagJHLhEU%2B%2BEWF3bi2ccwr9HWYqohKjqq%2BfN9%2FTeLBh9P5hVllO4p%2B%2BZWNTF94HN%2BNFCTsFEZMcmoCc2Ys1u9eHO1GVlhhQl2tjDM8nLCmSmJC4GUJt1Cwey0znZeVPg%2FDgtprOmK5o32BXHhmadbWb00CCoL5TYxdBCXVagtk%2FUty50Lnx7Gfjwe4jN%2B%2F1%2BW2w%2F7fagVn9M3MbA2VPaUTo7S5%2Fv71o4iQxstKYL%2BqGn0kavJT5SOGCW04EpnSmB2jBn2gQWDNJCXdU3xaQqqum%2BnpiqMTfVV1BrYnEBr6S%2Fezs6l%2FFRcFyMw6A7OuvL9WnmqK%2Bpw3JsxYyMtHyVo4V%2BLnlq9SN62qy3sXf2p1r1ffxxmwiFWpCUCdS7mDzK%2FwOclJOxddcVx3HU5MADWXd01IFeLvS%2F17P8NQA%3D", url)
 }
 
 // Verify NV can accept Okta Authn response.
@@ -323,7 +323,7 @@ ma7nkie3ORja96UTROAZ77o=
 	assert.Nil(t, err)
 
 	// Verify if it's consistent with logout request for Okta.
-	assert.Equal(t, "https://dev.okta.com/app/dev/xxxxx/slo/saml?SAMLRequest=fJLf65swFMX%2FFcl7NP6o%2Bg1fZYMyELo9rGMPe5Frcl2lmrjcWPzzh7aFbrDl8SSfc8K5951gGmd5sj%2Ft4r%2FirwXJB%2Bs0GpL7TcUWZ6QFGkgamJCkV%2FL88fNJJqGQs7PeKjuyF%2BT%2FBBCh84M1LGiOFWtRZQWqouRQ9BnPDqXmZQ6a9yUetCoP2JXAgu%2FoaLCmYkkoWNAQLdgY8mB8xRKRpDwWXOTfhJAil6n4wYIjkh8M%2BJ26eD%2BTjCKNt9BePYTKThHM8yZE63YiGm20%2FZ7VeyNyz3D1k8QVpnnEHfT2iqaFxV9aQndD9x69Inf%2BC0zYHINP1k3g%2F11JHMa7Mmje70%2FlYmhGNfQDalYDfOi6UKlHwt20fszsjLSV0hiNa93muojT%2FC3leS6AZ0UmePeGgqsYVJImcQ8d3m3%2BIp%2FiHytQ%2Fw4AAP%2F%2F&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256&Signature=IAXj56i9MlhULmRq9v0LNTeFmmuce4PK%2B41jiEM%2BYX5HFgdav7u6%2B8zlNk5PQB%2FGqYsXpT4CbhB%2BwVDj4DaL87OFDAk5urz2Af3CK209ktL0YO1MT3D%2BitwP8nzmxdfQ1LIxQp%2B8MMk6vVlLzosY3M0wtxMnQ3QOO229BT13FTt%2BNtTxzY4TiUtgPaa7xzAVdgKLZFabPG8U%2FvKZkttaifjMRK1V1px42KiRB6WoD1bWRRdAZecfUg4AcUH%2BOs21OwmL4LVQiLkCzuXNL4dOlqqbxz5P9AjXZS5XTfog1fMvxhqM2Rk0pOnUxTyrlctJVigzENhmvn1MuJPjSCt3JA%3D%3D", url)
+	assert.Equal(t, "https://dev.okta.com/app/dev/xxxxx/slo/saml?SAMLRequest=fJLPbpwwEIdfBflubP4sEAtQK60qIaU9NFUPvaDBHhoUsKnHRDx%2BBUmlPWzjo%2B1vfppvpiZY5lU9ut9uC9%2Fxz4YUon2ZLanzpWGbt8oBTaQsLEgqaPX0%2BeujSmOpVu%2BC025mN8jHBBChD5OzLOquDetR5yXqsuJQjjnPL5XhVQGGjxVejK4uOFTAop%2FoaXK2YWksWdQRbdhZCmBDw1KZZjyRXBY%2FpFSyUJn8xaIrUpgsHEkNew5hJSWEwdfYvQSItVsErOtxIfbjCJqdOBpm7WlEnRm%2B%2FUfiDss64wkG94K2hy0894T%2BFX0tbpE3%2Fhss2F2jL84vEP6vJImTU%2Btk%2BHh%2BVZulFfU0TmhYC%2FBpGGKt3xPeirbvM3tCOqR01uDe9oUpk6x4yHhRSOB5mUs%2BPKDkOgGdZmkywoC1uEPW4s4KtH8HAA%3D%3D&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256&Signature=nEzjH0boa9MgxPbH2zhBPPu3yNZ%2B9NP%2Ft2URXPPkP10DXHWPbV0MYOUkZGVDF3XVlEnIjQRsi6QNr8Ub5rT0va7lpj6GIySzkBUIhxYBoI3ik00PyJxRpPI5Sf%2FbqsCM%2FPJsQw%2FtTRerep9jHkbaI67Vx3wtEdNYHjl4F9PuNshk%2Bzswtg%2FVSdLQ7nd2QvIUkh0%2BAs%2BawQ%2BbrpMOM29DYUL%2FX6Q2fekmD7ngw5z4H2MZYXGhCPL4asbjqjFEOEqZ2KbPfjP3gTzNTuGhGVuEolOcsR9ahX9vItOCizzdxKjtU8vy9w0LhhQc9oAx4vKv9AXHh%2BbnBhNGJ3m18yTkGA%3D%3D", url)
 }
 
 func TestOktaSAMLSLOResponse(t *testing.T) {

--- a/upgrader/postsync.go
+++ b/upgrader/postsync.go
@@ -81,11 +81,11 @@ func WaitUntilRolledOut(ctx context.Context, gr schema.GroupVersionResource, cli
 
 	fieldSelector := fields.OneTermEqualSelector("metadata.name", deployment.Name).String()
 	lw := &cache.ListWatch{
-		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
 			options.FieldSelector = fieldSelector
 			return client.Resource(gr).Namespace(deployment.Namespace).List(ctx, options)
 		},
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 			options.FieldSelector = fieldSelector
 			return client.Resource(gr).Namespace(deployment.Namespace).Watch(ctx, options)
 		},


### PR DESCRIPTION
## Description

resolve resolve issues introduced by upgrading to golangci-lint 1.13.1 for golang 1.27.0

## Test

## Additional Information

### Tradeoff

### Potential improvement

### Special notes for your reviewer

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
