### PR TITLE
fix: improve enforcer conn scaling

### DIFF
--- a/agent/timer.go
+++ b/agent/timer.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -39,6 +40,7 @@ var threatMutex sync.Mutex
 var connectionMutex sync.Mutex
 var connsCache []*dp.ConnectionData
 var connsCacheMutex sync.Mutex
+var connsCacheDropped uint64 // low-priority connections dropped while connsCache was full
 var auditLogCache []*share.CLUSAuditLog
 var auditMutex sync.Mutex
 var fqdnIpCache []*share.CLUSFqdnIp
@@ -171,11 +173,24 @@ func statsLoop(bPassiveContainerDetect bool) {
 	}
 }
 
+// writeClusterRunning guards against overlapping writeCluster() runs. Each tick
+// previously spawned a new goroutine unconditionally; if a run stalled (e.g. on a
+// slow connection drain), goroutines and their retained connection data piled up
+// without bound. Skip a tick when the previous run has not finished yet.
+var writeClusterRunning atomic.Bool
+
 func timerLoop() {
 	ticker := time.Tick(time.Second * time.Duration(reportInterval))
 	for {
 		<-ticker
-		go writeCluster()
+		if !writeClusterRunning.CompareAndSwap(false, true) {
+			log.Warn("Previous writeCluster still running -- skip this tick")
+			continue
+		}
+		go func() {
+			defer writeClusterRunning.Store(false)
+			writeCluster()
+		}()
 	}
 }
 
@@ -214,9 +229,7 @@ func dpTaskCallback(task *dp.DPTask) {
 		delete(ipFqdnStorageCache, ip)
 		ipFqdnStorageMutex.Unlock()
 	case dp.DP_TASK_CONNECTION:
-		connsCacheMutex.Lock()
-		connsCache = append(connsCache, task.Connects...)
-		connsCacheMutex.Unlock()
+		cacheConnections(task.Connects)
 	case dp.DP_TASK_HOST_CONNECTION:
 		updateHostConnection(task.Connects)
 	case dp.DP_TASK_APPLICATION:
@@ -385,6 +398,52 @@ func putAuditLogs() {
 
 const connectionMapMax int = 2048 * 16
 
+// connsCache is the unbounded ingestion queue between dp (dpMsgConnection) and
+// updateConnection(). Cap it so a burst of new connections (e.g. a DNS flood)
+// cannot grow it without limit while the drain is slow. Low-priority (allow/open)
+// connections are dropped first once connsCacheMax is reached; high-priority ones
+// (LEARN/VIOLATE/DENY) are kept up to a hard ceiling so they still get reported.
+const connsCacheMax int = connectionMapMax * 8
+const connsCacheHardMax int = connsCacheMax * 2
+
+// connIsHighPriority reports whether a connection must be reported even under
+// load (LEARN so it can be learned into policy; VIOLATE/DENY so violations are
+// not lost). Low-priority (OPEN/ALLOW/CHECK_*) connections are dropped first.
+func connIsHighPriority(conn *dp.Connection) bool {
+	return conn.PolicyAction > C.DP_POLICY_ACTION_CHECK_APP ||
+		conn.PolicyAction == C.DP_POLICY_ACTION_LEARN
+}
+
+// cacheConnections appends dp connection reports to connsCache with a bound.
+// Once connsCacheMax is reached, only high-priority connections are kept (up to
+// connsCacheHardMax); everything else is counted in connsCacheDropped so the
+// queue cannot grow without limit when updateConnection() falls behind.
+func cacheConnections(conns []*dp.ConnectionData) {
+	connsCacheMutex.Lock()
+	defer connsCacheMutex.Unlock()
+	for _, cd := range conns {
+		if len(connsCache) < connsCacheMax ||
+			(connIsHighPriority(cd.Conn) && len(connsCache) < connsCacheHardMax) {
+			connsCache = append(connsCache, cd)
+		} else {
+			connsCacheDropped++
+		}
+	}
+}
+
+// drainConnsCache takes ownership of the current connsCache contents and resets
+// it to nil (releasing the backing array to the GC rather than retaining its
+// peak capacity), returning the drained connections and the dropped count.
+func drainConnsCache() ([]*dp.ConnectionData, uint64) {
+	connsCacheMutex.Lock()
+	defer connsCacheMutex.Unlock()
+	conns := connsCache
+	connsCache = nil
+	dropped := connsCacheDropped
+	connsCacheDropped = 0
+	return conns, dropped
+}
+
 func keyTCPUDPConnection(conn *dp.Connection) string {
 	return fmt.Sprintf("%v-%v-%v-%v-%v-%v-%v",
 		conn.ClientIP, conn.ServerIP, conn.ServerPort, conn.IPProto, conn.Ingress, conn.PolicyId, conn.Application)
@@ -396,10 +455,12 @@ func keyOtherConnection(conn *dp.Connection) string {
 }
 
 func updateConnection() {
-	connsCacheMutex.Lock()
-	conns := slices.Clone(connsCache)
-	connsCache = connsCache[:0]
-	connsCacheMutex.Unlock()
+	conns, dropped := drainConnsCache()
+
+	if dropped > 0 {
+		connLog.WithFields(log.Fields{"dropped": dropped, "processing": len(conns)}).
+			Warn("connsCache full -- dropped low-priority connections")
+	}
 
 	for _, data := range conns {
 		conn := data.Conn

--- a/agent/timer.go
+++ b/agent/timer.go
@@ -400,18 +400,34 @@ const connectionMapMax int = 2048 * 16
 
 // connsCache is the unbounded ingestion queue between dp (dpMsgConnection) and
 // updateConnection(). Cap it so a burst of new connections (e.g. a DNS flood)
-// cannot grow it without limit while the drain is slow. Low-priority (allow/open)
-// connections are dropped first once connsCacheMax is reached; high-priority ones
-// (LEARN/VIOLATE/DENY) are kept up to a hard ceiling so they still get reported.
+// cannot grow it without limit while the drain is slow. Low-priority connections
+// are dropped first once connsCacheMax is reached; high-priority ones (see
+// connIsHighPriority) are kept up to a hard ceiling so they still get reported.
 const connsCacheMax int = connectionMapMax * 8
 const connsCacheHardMax int = connsCacheMax * 2
 
 // connIsHighPriority reports whether a connection must be reported even under
-// load (LEARN so it can be learned into policy; VIOLATE/DENY so violations are
-// not lost). Low-priority (OPEN/ALLOW/CHECK_*) connections are dropped first.
+// load. Low-priority (OPEN/ALLOW/CHECK_*) connections are dropped first; a
+// connection is kept when it is:
+//   - LEARN so it can be learned into policy, or VIOLATE/DENY so violations
+//     are not lost;
+//   - a DNS-tunnel candidate: dp sets ClientPort only for large DNS/UDP
+//     sessions (ClientBytes > threshold), the ones fed to CheckDNSTunneling,
+//     so dropping them would defeat tunnel detection under load;
+//   - already carrying a dp-detected threat (Severity/ThreatID set), which
+//     must not be silently dropped regardless of its policy action.
 func connIsHighPriority(conn *dp.Connection) bool {
-	return conn.PolicyAction > C.DP_POLICY_ACTION_CHECK_APP ||
-		conn.PolicyAction == C.DP_POLICY_ACTION_LEARN
+	if conn.PolicyAction > C.DP_POLICY_ACTION_CHECK_APP ||
+		conn.PolicyAction == C.DP_POLICY_ACTION_LEARN {
+		return true
+	}
+	if conn.ClientPort != 0 {
+		return true
+	}
+	if conn.Severity > 0 || conn.ThreatID != 0 {
+		return true
+	}
+	return false
 }
 
 // cacheConnections appends dp connection reports to connsCache with a bound.

--- a/agent/timer_test.go
+++ b/agent/timer_test.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/neuvector/neuvector/agent/dp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dp policy action values mirrored from defs.h so the test does not depend on cgo.
+const (
+	testActionOpen     uint8 = 0
+	testActionLearn    uint8 = 1
+	testActionAllow    uint8 = 2
+	testActionCheckVH  uint8 = 3
+	testActionCheckNBE uint8 = 4
+	testActionCheckApp uint8 = 5
+	testActionViolate  uint8 = 6
+	testActionDeny     uint8 = 7
+)
+
+// NOTE: these tests mutate the package-global connsCache/connsCacheDropped and
+// therefore must NOT be run with t.Parallel(); each resets state via
+// resetConnsCache() and relies on serial execution.
+
+// resetConnsCache clears the package-global ingestion state so each subtest starts clean.
+func resetConnsCache() {
+	connsCacheMutex.Lock()
+	connsCache = nil
+	connsCacheDropped = 0
+	connsCacheMutex.Unlock()
+}
+
+func newConnData(action uint8) *dp.ConnectionData {
+	return &dp.ConnectionData{Conn: &dp.Connection{PolicyAction: action}}
+}
+
+// repeatConnData returns a slice of n ConnectionData all pointing at a single
+// shared Conn of the given action, so a large count costs only pointer memory.
+func repeatConnData(action uint8, n int) []*dp.ConnectionData {
+	cd := newConnData(action)
+	conns := make([]*dp.ConnectionData, n)
+	for i := range conns {
+		conns[i] = cd
+	}
+	return conns
+}
+
+func TestConnIsHighPriority(t *testing.T) {
+	cases := []struct {
+		name string
+		conn *dp.Connection
+		want bool
+	}{
+		// policy-action based priority
+		{name: "open", conn: &dp.Connection{PolicyAction: testActionOpen}, want: false},
+		{name: "learn", conn: &dp.Connection{PolicyAction: testActionLearn}, want: true},
+		{name: "allow", conn: &dp.Connection{PolicyAction: testActionAllow}, want: false},
+		{name: "check_vh", conn: &dp.Connection{PolicyAction: testActionCheckVH}, want: false},
+		{name: "check_nbe", conn: &dp.Connection{PolicyAction: testActionCheckNBE}, want: false},
+		{name: "check_app", conn: &dp.Connection{PolicyAction: testActionCheckApp}, want: false},
+		{name: "violate", conn: &dp.Connection{PolicyAction: testActionViolate}, want: true},
+		{name: "deny", conn: &dp.Connection{PolicyAction: testActionDeny}, want: true},
+		// DNS-tunnel candidate: dp set ClientPort on an otherwise low-priority conn
+		{name: "allow with client port", conn: &dp.Connection{PolicyAction: testActionAllow, ClientPort: 5353}, want: true},
+		{name: "open with client port", conn: &dp.Connection{PolicyAction: testActionOpen, ClientPort: 1}, want: true},
+		// dp-detected threat on an otherwise low-priority conn
+		{name: "allow with severity", conn: &dp.Connection{PolicyAction: testActionAllow, Severity: 1}, want: true},
+		{name: "allow with threat id", conn: &dp.Connection{PolicyAction: testActionAllow, ThreatID: 42}, want: true},
+		// plain low-priority conn with none of the above stays droppable
+		{name: "allow no signals", conn: &dp.Connection{PolicyAction: testActionAllow, ClientPort: 0, Severity: 0, ThreatID: 0}, want: false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, connIsHighPriority(c.conn))
+		})
+	}
+}
+
+func TestCacheConnections(t *testing.T) {
+	cases := []struct {
+		name        string
+		feed        []*dp.ConnectionData
+		wantLen     int
+		wantDropped uint64
+	}{
+		{
+			name:        "under cap keeps all low priority",
+			feed:        repeatConnData(testActionAllow, 100),
+			wantLen:     100,
+			wantDropped: 0,
+		},
+		{
+			name:        "exactly at soft cap keeps all low priority",
+			feed:        repeatConnData(testActionAllow, connsCacheMax),
+			wantLen:     connsCacheMax,
+			wantDropped: 0,
+		},
+		{
+			name:        "low priority dropped once soft cap reached",
+			feed:        repeatConnData(testActionAllow, connsCacheMax+50),
+			wantLen:     connsCacheMax,
+			wantDropped: 50,
+		},
+		{
+			name:        "exactly at hard cap keeps all high priority",
+			feed:        repeatConnData(testActionViolate, connsCacheHardMax),
+			wantLen:     connsCacheHardMax,
+			wantDropped: 0,
+		},
+		{
+			name:        "high priority kept past soft cap up to hard cap",
+			feed:        repeatConnData(testActionViolate, connsCacheHardMax+50),
+			wantLen:     connsCacheHardMax,
+			wantDropped: 50,
+		},
+		{
+			name:        "learn is high priority",
+			feed:        repeatConnData(testActionLearn, connsCacheMax+10),
+			wantLen:     connsCacheMax + 10,
+			wantDropped: 0,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resetConnsCache()
+			cacheConnections(c.feed)
+
+			connsCacheMutex.Lock()
+			gotLen := len(connsCache)
+			gotDropped := connsCacheDropped
+			connsCacheMutex.Unlock()
+
+			assert.Equal(t, c.wantLen, gotLen)
+			assert.Equal(t, c.wantDropped, gotDropped)
+		})
+	}
+}
+
+// TestCacheConnectionsHighPriorityAfterLowFills verifies that once low-priority
+// connections have filled the soft cap, high-priority connections are still
+// admitted (up to the hard cap) while further low-priority ones are dropped.
+func TestCacheConnectionsHighPriorityAfterLowFills(t *testing.T) {
+	resetConnsCache()
+
+	cacheConnections(repeatConnData(testActionAllow, connsCacheMax))
+	cacheConnections(repeatConnData(testActionViolate, 100))
+	cacheConnections(repeatConnData(testActionAllow, 100))
+
+	connsCacheMutex.Lock()
+	gotLen := len(connsCache)
+	gotDropped := connsCacheDropped
+	connsCacheMutex.Unlock()
+
+	assert.Equal(t, connsCacheMax+100, gotLen, "high-priority admitted past soft cap")
+	assert.Equal(t, uint64(100), gotDropped, "later low-priority dropped")
+}
+
+// TestCacheConnectionsDNSTunnelCandidateKeptPastSoftCap verifies that a large
+// DNS-tunnel candidate (ClientPort set by dp on an otherwise ALLOW connection)
+// is treated as high-priority and admitted past the soft cap.
+func TestCacheConnectionsDNSTunnelCandidateKeptPastSoftCap(t *testing.T) {
+	resetConnsCache()
+
+	cacheConnections(repeatConnData(testActionAllow, connsCacheMax))
+
+	tunnelCandidate := &dp.ConnectionData{Conn: &dp.Connection{PolicyAction: testActionAllow, ClientPort: 5353}}
+	cacheConnections([]*dp.ConnectionData{tunnelCandidate})
+	cacheConnections(repeatConnData(testActionAllow, 5)) // plain low-priority, dropped
+
+	connsCacheMutex.Lock()
+	gotLen := len(connsCache)
+	gotDropped := connsCacheDropped
+	connsCacheMutex.Unlock()
+
+	assert.Equal(t, connsCacheMax+1, gotLen, "DNS-tunnel candidate admitted past soft cap")
+	assert.Equal(t, uint64(5), gotDropped, "plain low-priority still dropped")
+}
+
+// TestCacheConnectionsInterleavedSingleFeed verifies the per-element decision
+// within a single cacheConnections call: once the soft cap is reached partway
+// through the slice, subsequent high-priority elements are still admitted while
+// low-priority ones in the same slice are dropped.
+func TestCacheConnectionsInterleavedSingleFeed(t *testing.T) {
+	resetConnsCache()
+
+	feed := repeatConnData(testActionAllow, connsCacheMax)
+	// After the soft cap, interleave two high- and two low-priority connections.
+	feed = append(feed,
+		newConnData(testActionDeny),
+		newConnData(testActionAllow),
+		newConnData(testActionViolate),
+		newConnData(testActionOpen),
+	)
+	cacheConnections(feed)
+
+	connsCacheMutex.Lock()
+	gotLen := len(connsCache)
+	gotDropped := connsCacheDropped
+	connsCacheMutex.Unlock()
+
+	assert.Equal(t, connsCacheMax+2, gotLen, "two high-priority admitted past soft cap")
+	assert.Equal(t, uint64(2), gotDropped, "two low-priority dropped")
+}
+
+func TestDrainConnsCache(t *testing.T) {
+	cases := []struct {
+		name        string
+		feed        []*dp.ConnectionData
+		wantConns   int
+		wantDropped uint64
+	}{
+		{name: "empty", feed: nil, wantConns: 0, wantDropped: 0},
+		{name: "some", feed: repeatConnData(testActionAllow, 10), wantConns: 10, wantDropped: 0},
+		{
+			name:        "carries drop count",
+			feed:        repeatConnData(testActionAllow, connsCacheMax+7),
+			wantConns:   connsCacheMax,
+			wantDropped: 7,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resetConnsCache()
+			cacheConnections(c.feed)
+
+			conns, dropped := drainConnsCache()
+			assert.Len(t, conns, c.wantConns)
+			assert.Equal(t, c.wantDropped, dropped)
+
+			// After draining, the cache must be reset to nil so the backing
+			// array is released rather than retained at peak capacity.
+			connsCacheMutex.Lock()
+			require.Nil(t, connsCache)
+			assert.Zero(t, connsCacheDropped)
+			connsCacheMutex.Unlock()
+		})
+	}
+}
+
+// TestDrainConnsCacheSecondDrainEmpty verifies that a drain immediately
+// following another (with no intervening cacheConnections) reports nothing,
+// confirming the drain fully resets both the slice and the drop counter.
+func TestDrainConnsCacheSecondDrainEmpty(t *testing.T) {
+	resetConnsCache()
+	cacheConnections(repeatConnData(testActionAllow, connsCacheMax+7))
+
+	_, dropped := drainConnsCache()
+	require.Equal(t, uint64(7), dropped)
+
+	conns, dropped := drainConnsCache()
+	assert.Empty(t, conns)
+	assert.Zero(t, dropped)
+}


### PR DESCRIPTION


## Description

This commit implements the low-hanging fruits for memory utilization from dpMsgConnection().

1. Make sure only one writeCluster running at the same time to prevent go routine leaks.
2. Ensure connsCache can be released through GC.
3. Drop non-critical connection events.

Fix #XXX

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

### Special notes for your reviewer

<!-- Please describe, if any special design or notes you want to share with your reviewer in this pull request -->

### Checklist
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
