### PR TITLE
chore: bump crypto to 0.56.0 to fix the cve

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,18 +12,19 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "go.mod"
       - name: Install dependencies
         run: |
           sudo apt update && sudo apt install -y libpcre3-dev
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.9.0
+          version: v2.13.1
           install-mode: binary
           args: --timeout=30m
+          skip-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,13 @@ linters:
     - staticcheck
     - unused
     - nolintlint # reports ill-formed or insufficient nolint directives
+  settings:
+    govet:
+      disable:
+        - inline
+    staticcheck:
+      checks:
+        - "-QF1012" # Explicitly disables the QF1012 rule
   exclusions:
     generated: lax
     presets:
@@ -24,6 +31,14 @@ linters:
           - staticcheck
         path: controller/
         text: 'SA5008: unknown JSON option ("cloak"|"overflow")'
+      - linters:
+          - staticcheck
+        path: share/
+        text: 'SA5008: invalid appearance of unknown `cloak` tag option'
+      - linters:
+          - staticcheck
+        path: controller/
+        text: 'SA5008: invalid appearance of unknown `cloak` tag option'
       - path: (.+)\.go$
         text: 'SA1019: grpc.RPCCompressor is deprecated: use encoding.RegisterCompressor'
       - path: (.+)\.go$

--- a/controller/cache/admission_test.go
+++ b/controller/cache/admission_test.go
@@ -543,12 +543,12 @@ func TestNormalizeImageValue(t *testing.T) {
 		"https://localhost:8080": "https://localhost:8080/",
 		"10.1.127.3:5000/neuvector/toolbox/selvam_coreos_http":        "https://10.1.127.3:5000/neuvector/toolbox/selvam_coreos_http",
 		"10.1.127.3:5000/neuvector/toolbox/selvam_coreos_http:latest": "https://10.1.127.3:5000/neuvector/toolbox/selvam_coreos_http:latest",
-		"docker.io/nvlab/iperf":                                       "https://docker.io/nvlab/iperf",
-		"docker.io/nvlab/iperf:RELEASE":                               "https://docker.io/nvlab/iperf:RELEASE",
-		"docker.io":                                                   "https://docker.io/",
-		"nvlab/iperf":                                                 "nvlab/iperf",
-		"iperfserver:latest":                                          "iperfserver:latest",
-		":latest":                                                     ":latest",
+		"docker.io/nvlab/iperf":         "https://docker.io/nvlab/iperf",
+		"docker.io/nvlab/iperf:RELEASE": "https://docker.io/nvlab/iperf:RELEASE",
+		"docker.io":                     "https://docker.io/",
+		"nvlab/iperf":                   "nvlab/iperf",
+		"iperfserver:latest":            "iperfserver:latest",
+		":latest":                       ":latest",
 	}
 	var output string
 	for k, v := range input {
@@ -565,12 +565,12 @@ func TestNormalizeImageValue(t *testing.T) {
 		"https://localhost:8080": "https://localhost:8080/",
 		"10.1.127.3:5000/neuvector/toolbox/selvam_coreos_http":        "https://10.1.127.3:5000/",
 		"10.1.127.3:5000/neuvector/toolbox/selvam_coreos_http:latest": "https://10.1.127.3:5000/",
-		"docker.io/nvlab/iperf":                                       "https://docker.io/",
-		"docker.io/nvlab/iperf:RELEASE":                               "https://docker.io/",
-		"docker.io":                                                   "https://docker.io/",
-		"nvlab/iperf":                                                 "",
-		"iperfserver:latest":                                          "",
-		":latest":                                                     "",
+		"docker.io/nvlab/iperf":         "https://docker.io/",
+		"docker.io/nvlab/iperf:RELEASE": "https://docker.io/",
+		"docker.io":                     "https://docker.io/",
+		"nvlab/iperf":                   "",
+		"iperfserver:latest":            "",
+		":latest":                       "",
 	}
 	for k, v := range input {
 		output = normalizeImageValue(k, true)

--- a/controller/cache/profile.go
+++ b/controller/cache/profile.go
@@ -44,16 +44,12 @@ func profileConfigUpdate(nType cluster.ClusterNotifyType, key string, value []by
 		cacheMutexLock()
 		profileGroups[group] = &profile
 		cacheMutexUnlock()
-		if procRuleHelper != nil {
-			procRuleHelper.AddProcesProfile(&profile)
-		}
+		procRuleHelper.AddProcesProfile(&profile)
 
 	case cluster.ClusterNotifyDelete:
 		cacheMutexLock()
 		if profile, ok := profileGroups[group]; ok {
-			if procRuleHelper != nil {
-				procRuleHelper.DeleteProcesProfile(profile)
-			}
+			procRuleHelper.DeleteProcesProfile(profile)
 			delete(profileGroups, group)
 		}
 		cacheMutexUnlock()

--- a/controller/rest/admwebhook.go
+++ b/controller/rest/admwebhook.go
@@ -1580,9 +1580,8 @@ func k8sWebhookRestServer(svcName string, port uint, clientAuth, debug bool) {
 		server: &http.Server{
 			Addr: listenPortTLS,
 			TLSConfig: &tls.Config{
-				Certificates:             []tls.Certificate{pair},
-				PreferServerCipherSuites: true,
-				MinVersion:               tls.VersionTLS12,
+				Certificates: []tls.Certificate{pair},
+				MinVersion:   tls.VersionTLS12,
 				CurvePreferences: []tls.CurveID{
 					tls.CurveP256,
 					tls.X25519,

--- a/controller/rest/process.go
+++ b/controller/rest/process.go
@@ -431,10 +431,6 @@ func handlerProcRuleShow(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	log.WithFields(log.Fields{"URL": r.URL.String()}).Debug("")
 	defer r.Body.Close()
 	procRuleHelper := ruleid.GetProcessRuleIDHelper()
-	if procRuleHelper == nil {
-		restRespError(w, http.StatusBadRequest, api.RESTErrInvalidRequest)
-		return
-	}
 
 	acc, login := getAccessControl(w, r, "")
 	if acc == nil {

--- a/controller/rest/rest.go
+++ b/controller/rest/rest.go
@@ -1991,7 +1991,7 @@ func StartRESTServer(isNewCluster, isLead bool, maxConcurrentRepoScanTasks, scan
 
 	addr := fmt.Sprintf(":%d", _restPort)
 	config := &tls.Config{
-		MinVersion:   tls.VersionTLS11,
+		MinVersion:   tls.VersionTLS12,
 		CipherSuites: utils.GetSupportedTLSCipherSuites(),
 	}
 

--- a/controller/rest/rest.go
+++ b/controller/rest/rest.go
@@ -1991,9 +1991,8 @@ func StartRESTServer(isNewCluster, isLead bool, maxConcurrentRepoScanTasks, scan
 
 	addr := fmt.Sprintf(":%d", _restPort)
 	config := &tls.Config{
-		MinVersion:               tls.VersionTLS11,
-		PreferServerCipherSuites: true,
-		CipherSuites:             utils.GetSupportedTLSCipherSuites(),
+		MinVersion:   tls.VersionTLS11,
+		CipherSuites: utils.GetSupportedTLSCipherSuites(),
 	}
 
 	// tlsCertificate is only generated when default location has no files

--- a/controller/scan/aws_auth.go
+++ b/controller/scan/aws_auth.go
@@ -111,9 +111,7 @@ func getAwsEcrAuthTokenById(sess *session.Session, registryID, region string) (*
 	svc := ecr.New(sess, aws.NewConfig().WithRegion(region))
 
 	// this lets us handle multiple registries
-	params := &ecr.GetAuthorizationTokenInput{
-		RegistryIds: []*string{aws.String(registryID)},
-	}
+	params := &ecr.GetAuthorizationTokenInput{}
 
 	// request the token
 	resp, err := svc.GetAuthorizationToken(params)

--- a/go.mod
+++ b/go.mod
@@ -169,7 +169,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/time v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -433,8 +433,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=

--- a/share/auth/auth_test.go
+++ b/share/auth/auth_test.go
@@ -73,7 +73,7 @@ func TestOktaSAMLUnsignedAuthnRequest(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Verify if it's consistent with Authn request for Okta.
-	assert.Equal(t, "https://dev.okta.com/app/dev/xxxxx/sso/saml?SAMLRequest=jJJBb9swDIX%2FisC7LcdNFkOoA2QNhgXotqDJdtglYGVmEWpJnkhl2b8f4rZAd1gwHSk%2Bfg98vGX0%2FWCWWY7hgX5mYlFn3wc240cLOQUTkR2bgJ7YiDXb5ad7U5eVGVKUaGMPbyTXFchMSVwMoNarFvZkp3Oy86bA%2BWFaTGdNVzTvsCsODc0628zosUFQ3yixi6GFuqxAbV6o713oXPhxHfj43MTm4263KTZftjtQy1cTdzFw9pS2lE7O0teH%2BxaOIgMbremMfuiptNFriU8U9pjluGdKJ0qg1syZ1oEFg7RQV%2FVNMamKarqrJ6ZqzE31HdSKWFxAGa2%2Fzu3oVMYnwXEwDsOloM%2BXp5mjvqwQFmMqZmSkxX85utVvJS%2BpfkZP69Um9s7%2BVsu%2Bj7%2FuEqFQC5IygfoQk0f59wIn5WSsuK44jK0mBx7IuoOjDvTiGfr39Sz%2BBAAA%2F%2F8%3D", url)
+	assert.Equal(t, "https://dev.okta.com/app/dev/xxxxx/sso/saml?SAMLRequest=jJJBbxMxEIX%2FijX3XW%2B2CVlZ2UihESJSgagJHLhEU%2B%2BEWF3bi2ccwr9HWYqohKjqq%2BfN9%2FTeLBh9P5hVllO4p%2B%2BZWNTF94HN%2BNFCTsFEZMcmoCc2Ys1u9eHO1GVlhhQl2tjDM8nLCmSmJC4GUJt1Cwey0znZeVPg%2FDgtprOmK5o32BXHhmadbWb00CCoL5TYxdBCXVagtk%2FUty50Lnx7Gfjwe4jN%2B%2F1%2BW2w%2F7fagVn9M3MbA2VPaUTo7S5%2Fv71o4iQxstKYL%2BqGn0kavJT5SOGCW04EpnSmB2jBn2gQWDNJCXdU3xaQqqum%2BnpiqMTfVV1BrYnEBr6S%2Fezs6l%2FFRcFyMw6A7OuvL9WnmqK%2Bpw3JsxYyMtHyVo4V%2BLnlq9SN62qy3sXf2p1r1ffxxmwiFWpCUCdS7mDzK%2FwOclJOxddcVx3HU5MADWXd01IFeLvS%2F17P8NQA%3D", url)
 }
 
 // This test verifies signed Authn request.
@@ -166,7 +166,7 @@ ma7nkie3ORja96UTROAZ77o=
 	assert.Nil(t, err)
 
 	// Verify if it's consistent with Authn request for Okta.
-	assert.Equal(t, "https://dev.okta.com/app/dev/xxxxx/sso/saml?SAMLRequest=jJJBb9swDIX%2FisC7LcdNFkOoA2QNhgXotqDJdtglYGVmEWpJnkhl2b8f4rZAd1gwHSk%2Bfg98vGX0%2FWCWWY7hgX5mYlFn3wc240cLOQUTkR2bgJ7YiDXb5ad7U5eVGVKUaGMPbyTXFchMSVwMoNarFvZkp3Oy86bA%2BWFaTGdNVzTvsCsODc0628zosUFQ3yixi6GFuqxAbV6o713oXPhxHfj43MTm4263KTZftjtQy1cTdzFw9pS2lE7O0teH%2BxaOIgMbremMfuiptNFriU8U9pjluGdKJ0qg1syZ1oEFg7RQV%2FVNMamKarqrJ6ZqzE31HdSKWFxAGa2%2Fzu3oVMYnwXEwDsOloM%2BXp5mjvqwQFmMqZmSkxX85utVvJS%2BpfkZP69Um9s7%2BVsu%2Bj7%2FuEqFQC5IygfoQk0f59wIn5WSsuK44jK0mBx7IuoOjDvTiGfr39Sz%2BBAAA%2F%2F8%3D", url)
+	assert.Equal(t, "https://dev.okta.com/app/dev/xxxxx/sso/saml?SAMLRequest=jJJBbxMxEIX%2FijX3XW%2B2CVlZ2UihESJSgagJHLhEU%2B%2BEWF3bi2ccwr9HWYqohKjqq%2BfN9%2FTeLBh9P5hVllO4p%2B%2BZWNTF94HN%2BNFCTsFEZMcmoCc2Ys1u9eHO1GVlhhQl2tjDM8nLCmSmJC4GUJt1Cwey0znZeVPg%2FDgtprOmK5o32BXHhmadbWb00CCoL5TYxdBCXVagtk%2FUty50Lnx7Gfjwe4jN%2B%2F1%2BW2w%2F7fagVn9M3MbA2VPaUTo7S5%2Fv71o4iQxstKYL%2BqGn0kavJT5SOGCW04EpnSmB2jBn2gQWDNJCXdU3xaQqqum%2BnpiqMTfVV1BrYnEBr6S%2Fezs6l%2FFRcFyMw6A7OuvL9WnmqK%2Bpw3JsxYyMtHyVo4V%2BLnlq9SN62qy3sXf2p1r1ffxxmwiFWpCUCdS7mDzK%2FwOclJOxddcVx3HU5MADWXd01IFeLvS%2F17P8NQA%3D", url)
 }
 
 // Verify NV can accept Okta Authn response.
@@ -323,7 +323,7 @@ ma7nkie3ORja96UTROAZ77o=
 	assert.Nil(t, err)
 
 	// Verify if it's consistent with logout request for Okta.
-	assert.Equal(t, "https://dev.okta.com/app/dev/xxxxx/slo/saml?SAMLRequest=fJLf65swFMX%2FFcl7NP6o%2Bg1fZYMyELo9rGMPe5Frcl2lmrjcWPzzh7aFbrDl8SSfc8K5951gGmd5sj%2Ft4r%2FirwXJB%2Bs0GpL7TcUWZ6QFGkgamJCkV%2FL88fNJJqGQs7PeKjuyF%2BT%2FBBCh84M1LGiOFWtRZQWqouRQ9BnPDqXmZQ6a9yUetCoP2JXAgu%2FoaLCmYkkoWNAQLdgY8mB8xRKRpDwWXOTfhJAil6n4wYIjkh8M%2BJ26eD%2BTjCKNt9BePYTKThHM8yZE63YiGm20%2FZ7VeyNyz3D1k8QVpnnEHfT2iqaFxV9aQndD9x69Inf%2BC0zYHINP1k3g%2F11JHMa7Mmje70%2FlYmhGNfQDalYDfOi6UKlHwt20fszsjLSV0hiNa93muojT%2FC3leS6AZ0UmePeGgqsYVJImcQ8d3m3%2BIp%2FiHytQ%2Fw4AAP%2F%2F&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256&Signature=IAXj56i9MlhULmRq9v0LNTeFmmuce4PK%2B41jiEM%2BYX5HFgdav7u6%2B8zlNk5PQB%2FGqYsXpT4CbhB%2BwVDj4DaL87OFDAk5urz2Af3CK209ktL0YO1MT3D%2BitwP8nzmxdfQ1LIxQp%2B8MMk6vVlLzosY3M0wtxMnQ3QOO229BT13FTt%2BNtTxzY4TiUtgPaa7xzAVdgKLZFabPG8U%2FvKZkttaifjMRK1V1px42KiRB6WoD1bWRRdAZecfUg4AcUH%2BOs21OwmL4LVQiLkCzuXNL4dOlqqbxz5P9AjXZS5XTfog1fMvxhqM2Rk0pOnUxTyrlctJVigzENhmvn1MuJPjSCt3JA%3D%3D", url)
+	assert.Equal(t, "https://dev.okta.com/app/dev/xxxxx/slo/saml?SAMLRequest=fJLPbpwwEIdfBflubP4sEAtQK60qIaU9NFUPvaDBHhoUsKnHRDx%2BBUmlPWzjo%2B1vfppvpiZY5lU9ut9uC9%2Fxz4YUon2ZLanzpWGbt8oBTaQsLEgqaPX0%2BeujSmOpVu%2BC025mN8jHBBChD5OzLOquDetR5yXqsuJQjjnPL5XhVQGGjxVejK4uOFTAop%2FoaXK2YWksWdQRbdhZCmBDw1KZZjyRXBY%2FpFSyUJn8xaIrUpgsHEkNew5hJSWEwdfYvQSItVsErOtxIfbjCJqdOBpm7WlEnRm%2B%2FUfiDss64wkG94K2hy0894T%2BFX0tbpE3%2Fhss2F2jL84vEP6vJImTU%2Btk%2BHh%2BVZulFfU0TmhYC%2FBpGGKt3xPeirbvM3tCOqR01uDe9oUpk6x4yHhRSOB5mUs%2BPKDkOgGdZmkywoC1uEPW4s4KtH8HAA%3D%3D&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256&Signature=nEzjH0boa9MgxPbH2zhBPPu3yNZ%2B9NP%2Ft2URXPPkP10DXHWPbV0MYOUkZGVDF3XVlEnIjQRsi6QNr8Ub5rT0va7lpj6GIySzkBUIhxYBoI3ik00PyJxRpPI5Sf%2FbqsCM%2FPJsQw%2FtTRerep9jHkbaI67Vx3wtEdNYHjl4F9PuNshk%2Bzswtg%2FVSdLQ7nd2QvIUkh0%2BAs%2BawQ%2BbrpMOM29DYUL%2FX6Q2fekmD7ngw5z4H2MZYXGhCPL4asbjqjFEOEqZ2KbPfjP3gTzNTuGhGVuEolOcsR9ahX9vItOCizzdxKjtU8vy9w0LhhQc9oAx4vKv9AXHh%2BbnBhNGJ3m18yTkGA%3D%3D", url)
 }
 
 func TestOktaSAMLSLOResponse(t *testing.T) {

--- a/share/auth/ldap.go
+++ b/share/auth/ldap.go
@@ -36,7 +36,6 @@ func (lc *LDAPClient) Connect() error {
 		var err error
 		address := fmt.Sprintf("%s:%d", lc.Host, lc.Port)
 		if !lc.UseSSL {
-			//nolint:staticcheck // SA1019
 			l, err = ldap.Dial("tcp", address)
 			if err != nil {
 				return err
@@ -57,7 +56,6 @@ func (lc *LDAPClient) Connect() error {
 		} else {
 			sharedConfig := httpclient.GetTLSConfig()
 
-			//nolint:staticcheck // SA1019
 			l, err = ldap.DialTLS("tcp", address, &tls.Config{
 				InsecureSkipVerify: sharedConfig.InsecureSkipVerify,
 				ServerName:         lc.Host,

--- a/share/cluster/grpc.go
+++ b/share/cluster/grpc.go
@@ -96,7 +96,6 @@ func NewGRPCServerTCP(endpoint string) (*GRPCServer, error) {
 		return nil, fmt.Errorf("failed to create new server credentials: %w", err)
 	}
 
-	//nolint:staticcheck // SA1019
 	opts := []grpc.ServerOption{
 		grpc.Creds(ct),
 		grpc.UnaryInterceptor(middlefunc),
@@ -167,7 +166,6 @@ func ReloadInternalCert() error {
 }
 
 func NewGRPCServerUnix(socket string) (*GRPCServer, error) {
-	//nolint:staticcheck // SA1019
 	opts := []grpc.ServerOption{
 		grpc.RPCCompressor(grpc.NewGZIPCompressor()),
 		grpc.RPCDecompressor(grpc.NewGZIPDecompressor()),
@@ -317,7 +315,6 @@ func newGRPCClientTCP(ctx context.Context, key, endpoint string, cb GRPCCallback
 	// This is to be compatible with pre-3.2 grpc server that doesn't install decompressor.
 	var opts []grpc.DialOption
 	if compress {
-		//nolint:staticcheck // SA1019
 		opts = []grpc.DialOption{
 			grpc.WithTransportCredentials(ct),
 			grpc.WithDecompressor(grpc.NewGZIPDecompressor()),
@@ -328,7 +325,6 @@ func newGRPCClientTCP(ctx context.Context, key, endpoint string, cb GRPCCallback
 				grpc.MaxCallSendMsgSize(GRPCMaxMsgSize)),
 		}
 	} else {
-		//nolint:staticcheck // SA1019
 		opts = []grpc.DialOption{
 			grpc.WithTransportCredentials(ct),
 			grpc.WithDecompressor(grpc.NewGZIPDecompressor()),
@@ -339,7 +335,6 @@ func newGRPCClientTCP(ctx context.Context, key, endpoint string, cb GRPCCallback
 		}
 	}
 
-	//nolint:staticcheck // SA1019
 	conn, err := grpc.DialContext(ctx, endpoint, opts...)
 	if err != nil {
 		return nil, err
@@ -355,7 +350,6 @@ func newGRPCClientTCP(ctx context.Context, key, endpoint string, cb GRPCCallback
 func newGRPCClientUnix(ctx context.Context, key, socket string, cb GRPCCallback, compress bool) (*GRPCClient, error) {
 	var opts []grpc.DialOption
 	if compress {
-		//nolint:staticcheck // SA1019
 		opts = []grpc.DialOption{
 			grpc.WithInsecure(),
 			grpc.WithDecompressor(grpc.NewGZIPDecompressor()),
@@ -369,7 +363,6 @@ func newGRPCClientUnix(ctx context.Context, key, socket string, cb GRPCCallback,
 			}),
 		}
 	} else {
-		//nolint:staticcheck // SA1019
 		opts = []grpc.DialOption{
 			grpc.WithInsecure(),
 			grpc.WithDecompressor(grpc.NewGZIPDecompressor()),
@@ -383,7 +376,6 @@ func newGRPCClientUnix(ctx context.Context, key, socket string, cb GRPCCallback,
 		}
 	}
 
-	//nolint:staticcheck // SA1019
 	conn, err := grpc.DialContext(ctx, socket, opts...)
 	if err != nil {
 		return nil, err

--- a/share/container/cri_client.go
+++ b/share/container/cri_client.go
@@ -87,7 +87,6 @@ func newCriClient(sock string, ctx context.Context) (*grpc.ClientConn, *criRT.Ve
 	}
 
 	log.WithFields(log.Fields{"addr": addr}).Debug()
-	//nolint:staticcheck // SA1019
 	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(4*time.Second), grpc.WithDialer(dialer))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to connect, make sure you are running as root and the runtime has been started: %v", err)

--- a/share/utils/utils.go
+++ b/share/utils/utils.go
@@ -931,7 +931,6 @@ func Encrypt(encryptionKey, text []byte) ([]byte, error) {
 	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
 		return nil, err
 	}
-	//nolint:staticcheck // SA1019
 	cfb := cipher.NewCFBEncrypter(block, iv)
 	cfb.XORKeyStream(ciphertext[aes.BlockSize:], text)
 	return ciphertext, nil
@@ -955,7 +954,6 @@ func Decrypt(encryptionKey, text []byte) ([]byte, error) {
 	}
 	iv := text[:aes.BlockSize]
 	text = text[aes.BlockSize:]
-	//nolint:staticcheck // SA1019
 	cfb := cipher.NewCFBDecrypter(block, iv)
 	cfb.XORKeyStream(text, text)
 	return text, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -726,8 +726,8 @@ go.starlark.net/resolve
 go.starlark.net/starlark
 go.starlark.net/starlarkstruct
 go.starlark.net/syntax
-# golang.org/x/crypto v0.55.0
-## explicit; go 1.25.0
+# golang.org/x/crypto v0.56.0
+## explicit; go 1.26.0
 golang.org/x/crypto/cryptobyte
 golang.org/x/crypto/cryptobyte/asn1
 golang.org/x/crypto/md4


### PR DESCRIPTION
## Description

- bump crypto to 0.56 to fix the cve
- fix golangci-lint errors introduced by upgrading to golang 1.27.0

## Test

## Additional Information

### Tradeoff

### Potential improvement

### Special notes for your reviewer

### Checklist

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
