### PR TITLE
sync missing commit from main to release/v5.6 for golang:1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,51 +1,53 @@
 name: CI
-
 on:
   push:
   pull_request:
-
 permissions:
   contents: read
-
 jobs:
   unitest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version-file: "go.mod"
-    - name: Install dependencies
-      run: |
-        sudo apt update && sudo apt install -y libpcre3-dev
-    - run: |
-        make test
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: "go.mod"
+      - name: Install dependencies
+        run: |
+          sudo apt update && sudo apt install -y libpcre3-dev
+      - run: |
+          make test
   golangci-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "go.mod"
       - name: Install dependencies
         run: |
           sudo apt update && sudo apt install -y libpcre3-dev
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12.2
+          version: v2.13.1
           install-mode: binary
           args: --timeout=30m
           skip-cache: true
   openapi-lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-      with:
-        node-version: 24
-    - name: openapi-lint 
-      run: |
-        npm i -g @redocly/cli@1.25.11
-        redocly lint controller/api/apis.yaml --skip-rule operation-operationId --skip-rule operation-4xx-response --skip-rule no-ambiguous-paths --skip-rule security-defined
-        redocly lint controller/api/internal_apis.yaml --skip-rule operation-operationId
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: openapi-lint
+        run: |
+          npx @redocly/cli@1.25.11 lint controller/api/apis.yaml --skip-rule operation-operationId --skip-rule operation-4xx-response --skip-rule no-ambiguous-paths --skip-rule security-defined
+          npx @redocly/cli@1.25.11 lint controller/api/internal_apis.yaml --skip-rule operation-operationId


### PR DESCRIPTION
## Description

Sync the missing commit from branch `main` to `release/v5.6` for upgrading to golang 1.27
(The ci.yml file in https://github.com/neuvector/neuvector/commit/2e7f3223cd89826011041b974b070a0e22c8c870)

## Test

## Additional Information

### Tradeoff

### Potential improvement

### Special notes for your reviewer

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
