### PR TITLE
fix(nvbench): pass non-applicable RKE2 hostname override check K4.2.7

### DIFF
--- a/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
@@ -424,11 +424,7 @@ groups:
         tags: {}
         audit: |
           check="$id  - $description"
-          if check_argument "$CIS_KUBELET_CMD" '--hostname-override' >/dev/null 2>&1; then
-              warn "$check"
-          else
-              pass "$check"
-          fi
+          pass "$check"
         remediation: |
           Not Applicable.
           By default, RKE2 does set the --hostname-override argument. Per CIS guidelines, this is to comply


### PR DESCRIPTION
## Description

No associated GitHub issue.

[RKE2 CIS 1.8 Self-Assessment – Control 4.2.7](https://docs.rke2.io/security/cis_self_assessment18#427-ensure-that-the---hostname-override-argument-is-not-set-automated)

RKE2 classifies control `K.4.2.7` as `Not Applicable` because RKE2 sets `--hostname-override` by default. NeuVector currently emits `WARN` whenever this expected argument is present.

This differs from every other `Not Applicable` control in the same RKE2 worker profile:

- [`K.4.1.1`](https://github.com/neuvector/neuvector/blob/f28d5d65aa7dfabc3acfd05326b5eaa3ae79c27d/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml#L21-L25) unconditionally calls `pass "$check"`.
- [`K.4.1.2`](https://github.com/neuvector/neuvector/blob/f28d5d65aa7dfabc3acfd05326b5eaa3ae79c27d/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml#L39-L43) unconditionally calls `pass "$check"`.
- [`K.4.1.9`](https://github.com/neuvector/neuvector/blob/f28d5d65aa7dfabc3acfd05326b5eaa3ae79c27d/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml#L236-L240) unconditionally calls `pass "$check"`.
- [`K.4.1.10`](https://github.com/neuvector/neuvector/blob/f28d5d65aa7dfabc3acfd05326b5eaa3ae79c27d/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml#L254-L258) unconditionally calls `pass "$check"`.

[`K.4.2.7`](https://github.com/neuvector/neuvector/blob/f28d5d65aa7dfabc3acfd05326b5eaa3ae79c27d/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml#L425-L433) is the only `Not Applicable` control in this file that can emit `WARN`.

This change replaces the conditional warning with `pass "$check"`, aligning `K.4.2.7` with the existing handling of non-applicable controls in the same profile.

## Test

Validated the modified benchmark YAML successfully with PyYAML:

```shell
python3 -c 'import pathlib, yaml; yaml.safe_load(pathlib.Path("agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml").read_text())'
```

The branch contains one logical commit and modifies only the audit result for `K.4.2.7`.

Expected result when running the RKE2 CIS worker scan: `K.4.2.7` reports `PASS` when RKE2's expected `--hostname-override` argument is present.

## Additional Information

### Tradeoff

NeuVector will no longer emit a warning for `--hostname-override` in the RKE2 CIS 1.8.0 worker profile. This is intentional because the control is explicitly classified as `Not Applicable`.

### Potential improvement

Introduce an explicit `Not Applicable` or `SKIP` result state so non-applicable controls do not need to be represented as `PASS`.

### Special notes for your reviewer

The change is limited to `K.4.2.7` in the RKE2 CIS 1.8.0 worker profile. Generic Kubernetes CIS profiles and other controls are unchanged.

### Checklist

- [x] squashed commits into logical changes