### PR TITLE
fix: NVSHAS-10273 inherit parent sid when process absent

### DIFF
--- a/agent/probe/process.go
+++ b/agent/probe/process.go
@@ -1112,6 +1112,17 @@ func (p *Probe) handleProcFork(pid, ppid int, name string) (inContainer bool, pc
 	}
 
 	if parent, ok := p.pidProcMap[proc.ppid]; ok {
+		// GetSessionId returns 0 (ESRCH) when the child has already exited by the
+		// time this fork event is processed (common for the microsecond-lived
+		// CIS-benchmark subshells and grep/yq/cut/tr descendants). In that case
+		// fall back to the parent's session, which the child inherited at fork -
+		// keeping sid valid for tool-process recognition (IsToolProcess/
+		// isAgentChild). A still-live child keeps its own /proc value, so a
+		// process that called setsid() to start a new session is unaffected.
+		if proc.sid == 0 {
+			proc.sid = parent.sid
+		}
+
 		// Inherit parent's information
 		proc.pname = parent.name
 		proc.ppath = parent.path

--- a/agent/probe/process_test.go
+++ b/agent/probe/process_test.go
@@ -3,13 +3,18 @@ package probe
 import (
 	"encoding/json"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/neuvector/neuvector/share"
 	"github.com/neuvector/neuvector/share/container"
 	"github.com/neuvector/neuvector/share/global"
+	"github.com/neuvector/neuvector/share/osutil"
 	"github.com/neuvector/neuvector/share/scan/secrets"
+	"github.com/neuvector/neuvector/share/system"
 	"github.com/neuvector/neuvector/share/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // a fake runtime driver
@@ -234,6 +239,91 @@ func TestAzureCniCmd(t *testing.T) {
 				t.Errorf("Error[%v]: negative: %v\n", k, v)
 			}
 		}
+	}
+}
+
+// TestHandleProcForkSidInheritance verifies the session-id assignment in
+// handleProcFork:
+//   - an already-exited child (GetSessionId returns 0/ESRCH) inherits its
+//     parent's session, keeping sid valid for tool-process recognition of the
+//     short-lived CIS-benchmark descendants;
+//   - a still-live child keeps its own /proc session and is NEVER overwritten by
+//     the parent's - so a user workload that called setsid() reports the correct
+//     new session;
+//   - with no parent in the map, the child's own /proc session is used.
+func TestHandleProcForkSidInheritance(t *testing.T) {
+	global.RT = &dummyRTDriver{cmd: "runc"}
+	global.SYS = system.NewSystemTools()
+
+	// bogus parent session, deliberately not equal to any live process's real
+	// session id so the "live child" case can prove no inheritance happened.
+	const parentSid = 4242
+	selfSid := osutil.GetSessionId(os.Getpid())
+	require.NotEqual(t, parentSid, selfSid, "test precondition: parentSid must differ from the live session")
+
+	cases := []struct {
+		name        string
+		parentInMap bool
+		childLive   bool
+		wantSid     int
+	}{
+		{
+			// exited child: /proc read yields 0, so it inherits the parent's sid.
+			name:        "exited child inherits parent sid",
+			parentInMap: true,
+			childLive:   false,
+			wantSid:     parentSid,
+		},
+		{
+			// live child (e.g. one that called setsid): keeps its own session,
+			// must not be overwritten by the parent's sid.
+			name:        "live child keeps its own sid",
+			parentInMap: true,
+			childLive:   true,
+			wantSid:     selfSid,
+		},
+		{
+			// no parent to inherit from: fall back to the child's /proc session.
+			name:        "no parent falls back to proc",
+			parentInMap: false,
+			childLive:   true,
+			wantSid:     selfSid,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := &Probe{
+				pidProcMap:      make(map[int]*procInternal),
+				pidContainerMap: make(map[int]*procContainer),
+				containerMap:    make(map[string]*procContainer),
+				inspectProcess:  utils.NewSet(),
+			}
+
+			parentPid := 5000
+			childPid := 5001 // non-existent -> GetSessionId returns 0
+			if c.childLive {
+				childPid = os.Getpid() // live -> GetSessionId returns selfSid
+			}
+			if !c.parentInMap {
+				parentPid = 999999 // absent from pidProcMap
+			} else {
+				p.pidProcMap[parentPid] = &procInternal{
+					pid:  parentPid,
+					ppid: 1,
+					sid:  parentSid,
+					name: "sh",
+					path: "/bin/sh",
+					user: "root",
+				}
+			}
+
+			p.handleProcFork(childPid, parentPid, "grep")
+
+			child, ok := p.pidProcMap[childPid]
+			require.True(t, ok, "forked child should be recorded in pidProcMap")
+			assert.Equal(t, c.wantSid, child.sid)
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Address #2784

This PR addresses a tricky situation.  NV relies on /proc/<pid>/ to know more information about a process. For short-lived processes, the window that NV can check its process is limited.

In case the enforcer can't find the process anymore, this fix makes short-lived processes to inherit parent sid, as the normal process does, so enforcer has sufficient information to make sure that the process comes from the process tree or not.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

### Special notes for your reviewer

<!-- Please describe, if any special design or notes you want to share with your reviewer in this pull request -->

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
