### PR TITLE
fix(rke2): read eventRecordQPS from kubelet configuration K.4.2.8

### DIFF
--- a/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
+++ b/agent/nvbench/kubernetes-cis-benchmark/cis-rke2-1.8.0/worker/4_worker_nodes.yaml
@@ -444,17 +444,22 @@ groups:
         tags: {}
         audit: |
           check="$id  - $description"
+
+          config_dir="/var/lib/rancher/rke2/agent/etc/kubelet.conf.d"
+          config_dir=$(append_prefix "$CONFIG_PREFIX" "$config_dir")
+          qps=$(sed -n \
+              's/^[[:space:]]*eventRecordQPS:[[:space:]]*\([0-9][0-9]*\).*$/\1/p' \
+              "$config_dir"/*.conf 2>/dev/null | tail -n 1)
+
           if check_argument "$CIS_KUBELET_CMD" '--event-qps' >/dev/null 2>&1; then
               qps=$(get_argument_value "$CIS_KUBELET_CMD" '--event-qps' | cut -d " " -f 1)
-              if [ "$qps" -gt 0 ]; then
-                  pass "$check"
-              else
-                  warn "$check"
-                  warn "      * --event-qps: $qps is not set to a positive value"
-              fi
+          fi
+
+          if [ -n "$qps" ] && [ "$qps" -gt 0 ]; then
+              pass "$check"
           else
               warn "$check"
-              warn "      * --event-qps is not set"
+              warn "      * eventRecordQPS: ${qps:-not set} is not set to a positive value"
           fi
         remediation: |
           Edit the RKE2 config file /etc/rancher/rke2/config.yaml, set the following parameter to an appropriate value.


### PR DESCRIPTION
## Description

K.4.2.8 currently reads the event QPS value only from the deprecated `--event-qps` kubelet command-line argument.

RKE2 stores its kubelet configuration in `/var/lib/rancher/rke2/agent/etc/kubelet.conf.d/`. Therefore, nodes with a positive `eventRecordQPS` value in the kubelet configuration are incorrectly reported as missing `--event-qps`.

This change reads `eventRecordQPS` from the RKE2 kubelet configuration drop-ins. When multiple files define the value, the last matching file in lexical order takes precedence. An explicit `--event-qps` command-line argument continues to override the configuration value.

[[Documentation](https://docs.rke2.io/install/configuration#kubelet-configuration)](https://docs.rke2.io/install/configuration#kubelet-configuration)

## Test

Verify that the kubelet does not use an explicit `--event-qps` argument:

```shell
ps -ef | grep '[k]ubelet' | grep -o -- '--event-qps[^ ]*' || true
```

Check the value stored in the RKE2 kubelet configuration:

```shell
sed -n \
  's/^[[:space:]]*eventRecordQPS:[[:space:]]*\([0-9][0-9]*\).*$/\1/p' \
  /var/lib/rancher/rke2/agent/etc/kubelet.conf.d/*.conf
```

Verify the effective kubelet configuration:

```shell
kubectl get --raw "/api/v1/nodes/<node-name>/proxy/configz" |
  jq -r '.kubeletconfig |
    "eventRecordQPS=\(.eventRecordQPS) eventBurst=\(.eventBurst)"'
```

Tested with RKE2 v1.35.6+rke2r1. The effective configuration on all tested worker nodes returned:

```text
eventRecordQPS=50 eventBurst=100
```

After applying the change, rerun the RKE2 CIS worker benchmark and verify that K.4.2.8 passes without an explicit `--event-qps` argument.

## Additional Information

### Tradeoff

This change reads the standard RKE2 kubelet configuration drop-in directory. Custom kubelet `--config` or `--config-dir` paths are not resolved.

### Potential improvement

Support custom kubelet configuration paths by resolving `--config` or `--config-dir` from the kubelet command line.

### Special notes for your reviewer

The change is intentionally limited to value resolution in K.4.2.8. Check metadata, scoring, and remediation remain unchanged.

Command-line precedence is preserved: an explicit `--event-qps` value overrides values found in the kubelet configuration drop-ins.

### Checklist

* [x] squashed commits into logical changes
* [ ] includes documentation
* [ ] adds unit tests
* [ ] adds or updates e2e tests